### PR TITLE
add Custom directory option to configure with the --with-custom=* flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,10 @@
 include make.inc
 SRC=src
 BUILD=$(SRC)/build
+
+# make the CUSTOMROOT variable available to sub-make processes
+export CUSTOMROOT
+
 rayleigh:
 	@mkdir -p $(BUILD)/compiled
 	@cp $(SRC)/parallel_framework/*.F90 $(BUILD)/.
@@ -18,6 +22,9 @@ rayleigh:
 	@cp $(SRC)/object_list $(BUILD)/.
 ifeq ($(NODIRS),1)
 	cp $(SRC)/Utility/MakeDir.F90_IBM $(BUILD)/MakeDir.F90
+endif
+ifdef CUSTOMROOT
+	@cp $(CUSTOMROOT)/* $(BUILD)/.
 endif
 	@$(MAKE) --no-print-directory --directory=$(BUILD) clean_exec
 	@$(MAKE) --no-print-directory --directory=$(BUILD) all

--- a/configure
+++ b/configure
@@ -99,6 +99,7 @@ function displayhelp {
     echo "  --devel / -devel "
     echo "      Forces Rayleigh to build with debugging flags and no."
     echo "      vectorization (useful for quick development builds)."
+    echo ""
 
     echo "  --FC=<fortran compiler name> "
     echo "      Specifies the Fortran compiler command to be invoked by Make."
@@ -237,6 +238,11 @@ function displayhelp {
     echo "          <LAPACK ROOT>/lib/liblapack.a"
     echo ""
 
+    echo "  --with-custom=<CUSTOM ROOT>"
+    echo "      Set this flag to specify the location of custom Rayleigh source files."
+    echo "      These files will be copied to the build directory and override any of"
+    echo "      the standard Rayleigh source files."
+    echo ""
 
 }
 
@@ -249,6 +255,7 @@ RAYLEIGHROOT=$PWD
 PREFIX=$RAYLEIGHROOT
 NEED_HELP=no
 USE_MKL="FALSE"
+CUSTOMROOT="none"
 
 
 ###############################################################################################
@@ -262,6 +269,10 @@ do
     -help | --help | -h)
       displayhelp;
       exit 0;
+      ;;
+
+    --with-custom=*)
+      CUSTOMROOT=`expr "x$option" : "x-*with-custom=\(.*\)"`;
       ;;
 
     -prefix=* | --prefix=*)
@@ -379,6 +390,12 @@ then
       if [[ $NODIRS == "TRUE" ]]
       then
         echo "NODIRS = 1" >> make.inc
+      fi
+      if [[ $CUSTOMROOT == "none" ]]
+      then
+        echo "CUSTOMROOT = " >> make.inc
+      else
+        echo "CUSTOMROOT = "$CUSTOMROOT >> make.inc
       fi
       exit 0
 
@@ -762,6 +779,12 @@ echo "PREFIX = "$PREFIX > make.inc
 if [[ $NODIRS == "TRUE" ]]
 then
   echo "NODIRS = 1" >> make.inc
+fi
+if [[ $CUSTOMROOT == "none" ]]
+then
+  echo "CUSTOMROOT = " >> make.inc
+else
+  echo "CUSTOMROOT = "$CUSTOMROOT >> make.inc
 fi
 
 echo " ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"


### PR DESCRIPTION
I added the --with-custom= flag to the configure script, and it would be invoked as
      ./configure --with-custom=/some/path/to/extra/source/files

A variable called CUSTOMROOT is added to the make.inc file. The main Makefile will copy all files in the CUSTOMROOT directory to the build directory. This is the last copy, so it will override any of the standard source files from the $RAYLEIGHDIR/src directory.
