### PR TITLE
Use /bin/sh instead of /bin/csh for making directories

### DIFF
--- a/etc/make_dirs
+++ b/etc/make_dirs
@@ -1,4 +1,4 @@
-#!/bin/csh
+#!/bin/sh
 mkdir Checkpoints
 mkdir AZ_Avgs
 mkdir G_Avgs


### PR DESCRIPTION
I do not think I was supposed to run this script (I got an unrelated error and was looking for a solution), but I think this script should be run by the default system shell instead of the c-shell. `mkdir` does not require the c-shell, and I for example did not have it installed.

Is this script only supposed to be run on clusters that do not support the creation of directories from the main code? If so, I can add a comment at the beginning to make that clear.