### PR TITLE
Add more checks for GNU compilers

### DIFF
--- a/configure
+++ b/configure
@@ -17,7 +17,11 @@ function compiler_version {
   then
     VTMP="GNU"
   fi
-  if [[ $1 == "gcc" ]]
+  if [[ $VSTR == *"gcc"* ]]
+  then
+    VTMP="GNU"
+  fi
+  if [[ $VSTR == *"GNU"* ]]
   then
     VTMP="GNU"
   fi


### PR DESCRIPTION
The version string of my gcc compiler (7.3.0 the default version that comes with ubuntu 18.04) reports itself as `gcc` not `GCC`, and `gfortran --version` reports `GNU Fortran`, thus the current compiler checks for GNU compilers did not work for me. This should fix the issue. Was there a special reason you check for the name of the command being `gcc`? Because I have my environment variables often set to the MPI wrappers, and `mpicc` should be just as valid as `gcc` if it uses the gcc compiler.