### PR TITLE
fix Issue #13: a typo in diagnostic logic for buoyancy term.

### DIFF
--- a/src/Diagnostics/Diagnostics_Linear_Forces.F90
+++ b/src/Diagnostics/Diagnostics_Linear_Forces.F90
@@ -69,7 +69,7 @@ Contains
                            & ell0_values(r,tvar))
             END_DO
             If (compute_quantity(buoyancy_mforce)) Call Add_Quantity(qty)
-            If (compute_quantity(buoy_work_pp)) Then
+            If (compute_quantity(buoy_work_mm)) Then
                 DO_PSI
                     qty(PSI)=m0_values(PSI2,vr)*qty(PSI)
                 END_DO


### PR DESCRIPTION
The logic previously asked if the prime-prime component was wanted, but the mean-mean is actually calculated. Now the logic asks if the mean-mean component is wanted.