### PR TITLE
Make jenkins check for new docker images

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,6 +10,7 @@ pipeline {
         image 'gassmoeller/rayleigh:base'
         ttyEnabled true
         command 'cat'
+        alwaysPull true
       }
     }
   }


### PR DESCRIPTION
Currently, Jenkins does not seem to check for new docker images of the tester configuration, if we need to change the tester setup (like adding new packages). This addition should fix this.