### PR TITLE
Remove permissions stage of tester

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,24 +19,6 @@ pipeline {
   }
 
   stages {
-    stage ("Check Permissions") {
-      when {
-        allOf {
-          not {branch 'master'}
-          not {changeRequest authorEmail: "feathern@colorado.edu"}
-          not {changeRequest authorEmail: "rene.gassmoeller@mailbox.org"}
-        }
-      }
-      steps {
-        container('rayleigh') {
-          sh '''
-            wget -q -O - https://api.github.com/repos/geodynamics/Rayleigh/issues/${CHANGE_ID}/labels | grep 'ready to test' || \
-            { echo "This commit will only be tested when it has the label 'ready to test'"; exit 1; }
-          '''
-        }
-      }
-    }
-
     stage('Build') {
       options {
         timeout(time: 15, unit: 'MINUTES')


### PR DESCRIPTION
We are currently having trouble running the tester for users without write access to the repo, because the docker container does not contain wget, which we use to check for the `ready to test` label, that determines whether a pull request should be checked. I updated the docker image to contain wget, but somehow that was not propagated to the tester yet. #44 might help, but if not, this disables the step for now, we can add and fix it later.