### PR TITLE
Make install and distclean phony targets in the Makefile.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,12 +43,13 @@ clean:
 	@$(MAKE) --no-print-directory --directory=$(BUILD) clean_exec
 	@$(MAKE) --no-print-directory --directory=$(BUILD) clean
 
-
+.PHONY: install
 install:
 	@echo "Installing executables into: " $(PREFIX)"/bin"
 	@mkdir -p $(PREFIX)/bin
 	@cp $(BUILD)/compiled/rayleigh.* $(PREFIX)/bin/.
 
+.PHONY: distclean
 distclean:
 	rm -f $(BUILD)/compiled/rayleigh.*
 	rm -f $(BUILD)/*.F


### PR DESCRIPTION
This prevents some versions of make getting confused by the fact that an INSTALL file exists already in the repo.  The distclean is just done for completeness.