### PR TITLE
Add latex styles for a more functional manual.

### DIFF
--- a/doc/src/user_guide/Rayleigh_User_Guide.tex
+++ b/doc/src/user_guide/Rayleigh_User_Guide.tex
@@ -1,20 +1,19 @@
 \documentclass[10pt, letterpaper]{article}
-\usepackage[letterpaper,margin=0.75in]{geometry}
 \usepackage{graphicx}
 \usepackage{amsmath}
 \usepackage[table]{xcolor}
 \usepackage{color}
-\usepackage[hidelinks]{hyperref}
 \setlength{\parindent}{0pt}
 \setlength{\parskip}{5pt}
 
+% use a larger page size; otherwise, it is difficult to have complete
+% code listings and output on a single page
+\usepackage{fullpage}
+
+
+% use the listings package for code snippets. define keywords for prm files
+% and for gnuplot
 \usepackage{listings}
-
-
-\definecolor{dkgreen}{rgb}{0,0.6,0}
-\definecolor{gray}{rgb}{0.5,0.5,0.5}
-\definecolor{mauve}{rgb}{0.58,0,0.82}
-
 \lstset{frame=tb,
   language=Fortran,
   aboveskip=3mm,
@@ -31,6 +30,23 @@
   breakatwhitespace=true,
   tabsize=3
 }
+\lstdefinelanguage{prmfile}{morekeywords={set,subsection,end},
+                            morecomment=[l]{\#},escapeinside={\%\%}{\%},}
+\lstdefinelanguage{gnuplot}{morekeywords={plot,using,title,with,set,replot},
+                            morecomment=[l]{\#},}
+
+
+% use the hyperref package; set the base for relative links to
+% the top-level Rayleigh directory so that we can link to
+% files in the Rayleigh tree without having to specify the
+% location relative to the directory where the pdf actually
+% resides
+\usepackage[colorlinks,linkcolor=blue,urlcolor=blue,citecolor=blue,destlabel=true,baseurl=../]{hyperref}
+
+\definecolor{dkgreen}{rgb}{0,0.6,0}
+\definecolor{gray}{rgb}{0.5,0.5,0.5}
+\definecolor{mauve}{rgb}{0.58,0,0.82}
+
 \renewcommand{\abstractname}{Overview}
 \begin{document}
 


### PR DESCRIPTION
Specifically, use better defaults for the 'listings' and 'hyperref'
styles.