### PR TITLE
Corrected a minus sign error in Diagnostics_Linear_Forces.F90 

### DIFF
--- a/src/Diagnostics/Diagnostics_Linear_Forces.F90
+++ b/src/Diagnostics/Diagnostics_Linear_Forces.F90
@@ -328,7 +328,7 @@ Contains
 
 
                 ! Finally, add the piece due to the gradient of mu
-                estress = fbuffer(PSI,dvrdr)-One_Third*fbuffer(PSI,vr)*ref%dlnrho(r)
+                estress = fbuffer(PSI,dvrdr)+One_Third*fbuffer(PSI,vr)*ref%dlnrho(r)
 
                 qty(PSI) = 2.0d0*dmudr(r)*estress + mu_visc(r)*del2u
 
@@ -433,7 +433,7 @@ Contains
 
 
                 ! Finally, add the piece due to the gradient of mu
-                estress = m0_values(PSI2,dvrdr)-One_Third*m0_values(PSI2,vr)*ref%dlnrho(r)
+                estress = m0_values(PSI2,dvrdr)+One_Third*m0_values(PSI2,vr)*ref%dlnrho(r)
 
                 qty(PSI) = 2.0d0*dmudr(r)*estress + mu_visc(r)*del2u
                 qty(PSI) = qty(PSI)-mean_ell0buffer(r,vforce_r)


### PR DESCRIPTION
The radial component of the viscous stress had a minus sign error in
the term involving the radial derivative of the dynamic viscosity.
The sign in front of the logarithmic derivative of the reference state
density was wrong. A correction was made to both the fluctuating and
mean viscous forces. The viscous force computed from the full velocity
field is computed elsewhere and passed through a buffer. So, no correction
to that term was made.