### PR TITLE
Change the sed whitespace removal in configure to be mac friendly.

### DIFF
--- a/configure
+++ b/configure
@@ -773,7 +773,7 @@ grep -o '^[^#]*' $OFILE > $NOCOMM
 
 #Next we copy NOCOMM to MACHDEF, removing trailing whitespace in the process
 #  This is super important as errors can arise in the make process otherwise.
-sed 's/[ \t]*$//' $NOCOMM > $MACHDEF
+sed -E 's/[ '$'\t'']+$//' $NOCOMM > $MACHDEF
 rm $NOCOMM
 rm $OFILE
 echo " "


### PR DESCRIPTION
`\t` is not recognized by sed on macs as being a tab so rayleigh.opt became rayleigh.op

This is an attempt at fixing that (very) minor bug/feature.

I've tested this on a mac osx 10.13 and ubuntu 18.04.  Might be worth testing elsewhere too.