### PR TITLE
Corrected a mistake in the spherical geometry in the computation of the viscous transport of turbulent KE

### DIFF
--- a/src/Diagnostics/Diagnostics_TurbKE_Budget.F90
+++ b/src/Diagnostics/Diagnostics_TurbKE_Budget.F90
@@ -183,8 +183,8 @@ Contains
 
                     ! Compute vector Laplacian u'
                     htmp1 = fbuffer(PSI,vr) + fbuffer(PSI,dvtdt) + cottheta(t) * fbuffer(PSI,vtheta)
-                    htmp2 = one_over_rsin**2 * fbuffer(PSI,dvpdp)
-                     Lap_r = Lap_r - 2D0*one_over_r(r)**2 * htmp1 - htmp2        ! r component (Lap u')_r
+                    htmp2 = one_over_r(r)*one_over_rsin * fbuffer(PSI,dvpdp)
+                    Lap_r = Lap_r - 2D0*(one_over_r(r)**2 * htmp1 + htmp2)        ! r component (Lap u')_r
 
                     htmp1 = one_over_rsin * fbuffer(PSI,vtheta) + 2D0*ctn_over_r * fbuffer(PSI,dvpdp)
                     htmp2 = 2D0*one_over_r(r)**2 * fbuffer(PSI,dvrdt)


### PR DESCRIPTION
Corrected a mistake in the spherical geometry in the diagnostic computation of the viscous transport of turbulent KE

   In the section of the code where the viscous transport of turbulent KE is
computed, there was a mistake in the radial component of the vector Laplacian
of the velocity field. In particular the term involving du_phi/dphi lacked the
necessary preceeding factor of 2 and there was a extra factor of sin(theta) in
the denominator.