### PR TITLE
Add .bib file to user guide.

### DIFF
--- a/doc/src/user_guide/manual.bib
+++ b/doc/src/user_guide/manual.bib
@@ -1,0 +1,82 @@
+@article{0004-637X-818-1-32,
+  author={Nicholas A. Featherstone and Bradley W. Hindman},
+  title={The Spectral Amplitude of Stellar Convection and Its Scaling in the High-Rayleigh-number Regime},
+  journal={The Astrophysical Journal},
+  volume={818},
+  number={1},
+  pages={32},
+  url={http://stacks.iop.org/0004-637X/818/i=1/a=32},
+  year={2016},
+  abstract={}
+}
+	
+@article{doi:10.1002/2015GC006159,
+author = {Matsui, Hiroaki and Heien, Eric and Aubert, Julien and Aurnou, Jonathan M. and Avery, Margaret and Brown, Ben and Buffett, Bruce A. and Busse, Friedrich and Christensen, Ulrich R. and Davies, Christopher J. and Featherstone, Nicholas and Gastine, Thomas and Glatzmaier, Gary A. and Gubbins, David and Guermond, Jean-Luc and Hayashi, Yoshi-Yuki and Hollerbach, Rainer and Hwang, Lorraine J. and Jackson, Andrew and Jones, Chris A. and Jiang, Weiyuan and Kellogg, Louise H. and Kuang, Weijia and Landeau, Maylis and Marti, Philippe and Olson, Peter and Ribeiro, Adolfo and Sasaki, Youhei and Schaeffer, Nathanaël and Simitev, Radostin D. and Sheyko, Andrey and Silva, Luis and Stanley, Sabine and Takahashi, Futoshi and Takehiro, Shin-ichi and Wicht, Johannes and Willis, Ashley P.},
+title = {Performance benchmarks for a next generation numerical dynamo model},
+journal = {Geochemistry, Geophysics, Geosystems},
+volume = {17},
+number = {5},
+pages = {1586-1607},
+keywords = {geodynamo, magnetohydrodynamics, benchmark, high-performance computing},
+doi = {10.1002/2015GC006159},
+url = {https://agupubs.onlinelibrary.wiley.com/doi/abs/10.1002/2015GC006159},
+eprint = {https://agupubs.onlinelibrary.wiley.com/doi/pdf/10.1002/2015GC006159},
+abstract = {}
+}
+
+
+@article{GLATZMAIER1984461,
+title = "Numerical simulations of stellar convective dynamos. I. the model and method",
+journal = "Journal of Computational Physics",
+volume = "55",
+number = "3",
+pages = "461 - 484",
+year = "1984",
+issn = "0021-9991",
+doi = "https://doi.org/10.1016/0021-9991(84)90033-0",
+url = "http://www.sciencedirect.com/science/article/pii/0021999184900330",
+author = "Gary A Glatzmaier"
+}
+
+@article{CLUNE1999361,
+title = "Computational aspects of a code to study rotating turbulent convection in spherical shells",
+journal = "Parallel Computing",
+volume = "25",
+number = "4",
+pages = "361 - 380",
+year = "1999",
+issn = "0167-8191",
+doi = "https://doi.org/10.1016/S0167-8191(99)00009-5",
+url = "http://www.sciencedirect.com/science/article/pii/S0167819199000095",
+author = "T.C. Clune and J.R. Elliott and M.S. Miesch and J. Toomre and G.A. Glatzmaier",
+keywords = "Convection, Anelastic spherical harmonic code"
+}
+
+@article{CHRISTENSEN200125,
+title = "A numerical dynamo benchmark",
+journal = "Physics of the Earth and Planetary Interiors",
+volume = "128",
+number = "1",
+pages = "25 - 34",
+year = "2001",
+note = "Dynamics and Magnetic Fields of the Earth's and Planetary Interiors",
+issn = "0031-9201",
+doi = "https://doi.org/10.1016/S0031-9201(01)00275-8",
+url = "http://www.sciencedirect.com/science/article/pii/S0031920101002758",
+author = "U.R. Christensen and J. Aubert and P. Cardin and E. Dormy and S. Gibbons and G.A. Glatzmaier and E. Grote and Y. Honkura and C. Jones and M. Kono and M. Matsushima and A. Sakuraba and F. Takahashi and A. Tilgner and J. Wicht and K. Zhang",
+keywords = "Geodynamo, Numerical modeling"
+}
+
+@article{JONES2011120,
+title = "Anelastic convection-driven dynamo benchmarks",
+journal = "Icarus",
+volume = "216",
+number = "1",
+pages = "120 - 135",
+year = "2011",
+issn = "0019-1035",
+doi = "https://doi.org/10.1016/j.icarus.2011.08.014",
+url = "http://www.sciencedirect.com/science/article/pii/S0019103511003319",
+author = "C.A. Jones and P. Boronski and A.S. Brun and G.A. Glatzmaier and T. Gastine and M.S. Miesch and J. Wicht",
+keywords = "Magnetic fields, Jovian planets, Interiors"
+}


### PR DESCRIPTION
This adds a .bib file to the documentation with the references cited in the user guide at the beginning of sections. It DOES NOT implement the .bib file. Additional work will need to be done at another hack to implement the autogeneration of the Reference section and use of this file.