### PR TITLE
ensure configure only builds one executable with the -devel flag

### DIFF
--- a/configure
+++ b/configure
@@ -541,10 +541,12 @@ MULTIVEC=FALSE
 if [[ $DEVELMODE == "TRUE" ]]
 then
   echo "************************************************************************"
-  echo " Development mode has been activated.  Both rayleigh.opt"
-  echo " and rayleigh.dbg will be compiled with debugging flags "
-  echo " and no vectorization."
+  echo " Development mode has been activated. Only rayleigh.dbg"
+  echo " will be compiled with debugging flags and no vectorization."
+  RVTAGS[0]="DEBUG"
+  RVALUES[0]=$DEBUG 
   FFLAGS[0]=$DBG_FLAGS
+  nvers=1
 fi
 
 


### PR DESCRIPTION
Modified configure to ensure that only a single executable is built with debugging flags. Previous behavior was to build both rayleigh.opt and rayleigh.dbg, but both would have debugging flags. This should work for both Intel and Gnu compilers.