### PR TITLE
Remove unused module dependency from Legendre_Transforms

### DIFF
--- a/src/Math_Layer/Legendre_Transforms.F90
+++ b/src/Math_Layer/Legendre_Transforms.F90
@@ -29,7 +29,6 @@
 
 Module Legendre_Transforms
     Use Legendre_Polynomials
-    Use Timing
     Use Structures
     !Type, Public :: rmcontainer
     !    Real*8, Allocatable :: data(:,:)


### PR DESCRIPTION
Legendre_Transforms.F90 explicitly uses the Timing module, but no routine from the Timing module is ever called. I removed the "use Timing" line and it successfully compiled in devel mode.