### PR TITLE
fix some Latex typos in the Diagnostics/*codes.F files

### DIFF
--- a/src/Diagnostics/amom_equation_codes.F
+++ b/src/Diagnostics/amom_equation_codes.F
@@ -30,7 +30,7 @@
     Integer, Parameter :: samom_advec_pp = amoff+1 ! :tex: $r\,\mathrm{sin}\theta\mathrm{f}_1\left[\boldsymbol{v'}\cdot\boldsymbol{\nabla}\boldsymbol{v'}\right]_\phi$
     Integer, Parameter :: samom_advec_mm = amoff+2 ! :tex: $r\,\mathrm{sin}\theta\mathrm{f}_1\left[\overline{\boldsymbol{v}}\cdot\boldsymbol{\nabla}\overline{\boldsymbol{v}}\right]_\phi$
 
-    Integer, Parameter :: samom_coriolis = amoff+3 ! :tex: $-c_1\mathrm{f}_1r\mathrm{sin}\theta \left(\mathrm{cos}\theta\, v_\theta + \mathrm{sin}\theta\, v_r\right)
+    Integer, Parameter :: samom_coriolis = amoff+3 ! :tex: $-c_1\mathrm{f}_1r\mathrm{sin}\theta \left(\mathrm{cos}\theta\, v_\theta + \mathrm{sin}\theta\, v_r\right)$
 
     Integer, Parameter :: samom_diffusion = amoff+4 ! :tex: $r\,\mathrm{sin}\theta\left[\boldsymbol{\nabla}\cdot\overline{\boldsymbol{\mathcal{D}}}\right]_\phi$
 
@@ -54,7 +54,7 @@
     Integer, Parameter :: famom_maxstr_r     = amoff+15 ! :tex:  $-r\mathrm{sin}\theta c_4\,B'_r\,B'_\phi$
     Integer, Parameter :: famom_maxstr_theta = amoff+16 ! :tex:  $-r\mathrm{sin}\theta c_4\,B'_\theta\,B'_\phi$
 
-    Integer, Parameter :: famom_magtor_r     = amoff+17 !:tex:  $-r\mathrm{sin}\theta c_4\,\overline{B_r}\,\overline{B_\phi}$ -rsintheta <B_r><B_phi>*Lorentz_Coeff
-    Integer, Parameter :: famom_magtor_theta = amoff+18 ! :tex:  $-r\mathrm{sin}\theta c_4\,\overline{B_\theta}\,\overline{B_\phi}$ -rsintheta <B_r><B_phi>*Lorentz_Coeff
+    Integer, Parameter :: famom_magtor_r     = amoff+17 !:tex:  $-r\mathrm{sin}\theta c_4\,\overline{B_r}\,\overline{B_\phi}$
+    Integer, Parameter :: famom_magtor_theta = amoff+18 ! :tex:  $-r\mathrm{sin}\theta c_4\,\overline{B_\theta}\,\overline{B_\phi}$
 
 

--- a/src/Diagnostics/induction_equation_codes.F
+++ b/src/Diagnostics/induction_equation_codes.F
@@ -101,15 +101,15 @@
     Integer, Parameter :: induct_shear_vpbp_r     = indoff+58 !  :tex: $\left[\boldsymbol{B'}\cdot\boldsymbol{\nabla}\boldsymbol{v'}\right]_r$
     Integer, Parameter :: induct_comp_vpbp_r      = indoff+59 !  :tex: $-\left(\boldsymbol{\nabla}\cdot\boldsymbol{v'} \right)B'_r$
     Integer, Parameter :: induct_advec_vpbp_r     = indoff+60 !  :tex: $-\left[\boldsymbol{v'}\cdot\boldsymbol{\nabla}\boldsymbol{B'}\right]_r$
-    Integer, Parameter :: induct_vpbp_r           = indoff+61 !  :tex: $\left[\boldsymbol{\nabla}\times\left(\boldsymbol{v}\times\boldsymbol{B'}\right)\right]_r$
+    Integer, Parameter :: induct_vpbp_r           = indoff+61 !  :tex: $\left[\boldsymbol{\nabla}\times\left(\boldsymbol{v'}\times\boldsymbol{B'}\right)\right]_r$
 
     Integer, Parameter :: induct_shear_vpbp_theta = indoff+62 !  :tex: $\left[\boldsymbol{B'}\cdot\boldsymbol{\nabla}\boldsymbol{v'}\right]_\theta$
     Integer, Parameter :: induct_comp_vpbp_theta  = indoff+63 !  :tex: $-\left(\boldsymbol{\nabla}\cdot\boldsymbol{v'} \right)B'_\theta$
     Integer, Parameter :: induct_advec_vpbp_theta = indoff+64 !  :tex: $-\left[\boldsymbol{v'}\cdot\boldsymbol{\nabla}\boldsymbol{B'}\right]_\theta$
-    Integer, Parameter :: induct_vpbp_theta       = indoff+65 !  :tex: $\left[\boldsymbol{\nabla}\times\left(\boldsymbol{v}\times\boldsymbol{B'}\right)\right]_\theta$
+    Integer, Parameter :: induct_vpbp_theta       = indoff+65 !  :tex: $\left[\boldsymbol{\nabla}\times\left(\boldsymbol{v'}\times\boldsymbol{B'}\right)\right]_\theta$
 
     Integer, Parameter :: induct_shear_vpbp_phi   = indoff+66 !  :tex: $\left[\boldsymbol{B'}\cdot\boldsymbol{\nabla}\boldsymbol{v'}\right]_\phi$
     Integer, Parameter :: induct_comp_vpbp_phi    = indoff+67 !  :tex: $-\left(\boldsymbol{\nabla}\cdot\boldsymbol{v'} \right)B'_\phi$
     Integer, Parameter :: induct_advec_vpbp_phi   = indoff+68 !  :tex: $-\left[\boldsymbol{v'}\cdot\boldsymbol{\nabla}\boldsymbol{B'}\right]_\phi$
-    Integer, Parameter :: induct_vpbp_phi         = indoff+69 !  :tex: $\left[\boldsymbol{\nabla}\times\left(\boldsymbol{v}\times\boldsymbol{B'}\right)\right]_\phi$
+    Integer, Parameter :: induct_vpbp_phi         = indoff+69 !  :tex: $\left[\boldsymbol{\nabla}\times\left(\boldsymbol{v'}\times\boldsymbol{B'}\right)\right]_\phi$
 

--- a/src/Diagnostics/kinetic_energy_codes.F
+++ b/src/Diagnostics/kinetic_energy_codes.F
@@ -32,9 +32,9 @@
     Integer, Parameter :: phi_mke         = keoffset+8 ! :tex: $\frac{1}{2}\mathrm{f}_1\overline{v_\phi}^2$
 
     Integer, Parameter :: pkinetic_energy = keoffset+9  ! :tex: $\frac{1}{2}\mathrm{f}_1{\boldsymbol v'}^2$
-    Integer, Parameter :: radial_pke      = keoffset+10 ! :tex: $\frac{1}{2}\mathrm{f}_1{v_r'}^2
-    Integer, Parameter :: theta_pke       = keoffset+11 ! :tex: $\frac{1}{2}\mathrm{f}_1{v_\theta'}^2
-    Integer, Parameter :: phi_pke         = keoffset+12 ! :tex: $\frac{1}{2}\mathrm{f}_1{v_\phi'}^2
+    Integer, Parameter :: radial_pke      = keoffset+10 ! :tex: $\frac{1}{2}\mathrm{f}_1{v_r'}^2$
+    Integer, Parameter :: theta_pke       = keoffset+11 ! :tex: $\frac{1}{2}\mathrm{f}_1{v_\theta'}^2$
+    Integer, Parameter :: phi_pke         = keoffset+12 ! :tex: $\frac{1}{2}\mathrm{f}_1{v_\phi'}^2$
 
     !--- Since density varies with radius, it can be useful to output the
     !--- squared fields, sans density, as well.

--- a/src/Diagnostics/magnetic_field_codes.F
+++ b/src/Diagnostics/magnetic_field_codes.F
@@ -181,7 +181,7 @@
     !--------- theta-phi Second Derivatives --------
     ! Full
     Integer, Parameter :: db_r_d2tp      = boffset+100 ! :tex: $\frac{\partial^2 B_r}{\partial \theta \partial \phi}$
-    Integer, Parameter :: db_theta_d2tp  = boffset+101 ! :tex: $\frac{\partial^2 B_\theta}{\partial \theta \partial \phi}
+    Integer, Parameter :: db_theta_d2tp  = boffset+101 ! :tex: $\frac{\partial^2 B_\theta}{\partial \theta \partial \phi}$
     Integer, Parameter :: db_phi_d2tp    = boffset+102 ! :tex: $\frac{\partial^2 B_\phi}{\partial \theta \partial    \phi}$
     ! Fluctuating
     Integer, Parameter :: dbp_r_d2tp     = boffset+103 ! :tex: $\frac{\partial^2 B_r'}{\partial \theta \partial \phi}$

--- a/src/Diagnostics/velocity_field_codes.F
+++ b/src/Diagnostics/velocity_field_codes.F
@@ -181,7 +181,7 @@
     !--------- theta-phi Second Derivatives --------
     ! Full
     Integer, Parameter :: dv_r_d2tp      = voffset+100 ! :tex: $\frac{\partial^2 v_r}{\partial \theta \partial \phi}$
-    Integer, Parameter :: dv_theta_d2tp  = voffset+101 ! :tex: $\frac{\partial^2 v_\theta}{\partial \theta \partial \phi}
+    Integer, Parameter :: dv_theta_d2tp  = voffset+101 ! :tex: $\frac{\partial^2 v_\theta}{\partial \theta \partial \phi}$
     Integer, Parameter :: dv_phi_d2tp    = voffset+102 ! :tex: $\frac{\partial^2 v_\phi}{\partial \theta \partial    \phi}$
     ! Fluctuating
     Integer, Parameter :: dvp_r_d2tp     = voffset+103 ! :tex: $\frac{\partial^2 v_r'}{\partial \theta \partial \phi}$

--- a/src/Diagnostics/vorticity_field_codes.F
+++ b/src/Diagnostics/vorticity_field_codes.F
@@ -44,9 +44,9 @@
     Integer, Parameter :: vort_theta_sq  = vort_off+15  ! :tex: $\omega_\theta^2$
     Integer, Parameter :: vort_phi_sq    = vort_off+16  ! :tex: $\omega_\phi^2$
 
-    Integer, Parameter :: vortp_r_sq     = vort_off+17  ! :tex: $\omega_r^\prime^2$ 
-    Integer, Parameter :: vortp_theta_sq = vort_off+18  ! :tex: $\omega_\theta^\prime^2$
-    Integer, Parameter :: vortp_phi_sq   = vort_off+19  ! :tex: $\omega_\phi^\prime^2$
+    Integer, Parameter :: vortp_r_sq     = vort_off+17  ! :tex: ${\omega_r^\prime}^2$ 
+    Integer, Parameter :: vortp_theta_sq = vort_off+18  ! :tex: ${\omega_\theta^\prime}^2$
+    Integer, Parameter :: vortp_phi_sq   = vort_off+19  ! :tex: ${\omega_\phi^\prime}^2$
 
     Integer, Parameter :: vortm_r_sq     = vort_off+20  ! :tex: $\overline{\omega_r}^2$
     Integer, Parameter :: vortm_theta_sq = vort_off+21  ! :tex: $\overline{\omega_\theta}^2$


### PR DESCRIPTION
Some comments with the :tex: directive were missing the closing "$" required by Latex. There was also a vorticity entry that needed another set of curly braces to separate consecutive square operations:

\omega_\phi^\prime^2 was changed to {\omega_\phi^\prime}^2