### PR TITLE
Included the Turbulent KE budget as a standard set of outputs, thereb…

### DIFF
--- a/src/Diagnostics/Diagnostics_Base.F90
+++ b/src/Diagnostics/Diagnostics_Base.F90
@@ -91,27 +91,7 @@ Module Diagnostics_Base
 
 
 
-    !//////////////////////////////////////////////////////////
-    !  Turbulent kinetic energy generation
-    Integer, Parameter :: turbke_offset = custom_offset+100
-
-
-    Integer, Parameter :: production_buoyant_pKE   = turbke_offset + 1    ! Buoyant Production of turbulent kinetic energy
-    !Integer, Parameter :: production_shear_pKE     = turbke_offset + 2        ! Shear Production of turbulent kinetic energy
-    Integer, Parameter :: dissipation_viscous_pKE  = turbke_offset + 3    ! Viscous Dissipation of turbulent kinetic energy
-    Integer, Parameter :: transport_pressure_pKE   = turbke_offset + 4    ! Pressure Transport of turbulent kinetic energy
-    Integer, Parameter :: transport_viscous_pKE    = turbke_offset + 5        ! Viscous Transport of turbulent kinetic energy
-    Integer, Parameter :: transport_turbadvect_pKE = turbke_offset + 6    ! Turbulent Advective Transport of turbulent kinetic energy
-    Integer, Parameter :: transport_meanadvect_pKE = turbke_offset + 7    ! Mean Advective Transport of turbulent kinetic energy
-    Integer, Parameter :: rflux_pressure_pKE       = turbke_offset + 8        ! Radial Pressure Flux of turbulent kinetic energy
-    Integer, Parameter :: rflux_viscous_pKE        = turbke_offset + 9            ! Radial Viscous Flux of turbulent kinetic energy
-    Integer, Parameter :: rflux_turbadvect_pKE     = turbke_offset + 10        ! Radial Turbulent Advective Flux of turbulent kinetic energy
-    Integer, Parameter :: rflux_meanadvect_pKE     = turbke_offset + 11        ! Radial Mean Advective Flux of turbulent kinetic energy
-    Integer, Parameter :: thetaflux_pressure_pKE   = turbke_offset + 12    ! Colatitudinal Pressure Flux of turbulent kinetic energy
-    Integer, Parameter :: thetaflux_viscous_pKE    = turbke_offset + 13    ! Colatitudinal Viscous Flux of turbulent kinetic energy
-    Integer, Parameter :: thetaflux_turbadvect_pKE = turbke_offset + 14    ! Colatitudinal Turbulent Advective Flux of turbulent kinetic energy
-    Integer, Parameter :: thetaflux_meanadvect_pKE = turbke_offset + 15    ! Colatitudinal Mean Advective Flux of turbulent kinetic energy
-
+    include "turbKE_codes.F"
     include "axial_field_codes.F"
 
 

--- a/src/Diagnostics/turbKE_codes.F
+++ b/src/Diagnostics/turbKE_codes.F
@@ -3,20 +3,27 @@
     !       Turbulent KE Outputs
     Integer, Parameter :: turbke_offset = custom_offset+500
 
-    Integer, Parameter :: production_buoyant_pKE   = turbke_offset + 1  ! Buoyant Production of turbulent kinetic energy
-    !Integer, Parameter :: production_shear_pKE     = turbke_offset + 2     ! Shear Production of turbulent kinetic energy
-    Integer, Parameter :: dissipation_viscous_pKE  = turbke_offset + 3  ! Viscous Dissipation of turbulent kinetic energy
-    Integer, Parameter :: transport_pressure_pKE   = turbke_offset + 4  ! Pressure Transport of turbulent kinetic energy
-    Integer, Parameter :: transport_viscous_pKE    = turbke_offset + 5      ! Viscous Transport of turbulent kinetic energy
-    Integer, Parameter :: transport_turbadvect_pKE = turbke_offset + 6  ! Turbulent Advective Transport of turbulent kinetic energy
-    Integer, Parameter :: transport_meanadvect_pKE = turbke_offset + 7  ! Mean Advective Transport of turbulent kinetic energy
-    Integer, Parameter :: rflux_pressure_pKE       = turbke_offset + 8          ! Radial Pressure Flux of turbulent kinetic energy
-    Integer, Parameter :: rflux_viscous_pKE        = turbke_offset + 9              ! Radial Viscous Flux of turbulent kinetic energy  $
-    Integer, Parameter :: rflux_turbadvect_pKE     = turbke_offset + 10     ! Radial Turbulent Advective Flux of turbulent kinetic ener$
-    Integer, Parameter :: rflux_meanadvect_pKE     = turbke_offset + 11     ! Radial Mean Advective Flux of turbulent kinetic energy
-    Integer, Parameter :: thetaflux_pressure_pKE   = turbke_offset + 12 ! Colatitudinal Pressure Flux of turbulent kinetic energy
-    Integer, Parameter :: thetaflux_viscous_pKE    = turbke_offset + 13 ! Colatitudinal Viscous Flux of turbulent kinetic energy
-    Integer, Parameter :: thetaflux_turbadvect_pKE = turbke_offset + 14 ! Colatitudinal Turbulent Advective Flux of turbulent kinetic e$
-    Integer, Parameter :: thetaflux_meanadvect_pKE = turbke_offset + 15 ! Colatitudinal Mean Advective Flux of turbulent kinetic energy
+    Integer, Parameter :: production_buoyant_pKE   = turbke_offset + 1  ! :tex: $\mathrm{f}_2{\Theta^\prime}{v^\prime}_r$
+    Integer, Parameter :: production_shear2_pKE    = turbke_offset + 2  ! :tex: $-\mathrm{f}_1{v^\prime_i}{v^\prime_j}\overline{e}_{ij}$
+    Integer, Parameter :: dissipation_viscous_pKE  = turbke_offset + 3  ! :tex: $2\mathrm{f}_1\mathrm{f}_3\left[e^\prime_{ij}e^\prime_{ij}-\left(\boldsymbol{\nabla}\cdot\boldsymbol{v}^\prime\right)^2/3\right]$
 
+    Integer, Parameter :: transport_pressure_pKE   = turbke_offset + 4  ! :tex: $-\boldsymbol{\nabla}\cdot\left(P^\prime\boldsymbol{v}^\prime\right)$
+    Integer, Parameter :: transport_viscous_pKE    = turbke_offset + 5  ! :tex: $\boldsymbol{\nabla}\cdot\left(\boldsymbol{\mathcal{D}}^\prime\cdot\boldsymbol{v}^\prime\right)$
+    Integer, Parameter :: transport_turbadvect_pKE = turbke_offset + 6  ! :tex: $-\boldsymbol{\nabla}\cdot\left(\frac{1}{2}\mathrm{f}_1{v^\prime}^2\boldsymbol{v}^\prime\right)$
+    Integer, Parameter :: transport_meanadvect_pKE = turbke_offset + 7  ! :tex: $-\boldsymbol{\nabla}\cdot\left(\frac{1}{2}\mathrm{f}_1{v^\prime}^2\overline{\boldsymbol{v}}\right)$
+
+    Integer, Parameter :: rflux_pressure_pKE       = turbke_offset + 8  ! :tex: $P^\prime{v_r^\prime}$
+    Integer, Parameter :: rflux_viscous_pKE        = turbke_offset + 9  ! :tex: $-\left[\boldsymbol{\mathcal{D}}^\prime\cdot\boldsymbol{v}^\prime\right]_r$
+    Integer, Parameter :: rflux_turbadvect_pKE     = turbke_offset + 10 ! :tex: $\frac{1}{2}\mathrm{f}_1{v^\prime}^2v_r^\prime$
+    Integer, Parameter :: rflux_meanadvect_pKE     = turbke_offset + 11 ! :tex: $\frac{1}{2}\mathrm{f}_1{v^\prime}^2\overline{v}_r$
+
+    Integer, Parameter :: thetaflux_pressure_pKE   = turbke_offset + 12 ! :tex: $P^\prime{v_\theta^\prime}$
+    Integer, Parameter :: thetaflux_viscous_pKE    = turbke_offset + 13 ! :tex: $-\left[\boldsymbol{\mathcal{D}}^\prime\cdot\boldsymbol{v}^\prime\right]_\theta$
+    Integer, Parameter :: thetaflux_turbadvect_pKE = turbke_offset + 14 ! :tex: $\frac{1}{2}\mathrm{f}_1{v^\prime}^2v_\theta^\prime$
+    Integer, Parameter :: thetaflux_meanadvect_pKE = turbke_offset + 15 ! :tex: $\frac{1}{2}\mathrm{f}_1{v^\prime}^2\overline{v}_\theta$
+
+    Integer, Parameter :: phiflux_pressure_pKE     = turbke_offset + 16 ! :tex: $P^\prime{v_\phi^\prime}$
+    Integer, Parameter :: phiflux_viscous_pKE      = turbke_offset + 17 ! :tex: $-\left[\boldsymbol{\mathcal{D}}^\prime\cdot\boldsymbol{v}^\prime\right]_\phi$
+    Integer, Parameter :: phiflux_turbadvect_pKE   = turbke_offset + 18 ! :tex: $\frac{1}{2}\mathrm{f}_1{v^\prime}^2v_\phi^\prime$
+    Integer, Parameter :: phiflux_meanadvect_pKE   = turbke_offset + 19 ! :tex: $\frac{1}{2}\mathrm{f}_1{v^\prime}^2\overline{v}_\phi$
 


### PR DESCRIPTION
…y making them public and part of the standard output list.

1) Moves the code number definitions from Diagnostics_Base.F90 to turbKE_codes.F and added the tex description for each.

2) Added a few trivial outputs that were missing (shear production and azimuthal components of the flux)---involving changes to both turbKE_codes.F and Diagnostics_TurbKE_Budget.F90.

3) Removed some obsolete comment statements.