### PR TITLE
Make turbKE a standard set of outputs

### DIFF
--- a/src/Diagnostics/Diagnostics_Base.F90
+++ b/src/Diagnostics/Diagnostics_Base.F90
@@ -91,27 +91,7 @@ Module Diagnostics_Base
 
 
 
-    !//////////////////////////////////////////////////////////
-    !  Turbulent kinetic energy generation
-    Integer, Parameter :: turbke_offset = custom_offset+100
-
-
-    Integer, Parameter :: production_buoyant_pKE   = turbke_offset + 1    ! Buoyant Production of turbulent kinetic energy
-    !Integer, Parameter :: production_shear_pKE     = turbke_offset + 2        ! Shear Production of turbulent kinetic energy
-    Integer, Parameter :: dissipation_viscous_pKE  = turbke_offset + 3    ! Viscous Dissipation of turbulent kinetic energy
-    Integer, Parameter :: transport_pressure_pKE   = turbke_offset + 4    ! Pressure Transport of turbulent kinetic energy
-    Integer, Parameter :: transport_viscous_pKE    = turbke_offset + 5        ! Viscous Transport of turbulent kinetic energy
-    Integer, Parameter :: transport_turbadvect_pKE = turbke_offset + 6    ! Turbulent Advective Transport of turbulent kinetic energy
-    Integer, Parameter :: transport_meanadvect_pKE = turbke_offset + 7    ! Mean Advective Transport of turbulent kinetic energy
-    Integer, Parameter :: rflux_pressure_pKE       = turbke_offset + 8        ! Radial Pressure Flux of turbulent kinetic energy
-    Integer, Parameter :: rflux_viscous_pKE        = turbke_offset + 9            ! Radial Viscous Flux of turbulent kinetic energy
-    Integer, Parameter :: rflux_turbadvect_pKE     = turbke_offset + 10        ! Radial Turbulent Advective Flux of turbulent kinetic energy
-    Integer, Parameter :: rflux_meanadvect_pKE     = turbke_offset + 11        ! Radial Mean Advective Flux of turbulent kinetic energy
-    Integer, Parameter :: thetaflux_pressure_pKE   = turbke_offset + 12    ! Colatitudinal Pressure Flux of turbulent kinetic energy
-    Integer, Parameter :: thetaflux_viscous_pKE    = turbke_offset + 13    ! Colatitudinal Viscous Flux of turbulent kinetic energy
-    Integer, Parameter :: thetaflux_turbadvect_pKE = turbke_offset + 14    ! Colatitudinal Turbulent Advective Flux of turbulent kinetic energy
-    Integer, Parameter :: thetaflux_meanadvect_pKE = turbke_offset + 15    ! Colatitudinal Mean Advective Flux of turbulent kinetic energy
-
+    include "turbKE_codes.F"
     include "axial_field_codes.F"
 
 

--- a/src/Diagnostics/Diagnostics_TurbKE_Budget.F90
+++ b/src/Diagnostics/Diagnostics_TurbKE_Budget.F90
@@ -457,9 +457,12 @@ Contains
                 DO k = 1, n_phi
                     ! Compute elements of the turbulent rate of strain tensor
                     ! e'_ij
-                    erp = 0.5D0*(one_over_rsin*fbuffer(PSI,dvrdp) - one_over_r(r)*fbuffer(PSI,vphi) + fbuffer(PSI,dvpdr))
-                    etp = 0.5D0*(one_over_rsin*fbuffer(PSI,dvtdp) - ctn_over_r*fbuffer(PSI,vphi) + one_over_r(r)*fbuffer(PSI,dvpdt))
-                    epp = one_over_rsin*fbuffer(PSI,dvpdp) + one_over_r(r)*fbuffer(PSI,vr) + ctn_over_r*fbuffer(PSI,vtheta)
+                    erp = 0.5D0*(one_over_rsin*fbuffer(PSI,dvrdp) - one_over_r(r)*fbuffer(PSI,vphi)     &
+                        + fbuffer(PSI,dvpdr))
+                    etp = 0.5D0*(one_over_rsin*fbuffer(PSI,dvtdp) - ctn_over_r*fbuffer(PSI,vphi)        &
+                        + one_over_r(r)*fbuffer(PSI,dvpdt))
+                    epp = one_over_rsin*fbuffer(PSI,dvpdp) + one_over_r(r)*fbuffer(PSI,vr)              &
+                        + ctn_over_r*fbuffer(PSI,vtheta)
 
                     ! Zonal component of the viscous stess contracted w/ the velocity: phi_hat . sigma' . u'
                     divu = -ref%dlnrho(r) * fbuffer(PSI,vr)                       ! Assume anelasticity

--- a/src/Diagnostics/Diagnostics_TurbKE_Budget.F90
+++ b/src/Diagnostics/Diagnostics_TurbKE_Budget.F90
@@ -375,7 +375,7 @@ Contains
         !    phi_hat . F_TP = P' u'_phi
         If (compute_quantity(phiflux_pressure_pKE)) Then
             DO_PSI
-                qty(PSI) = fbuffer(PSI,vp) * fbuffer(PSI,pvar)
+                qty(PSI) = fbuffer(PSI,vphi) * fbuffer(PSI,pvar)
             END_DO
             Call Add_Quantity(qty)
         Endif

--- a/src/Diagnostics/turbKE_codes.F
+++ b/src/Diagnostics/turbKE_codes.F
@@ -3,20 +3,27 @@
     !       Turbulent KE Outputs
     Integer, Parameter :: turbke_offset = custom_offset+500
 
-    Integer, Parameter :: production_buoyant_pKE   = turbke_offset + 1  ! Buoyant Production of turbulent kinetic energy
-    !Integer, Parameter :: production_shear_pKE     = turbke_offset + 2     ! Shear Production of turbulent kinetic energy
-    Integer, Parameter :: dissipation_viscous_pKE  = turbke_offset + 3  ! Viscous Dissipation of turbulent kinetic energy
-    Integer, Parameter :: transport_pressure_pKE   = turbke_offset + 4  ! Pressure Transport of turbulent kinetic energy
-    Integer, Parameter :: transport_viscous_pKE    = turbke_offset + 5      ! Viscous Transport of turbulent kinetic energy
-    Integer, Parameter :: transport_turbadvect_pKE = turbke_offset + 6  ! Turbulent Advective Transport of turbulent kinetic energy
-    Integer, Parameter :: transport_meanadvect_pKE = turbke_offset + 7  ! Mean Advective Transport of turbulent kinetic energy
-    Integer, Parameter :: rflux_pressure_pKE       = turbke_offset + 8          ! Radial Pressure Flux of turbulent kinetic energy
-    Integer, Parameter :: rflux_viscous_pKE        = turbke_offset + 9              ! Radial Viscous Flux of turbulent kinetic energy  $
-    Integer, Parameter :: rflux_turbadvect_pKE     = turbke_offset + 10     ! Radial Turbulent Advective Flux of turbulent kinetic ener$
-    Integer, Parameter :: rflux_meanadvect_pKE     = turbke_offset + 11     ! Radial Mean Advective Flux of turbulent kinetic energy
-    Integer, Parameter :: thetaflux_pressure_pKE   = turbke_offset + 12 ! Colatitudinal Pressure Flux of turbulent kinetic energy
-    Integer, Parameter :: thetaflux_viscous_pKE    = turbke_offset + 13 ! Colatitudinal Viscous Flux of turbulent kinetic energy
-    Integer, Parameter :: thetaflux_turbadvect_pKE = turbke_offset + 14 ! Colatitudinal Turbulent Advective Flux of turbulent kinetic e$
-    Integer, Parameter :: thetaflux_meanadvect_pKE = turbke_offset + 15 ! Colatitudinal Mean Advective Flux of turbulent kinetic energy
+    Integer, Parameter :: production_buoyant_pKE   = turbke_offset + 1  ! :tex: $\mathrm{f}_2{\Theta^\prime}{v^\prime}_r$
+    Integer, Parameter :: production_shear2_pKE    = turbke_offset + 2  ! :tex: $-\mathrm{f}_1{v^\prime_i}{v^\prime_j}\overline{e}_{ij}$
+    Integer, Parameter :: dissipation_viscous_pKE  = turbke_offset + 3  ! :tex: $2\mathrm{f}_1\mathrm{f}_3\left[e^\prime_{ij}e^\prime_{ij}-\left(\boldsymbol{\nabla}\cdot\boldsymbol{v}^\prime\right)^2/3\right]$
 
+    Integer, Parameter :: transport_pressure_pKE   = turbke_offset + 4  ! :tex: $-\boldsymbol{\nabla}\cdot\left(P^\prime\boldsymbol{v}^\prime\right)$
+    Integer, Parameter :: transport_viscous_pKE    = turbke_offset + 5  ! :tex: $\boldsymbol{\nabla}\cdot\left(\boldsymbol{\mathcal{D}}^\prime\cdot\boldsymbol{v}^\prime\right)$
+    Integer, Parameter :: transport_turbadvect_pKE = turbke_offset + 6  ! :tex: $-\boldsymbol{\nabla}\cdot\left(\frac{1}{2}\mathrm{f}_1{v^\prime}^2\boldsymbol{v}^\prime\right)$
+    Integer, Parameter :: transport_meanadvect_pKE = turbke_offset + 7  ! :tex: $-\boldsymbol{\nabla}\cdot\left(\frac{1}{2}\mathrm{f}_1{v^\prime}^2\overline{\boldsymbol{v}}\right)$
+
+    Integer, Parameter :: rflux_pressure_pKE       = turbke_offset + 8  ! :tex: $P^\prime{v_r^\prime}$
+    Integer, Parameter :: rflux_viscous_pKE        = turbke_offset + 9  ! :tex: $-\left[\boldsymbol{\mathcal{D}}^\prime\cdot\boldsymbol{v}^\prime\right]_r$
+    Integer, Parameter :: rflux_turbadvect_pKE     = turbke_offset + 10 ! :tex: $\frac{1}{2}\mathrm{f}_1{v^\prime}^2v_r^\prime$
+    Integer, Parameter :: rflux_meanadvect_pKE     = turbke_offset + 11 ! :tex: $\frac{1}{2}\mathrm{f}_1{v^\prime}^2\overline{v}_r$
+
+    Integer, Parameter :: thetaflux_pressure_pKE   = turbke_offset + 12 ! :tex: $P^\prime{v_\theta^\prime}$
+    Integer, Parameter :: thetaflux_viscous_pKE    = turbke_offset + 13 ! :tex: $-\left[\boldsymbol{\mathcal{D}}^\prime\cdot\boldsymbol{v}^\prime\right]_\theta$
+    Integer, Parameter :: thetaflux_turbadvect_pKE = turbke_offset + 14 ! :tex: $\frac{1}{2}\mathrm{f}_1{v^\prime}^2v_\theta^\prime$
+    Integer, Parameter :: thetaflux_meanadvect_pKE = turbke_offset + 15 ! :tex: $\frac{1}{2}\mathrm{f}_1{v^\prime}^2\overline{v}_\theta$
+
+    Integer, Parameter :: phiflux_pressure_pKE     = turbke_offset + 16 ! :tex: $P^\prime{v_\phi^\prime}$
+    Integer, Parameter :: phiflux_viscous_pKE      = turbke_offset + 17 ! :tex: $-\left[\boldsymbol{\mathcal{D}}^\prime\cdot\boldsymbol{v}^\prime\right]_\phi$
+    Integer, Parameter :: phiflux_turbadvect_pKE   = turbke_offset + 18 ! :tex: $\frac{1}{2}\mathrm{f}_1{v^\prime}^2v_\phi^\prime$
+    Integer, Parameter :: phiflux_meanadvect_pKE   = turbke_offset + 19 ! :tex: $\frac{1}{2}\mathrm{f}_1{v^\prime}^2\overline{v}_\phi$
 


### PR DESCRIPTION
 Modified the Turbulent KE budget outputs to make them a standard set of outputs: they should now appear in the PDF file of outputs.

1. Moved the code number definitions from Diagnostics_Base.F90 to turbKE_codes.F and added the tex description for each.

2. Added a few trivial outputs that were missing (shear production and azimuthal components of the flux)---involving changes to both turbKE_codes.F and Diagnostics_TurbKE_Budget.F90.

3. Removed some obsolete comment statements.

4. This should make Nick's pull request #95 unnecessary.