### PR TITLE
Sigterm

### DIFF
--- a/configure
+++ b/configure
@@ -32,12 +32,12 @@ function opt_flags {
   #$1 --version
   if [[ $1 == "INTEL" ]]
   then
-    echo '-FR -fpp -r8 -O3 -shared-intel'
+    echo '-FR -fpp -r8 -O3 -shared-intel -DINTEL_COMPILER'
   fi
 
   if [[ $1 == "GNU" ]]
   then
-    echo '-O3 -ffixed-line-length-132'
+    echo '-O3 -ffixed-line-length-132 -DGNU_COMPILER'
   fi
 }
 
@@ -45,11 +45,11 @@ function dbg_flags {
   #$1 --version
   if [[ $1 == "INTEL" ]]
   then
-    echo '-FR -fpp -r8 -O0 -g -CB -traceback -shared-intel'
+    echo '-FR -fpp -r8 -O0 -g -CB -traceback -shared-intel -DINTEL_COMPILER'
   fi
   if [[ $1 == "GNU" ]]
   then
-    echo '-O0 -fbounds-check -fbacktrace -ffixed-line-length-132'
+    echo '-O0 -fbounds-check -fbacktrace -ffixed-line-length-132 -DGNU_COMPILER'
   fi
 }
 

--- a/src/Physics/Controls.F90
+++ b/src/Physics/Controls.F90
@@ -82,6 +82,7 @@ Module Controls
     Real*8  :: max_time_minutes = 1d8           ! Maximum walltime to run the code (this should be ample...)
 
     Logical :: save_last_timestep = .true.
+    Logical :: save_on_sigterm = .false.       ! Rayleigh will attempt to checkpoint and exit upon termination request
     Integer :: check_frequency = -1            ! Number of iterations between checkpoint dumps
     Integer :: checkpoint_interval = 1000000   ! Same as check_frequency (check_frequency will be deprecated soon)
     Integer :: quicksave_interval =  -1        ! Number of iterations between quicksave dumps
@@ -98,7 +99,7 @@ Module Controls
     Namelist /Temporal_Controls_Namelist/ alpha_implicit, max_iterations, check_frequency, &
                 & cflmax, cflmin, max_time_step,chk_type, diagnostic_reboot_interval, min_time_step, &
                 & num_quicksaves, quicksave_interval, checkpoint_interval, quicksave_minutes, &
-                & max_time_minutes, save_last_timestep, new_iteration,read_chk_type
+                & max_time_minutes, save_last_timestep, new_iteration,read_chk_type, save_on_sigterm
 
 
 


### PR DESCRIPTION
I've added the capability for Rayleigh to intercept SIGTERM (kill -15) signals from the OS.  Many job schedulers will send a SIGTERM before sending SIGKILL (kill -9) to end the process, with some small amount of time (i.e. 30 seconds) in between.   This functionality allows Rayleigh to checkpoint and exit upon receiving a SIGTERM signal.   