### PR TITLE
Command-line Nondimensional Parameters

### DIFF
--- a/src/Physics/Controls.F90
+++ b/src/Physics/Controls.F90
@@ -80,7 +80,7 @@ Module Controls
     Real*8  :: alpha_implicit = 0.5d0       ! Crank Nicolson Implict/Explicit weighting factor (1.0 is fully implicit)
     Integer :: max_iterations = 1000000     ! The maximum number of iterations to be run in a given session
     Real*8  :: max_time_minutes = 1d8       ! Maximum walltime to run the code (this should be ample...)
-    Real*8  :: max_simulation_time = 1d20   ! Maximum simulation time to evolve the model for
+    Real*8  :: max_simulated_time = 1d20   ! Maximum simulation time to evolve the model for
 
     Logical :: save_last_timestep = .true.
     Logical :: save_on_sigterm = .false.       ! Rayleigh will attempt to checkpoint and exit upon termination request
@@ -101,7 +101,7 @@ Module Controls
                 & cflmax, cflmin, max_time_step,chk_type, diagnostic_reboot_interval, min_time_step, &
                 & num_quicksaves, quicksave_interval, checkpoint_interval, quicksave_minutes, &
                 & max_time_minutes, save_last_timestep, new_iteration,read_chk_type, save_on_sigterm, &
-                & max_simulation_time
+                & max_simulated_time
 
 
 

--- a/src/Physics/Controls.F90
+++ b/src/Physics/Controls.F90
@@ -78,8 +78,9 @@ Module Controls
     !   Temporal Controls
     !   Flags that control details of the time-stepping (some relate to the numerics, but we keep the time-related things together).
     Real*8  :: alpha_implicit = 0.5d0       ! Crank Nicolson Implict/Explicit weighting factor (1.0 is fully implicit)
-    Integer :: max_iterations = 1000000         ! The maximum number of iterations to be run in a given session
-    Real*8  :: max_time_minutes = 1d8           ! Maximum walltime to run the code (this should be ample...)
+    Integer :: max_iterations = 1000000     ! The maximum number of iterations to be run in a given session
+    Real*8  :: max_time_minutes = 1d8       ! Maximum walltime to run the code (this should be ample...)
+    Real*8  :: max_simulation_time = 1d20   ! Maximum simulation time to evolve the model for
 
     Logical :: save_last_timestep = .true.
     Logical :: save_on_sigterm = .false.       ! Rayleigh will attempt to checkpoint and exit upon termination request
@@ -99,7 +100,8 @@ Module Controls
     Namelist /Temporal_Controls_Namelist/ alpha_implicit, max_iterations, check_frequency, &
                 & cflmax, cflmin, max_time_step,chk_type, diagnostic_reboot_interval, min_time_step, &
                 & num_quicksaves, quicksave_interval, checkpoint_interval, quicksave_minutes, &
-                & max_time_minutes, save_last_timestep, new_iteration,read_chk_type, save_on_sigterm
+                & max_time_minutes, save_last_timestep, new_iteration,read_chk_type, save_on_sigterm, &
+                & max_simulation_time
 
 
 
@@ -117,7 +119,7 @@ Module Controls
     ! full pool of processes
     Real*8, Allocatable :: global_msgs(:)
     Real*8 :: kill_signal = 0.0d0  ! Signal will be passed in Real*8 buffer, but should be integer-like
-    Integer :: nglobal_msgs = 3  ! timestep, elapsed since checkpoint, kill_signal/global message
+    Integer :: nglobal_msgs = 4  ! timestep, elapsed since checkpoint, kill_signal/global message, simulation time
 
 
     Integer :: nicknum = 5   ! DO NOT LEAVE THIS HERE -- TEMPORARY LOCATION (AND NAME)

--- a/src/Physics/Input.F90
+++ b/src/Physics/Input.F90
@@ -29,7 +29,8 @@ Module Input
     Use BoundaryConditions, Only : boundary_conditions_namelist
     Use Initial_Conditions, Only : initial_conditions_namelist, alt_check
     Use TestSuite, Only : test_namelist
-    Use ReferenceState, Only : reference_namelist
+    Use ReferenceState, Only : reference_namelist, Prandtl_Number, Rayleigh_Number, &
+                               Magnetic_Prandtl_Number, Ekman_Number
     Use TransportCoefficients, Only : Transport_Namelist
     Use Parallel_Framework, Only : pfi
     Use Stable_Plugin, Only : stable_namelist
@@ -250,6 +251,32 @@ Contains
                     arg2 = TRIM(AdjustL(arg))
                   Read (arg2,*) jobinfo_file
                 Endif
+
+                ! Physical control parameters
+                If (arg .eq. '-Ra') then
+                    CALL get_command_argument(i+1, arg)
+                    arg2 = TRIM(AdjustL(arg))
+                  Read (arg2,*) Rayleigh_Number
+                Endif
+
+                If (arg .eq. '-E') then
+                    CALL get_command_argument(i+1, arg)
+                    arg2 = TRIM(AdjustL(arg))
+                  Read (arg2,*) Ekman_Number
+                Endif
+
+                If (arg .eq. '-Pr') then
+                    CALL get_command_argument(i+1, arg)
+                    arg2 = TRIM(AdjustL(arg))
+                  Read (arg2,*) Prandtl_Number
+                Endif
+
+                If (arg .eq. '-Pm') then
+                    CALL get_command_argument(i+1, arg)
+                    arg2 = TRIM(AdjustL(arg))
+                  Read (arg2,*) Magnetic_Prandtl_Number
+                Endif
+
               i = i+1
 
           END DO

--- a/src/Physics/Sphere_Driver.F90
+++ b/src/Physics/Sphere_Driver.F90
@@ -187,13 +187,13 @@ Contains
                 last_iteration = iteration !force loop to end
             Endif
 
-            If (global_msgs(4) .gt. max_simulation_time) Then
+            If (global_msgs(4) .gt. max_simulated_time) Then
                 last_iteration = iteration !force loop to end
 
                 If (my_rank .eq. 0) Then
 
                     Call stdout%print(' ')
-                    Call stdout%print(' Maximum simulation time exceeded.  Cleaning up.')
+                    Call stdout%print(' Maximum simulated time exceeded.  Cleaning up.')
                     Call stdout%print(' ')
 
 
@@ -202,7 +202,7 @@ Contains
                     Open(unit=io, file=Trim(my_path)//'simulation_complete.txt', form='formatted', &
                         & action='write', access='sequential', status='replace', iostat=ierr)
                     If (ierr .eq. 0) Then
-                        Write(io,*) "Maximum simulation time exceeded."
+                        Write(io,*) "Maximum simulated time exceeded."
                         Close(unit=io)
                     Endif
                 Endif

--- a/src/Physics/Sphere_Driver.F90
+++ b/src/Physics/Sphere_Driver.F90
@@ -139,6 +139,11 @@ Contains
             !If so, we will want to transfer additional information within
             !The transpose buffers
             output_iteration = time_to_output(iteration)
+
+            ! Information relevant to ending the simulation is added here.
+            ! All processes contain the same (cpu-pool max) value
+            ! for global_msgs following the completion of AdvanceTime
+            global_msgs(2) = stopwatch(walltime)%elapsed 
             global_msgs(3) = killsig
             global_msgs(4) = simulation_time
 
@@ -174,7 +179,7 @@ Contains
             !////////////////////////////////////////////////////////////////////
             !   The final part of the loop just deals with cleaning up if it's
             !      time to end the run.
-            global_msgs(2) = stopwatch(walltime)%elapsed !/timer_ticklength
+            
             If (global_msgs(2) .gt. max_time_seconds) Then
                 If (my_rank .eq. 0) Then
                     Call stdout%print(' User-specified maximum walltime exceeded.  Cleaning up.')
@@ -188,7 +193,7 @@ Contains
                 If (my_rank .eq. 0) Then
 
                     Call stdout%print(' ')
-                    Call stdout%print(' Maximum simulation time reached.  Checkpoint/exit sequence initiated.')
+                    Call stdout%print(' Maximum simulation time exceeded.  Cleaning up.')
                     Call stdout%print(' ')
 
 
@@ -197,7 +202,7 @@ Contains
                     Open(unit=io, file=Trim(my_path)//'simulation_complete.txt', form='formatted', &
                         & action='write', access='sequential', status='replace', iostat=ierr)
                     If (ierr .eq. 0) Then
-                        Write(io,*) "Maximum simulation time reached."
+                        Write(io,*) "Maximum simulation time exceeded."
                         Close(unit=io)
                     Endif
                 Endif
@@ -208,7 +213,7 @@ Contains
                 If (save_on_sigterm) Then
                     If (my_rank .eq. 0) Then
                         Call stdout%print(' ')
-                        Call stdout%print(' SIGTERM caught.  Checkpoint/exit sequence initiated.')
+                        Call stdout%print(' SIGTERM caught.  Cleaning up')
                         Call stdout%print(' ')
                     Endif
                     last_iteration = iteration !force loop to end


### PR DESCRIPTION
This commit allows Ra, Pm, Pr, and E to be specified at the command line.  Calling syntax works as with other command line parameters.   Parameters are specified by their abbreviation, namely:

./rayleigh -Pr N -Pm M -Ra X -E Y

Note that due to my branching/merging practices, this pull request contains changes associated with my earlier run-timing commit.  That commit should be accepted first.