### PR TITLE
Bug Fix:  Record numbering following restart

### DIFF
--- a/dev_build
+++ b/dev_build
@@ -1,4 +1,4 @@
 make distclean
-./configure -devel $1
+./configure -devel
 make
 make install

--- a/dev_build
+++ b/dev_build
@@ -1,4 +1,4 @@
 make distclean
-./configure -devel
+./configure -devel $1
 make
 make install

--- a/src/IO/Spherical_IO.F90
+++ b/src/IO/Spherical_IO.F90
@@ -3565,8 +3565,11 @@ Contains
 
             Call self%update_position                                ! save current position
             Read(self%file_unit,POS = 9)self%current_rec             ! read previous record #
+#ifdef INTEL_COMPILER 
+            fstat=fseek(self%file_unit, self%file_position, 0) ! return to end of file 
+#else
             Call fseek(self%file_unit, self%file_position, 0, fstat) ! return to end of file 
-
+#endif
 
             self%current_rec = self%current_rec+1
             If (errcheck .ne. 0) Then

--- a/src/IO/Spherical_IO.F90
+++ b/src/IO/Spherical_IO.F90
@@ -28,6 +28,9 @@ Module Spherical_IO
     Use Legendre_Transforms, Only : Legendre_Transform
     Use BufferedOutput
     Use Math_Constants
+#ifdef INTEL_COMPILER 
+    USE IFPORT
+#endif
 	Implicit None
 	! This module contains routines for outputing spherical data as:
 	! 1. Slices of sphere

--- a/src/IO/Spherical_IO.F90
+++ b/src/IO/Spherical_IO.F90
@@ -3529,9 +3529,8 @@ Contains
         Character*8 :: iterstring,istr
         Character*120 :: filename, omsg
         Integer :: modcheck, imod, file_iter, next_iter, ibelong
-        ! Note - we should do something to make sure that the file has been started before we start writing to it...
-        ! possibly look at self%rec_count*self%frequency
-        ! otherwise, if someone output with a strange cadence relative to
+        Integer :: fstat
+
         modcheck = self%frequency*self%rec_per_file
         imod = Mod(iter,modcheck) 
 
@@ -3545,9 +3544,6 @@ Contains
 
         If ( (imod .eq. self%frequency) .or. (self%rec_per_file .eq. 1) ) Then   ! time to begin a new file 
 
-            !omsg = ' Creating Filename: '//trim(filename)
-            !Write(6,*)'Creating Filename: ', filename
-            !Call stdout%print(omsg)
             Call stdout%print(' Creating Filename: '//trim(filename))
             Open(unit=self%file_unit,file=filename,form='unformatted', status='replace',access='stream',iostat = errcheck)
             Write(self%file_unit)endian_tag
@@ -3558,21 +3554,26 @@ Contains
                 next_iter =file_iter+modcheck
                 call stdout%print(' Unable to create file!!: '//trim(filename))
             Endif
+
         Else
+
             Open(unit=self%file_unit,file=filename,form='unformatted', status='old',access='stream', &
                 & iostat = errcheck, POSITION = 'APPEND')    
 
-            ! This looks redundant, but it allows partial files to be continued following restart
-            !Read(self%file_unit,POS = 9)self%current_rec  
+            Call self%update_position                                ! save current position
+            Read(self%file_unit,POS = 9)self%current_rec             ! read previous record #
+            Call fseek(self%file_unit, self%file_position, 0, fstat) ! return to end of file 
+
+
             self%current_rec = self%current_rec+1
             If (errcheck .ne. 0) Then
                 next_iter =file_iter+modcheck
                 Call stdout%print(' --Failed to find needed file: '//trim(filename))
                 Call stdout%print(' --Partial diagnostic files are not currently supported.')
                 Write(istr,'(i8.8)')ibelong+self%frequency
-               !Write(6,*)'No data will be written until a new file is created at iteration: ', ibelong+self%frequency
                 Call stdout%print(' --No data will be written until a new file is created at iteration: '//trim(istr))
             Endif
+
         Endif
 
     End Subroutine OpenFile
@@ -3648,12 +3649,11 @@ Contains
                  MPI_INFO_NULL, funit, ierr) 
             self%file_unit = funit
 
-            !disp = 8
-            !Call MPI_File_Seek(self%file_unit,disp,MPI_SEEK_SET,ierr)
-            !Read the current record
-
-            !call MPI_FILE_READ(self%file_unit, self%current_rec, 1, MPI_INTEGER, & 
-            !mstatus, ierr)
+            !Read the previous record number / advance record
+            disp = 8
+            Call MPI_File_Seek(self%file_unit,disp,MPI_SEEK_SET,ierr)
+            Call MPI_FILE_READ(self%file_unit, self%current_rec, 1, MPI_INTEGER, & 
+                & mstatus, ierr)
 
             self%current_rec = self%current_rec+1+self%cc
 
@@ -3710,7 +3710,8 @@ Contains
     Subroutine Update_Position(self)
         Implicit None
         Class(DiagnosticInfo) :: self
-        INQUIRE(UNIT=self%file_unit, POS=self%file_position)
+        !INQUIRE(UNIT=self%file_unit, POS=self%file_position)
+        self%file_position=ftell(self%file_unit)
     End Subroutine Update_Position
 
     Subroutine getq_now(self,yesno)

--- a/src/Physics/Input.F90
+++ b/src/Physics/Input.F90
@@ -27,7 +27,7 @@ Module Input
                             & io_controls_namelist, new_iteration, jobinfo_file
     Use Spherical_IO, Only : output_namelist
     Use BoundaryConditions, Only : boundary_conditions_namelist
-    Use Initial_Conditions, Only : initial_conditions_namelist, alt_check
+    Use Initial_Conditions, Only : initial_conditions_namelist, alt_check, init_type, magnetic_init_type
     Use TestSuite, Only : test_namelist
     Use ReferenceState, Only : reference_namelist, Prandtl_Number, Rayleigh_Number, &
                                Magnetic_Prandtl_Number, Ekman_Number
@@ -275,6 +275,18 @@ Contains
                     CALL get_command_argument(i+1, arg)
                     arg2 = TRIM(AdjustL(arg))
                   Read (arg2,*) Magnetic_Prandtl_Number
+                Endif
+
+                If (arg .eq. '-init') then
+                    CALL get_command_argument(i+1, arg)
+                    arg2 = TRIM(AdjustL(arg))
+                  Read (arg2,*) init_type
+                Endif
+
+                If (arg .eq. '-mag-init') then
+                    CALL get_command_argument(i+1, arg)
+                    arg2 = TRIM(AdjustL(arg))
+                  Read (arg2,*) magnetic_init_type
                 Endif
 
               i = i+1


### PR DESCRIPTION
This commit involves one bug fix and one small addition:

Bug fix:  There was a bug that was mentioned during the September hackathon.  Output files which were partially complete prior to restart were subsequently corrupted due to issues with the record numbering.   This commit fixes this bug.

Addition:  Normally I would make this a separate pull request, but I added this functionality while debugging the record-number issue.   Rayleigh now accepts the command-line flags -init and -mag_init which can be followed with the desired value of init_type and magnetic_init_type respectively (overriding the value set in main_input).  This can be useful for scripting in addition to debugging.  Calling syntax:  ./rayleigh -init_type -1  (to restart from a checkpoint, for example)
