### PR TITLE
Benchmark Mode / Jobinfo.txt Bug Fix

### DIFF
--- a/src/IO/Spherical_IO.F90
+++ b/src/IO/Spherical_IO.F90
@@ -3716,7 +3716,6 @@ Contains
     Subroutine Update_Position(self)
         Implicit None
         Class(DiagnosticInfo) :: self
-        !INQUIRE(UNIT=self%file_unit, POS=self%file_position)
         self%file_position=ftell(self%file_unit)
     End Subroutine Update_Position
 

--- a/src/Physics/Input.F90
+++ b/src/Physics/Input.F90
@@ -34,7 +34,7 @@ Module Input
     Use TransportCoefficients, Only : Transport_Namelist
     Use Parallel_Framework, Only : pfi
     Use Stable_Plugin, Only : stable_namelist
-    Use Run_Parameters, Only : write_run_parameters
+
     Implicit None
 
     Interface Read_CMD_Line
@@ -62,14 +62,10 @@ Contains
         Read(unit=20, nml=test_namelist)
         Read(unit=20, nml=reference_namelist)
         Read(unit=20, nml=Transport_Namelist)
-        !Read(unit=20, nml=Stable_Namelist)
         Close(20)
 
         ! Check the command line to see if any arguments were passed explicitly
         Call CheckArgs()
-
-        ! write input parameters and other build information
-        Call Write_Run_Parameters()
 
     End Subroutine Main_Input
 

--- a/src/Physics/Main.F90
+++ b/src/Physics/Main.F90
@@ -44,6 +44,7 @@ Program Main!
     Use Fourier_Transform, Only : Initialize_FFTs
     Use Benchmarking, Only : Initialize_Benchmarking, Benchmark_Input_Reset
     Use Stable_Plugin
+    Use Run_Parameters, Only : write_run_parameters
 
     Implicit None
 
@@ -54,6 +55,7 @@ Program Main!
 
     Call Main_Input()
     Call Benchmark_Input_Reset() ! Sets run parameters to benchmark parameters if benchmark_mode .ge. 0
+    Call Write_Run_Parameters()  ! write input parameters and other build information
 
     If (test_mode) Then
         Call Init_ProblemSize()
@@ -132,7 +134,7 @@ Contains
 
     Subroutine Finalization()
         If (.not. test_mode) Then
-         If (my_rank .eq. 0) Call stdout%finalize()
+            If (my_rank .eq. 0) Call stdout%finalize()
         Endif
         Call pfi%exit()
     End Subroutine Finalization


### PR DESCRIPTION
This is a minor bug fix.  I noticed last week that the jobinfo.txt file is created before benchmark-mode overrides are enforced.  When benchmark mode was on, the jobinfo.txt would display incorrect values for Rayleigh_Number etc.   I pulled the write_run_parameters() routine into Main.F90 to fix this.   I also made a few small style edits and removed a commented line in Spherical_IO.F90.