### PR TITLE
Spherical_3D Class Revision 

### DIFF
--- a/post_processing/rayleigh_diagnostics.py
+++ b/post_processing/rayleigh_diagnostics.py
@@ -41,6 +41,47 @@ class Spherical_3D:
     self.nr                                       : number of radial points
     self.ntheta                                   : number of theta points
     self.nphi                                     : number of phi points sampled
+    self.r                                        : radial coordinates
+    self.theta                                    : co-latitudinal coordinates
+    self.vals[0:nphi-1,0:ntheta=1,0:nr-1]         : 3-D array of values
+    """
+ 
+    def __init__(self,filename,path='Spherical_3D/'):
+        """filename  : The reference state file to read.
+           path      : The directory where the file is located (if not Spherical_3D)
+        """
+        self.basefilename = os.path.split(filename)[-1].split("_")[0]
+
+        grid_file = path+self.basefilename+"_grid"
+        fd = open(grid_file,'rb')
+        bs = check_endian(fd,314,'int32')
+        nr = swapread(fd,dtype='int32',count=1,swap=bs)
+        ntheta = swapread(fd,dtype='int32',count=1,swap=bs)
+        nphi = swapread(fd,dtype='int32',count=1,swap=bs)
+        assert(nphi == 2*ntheta)
+
+        self.nr = nr
+        self.ntheta = ntheta
+        self.nphi = nphi
+
+        rs = swapread(fd,dtype='float64',count=self.nr,swap=bs)
+        thetas = swapread(fd,dtype='float64',count=self.ntheta,swap=bs)
+        fd.close()
+
+        fd = open(path+filename, 'rb')
+        self.r = rs
+        self.theta = thetas
+        self.vals = np.reshape(swapread(fd,dtype='float64',count=nphi*ntheta*nr,swap=bs),(nphi,ntheta,nr), order = 'F')
+        fd.close()
+
+
+class Spherical_3D_multi:
+    """Rayleigh Spherical_3D Structure
+    ----------------------------------
+    self.basefilename                             : base filename
+    self.nr                                       : number of radial points
+    self.ntheta                                   : number of theta points
+    self.nphi                                     : number of phi points sampled
     self.rs                                       : radial coordinates
     self.thetas                                   : co-latitudinal coordinates
     self.vals[qindex][0:nphi-1,0:ntheta=1,0:nr-1] : dictionary of values, indexed by qindex
@@ -78,6 +119,8 @@ class Spherical_3D:
           if index == "grid": continue
           fd = open(path+var_file, 'rb')
           self.vals[index] = swapread(fd,dtype='float64',count=nphi*ntheta*nr,swap=bs)
+
+
 
 class RayleighTiming:
 


### PR DESCRIPTION
This pull request adds a revised Spherical_3D class to rayleigh_diagnostics.py.    As written,the class was structured very differently from other output-related classes.   In addition, it did not appear to return a dictionary of 3-D arrays as indicated by the docstring.   I have retained that original version, for now, having renamed it to Spherical_3D_multi in case this was something in-development that someone was hoping to come back to.