### PR TITLE
Fix bug in ReferenceState that shifted all arrays by one element if r…

### DIFF
--- a/post_processing/rayleigh_diagnostics.py
+++ b/post_processing/rayleigh_diagnostics.py
@@ -230,7 +230,10 @@ class ReferenceState:
             tmp = np.reshape(swapread(fd,dtype='float64',count=11*nr,swap=bs),(nr,11), order = 'F')
         except: # Heating was not written (different-size binary 'reference')
             fd.close() # close and reopen the file to start from the beginning
+            # Read in two ints first to make sure the float arrays read in start at the right place!
             fd = open(the_file,'rb')
+            dummy = swapread(fd, dtype='int32',count=1,swap=bs)
+            dummy = swapread(fd, dtype='int32',count=1,swap=bs)
             tmp = np.reshape(swapread(fd,dtype='float64',count=10*nr,swap=bs),(nr,10), order = 'F')
             heating_written = False
         self.nr = nr


### PR DESCRIPTION
…eading an older "reference" file

I messed up in my previous fix of ReferenceState; I forgot about the two ints in the beginning of the binary 'reference' file, namely sig=314 and nr. So when I closed and reopened the file when handling an exception, the float arrays started in the wrong spot, meaning each ref.radius, ref.density, etc., had their first element from the array previous. This should be fixed by this commit, which reads in two ints after the 'reference' file is opened again. 

Sorry about that!