### PR TITLE
Bug Fix:  Partial Files & Serial I/O

### DIFF
--- a/src/IO/Spherical_IO.F90
+++ b/src/IO/Spherical_IO.F90
@@ -3070,8 +3070,8 @@ Contains
         If (myid .eq. io_node) Then
 
             Call Global_Averages%OpenFile(this_iter, error)
+
             If (error .eq. 0) Then
-                Write(6,*)'error 0 at : ', this_iter
                 If (Global_Averages%write_header) Then
                     Write(funit)nq_globav
                     Write(funit)(Global_Averages%oqvals(i),i=1,nq_globav)


### PR DESCRIPTION
There was a bug in the OpenFile routine that was causing errors occurring when opening a file to be ignored, potentially leading to crashes.   I fixed this bug for OpenFile, and modified the routine so that partial output files are now supported.  This fix applied only to the Serio I/O routine OpenFile, which is used for G_Avgs and Shell_Avgs output. 

I suspect a similar issue exists for OpenFile_Par, which is used for the other outputs.  I will fix the bug + partial file I/O for that routine in the next week or so.

-Nick