### PR TITLE
Important Bug Fix:  Parallel Diagnostics Output

### DIFF
--- a/src/IO/Spherical_IO.F90
+++ b/src/IO/Spherical_IO.F90
@@ -917,10 +917,8 @@ Contains
 			    CALL Isend(probe_outputs,sirq,n_elements = nelem,dest = 0, &
                     tag=probe_tag, grp = pfi%rcomm, indstart = inds)            
                 CALL IWait(sirq)
-                If (allocated(probe_outputs)) DEALLOCATE(probe_outputs)
+                If (allocated(probe_outputs)) Deallocate(probe_outputs)
             ENDIF
-
-
 
 		Endif
 
@@ -932,13 +930,13 @@ Contains
 
         ! For the moment, every process in column 0 participates in the mpi file-open operation
  
-        if (my_row_rank .eq. 0) Call Point_Probes%OpenFile_Par(this_iter, error)
+        If (my_row_rank .eq. 0) Call Point_Probes%OpenFile_Par(this_iter, error)
 
         If ( (responsible .eq. 1) .and. (Point_Probes%file_open) ) Then   
             funit = Point_Probes%file_unit
             If (Point_Probes%current_rec .eq. ncache) Then                
                 
-                If (Point_Probes%master) Then    !           
+                If ( (Point_Probes%master) .and. (Point_Probes%write_header) ) Then    !           
                     ! The master rank (whoever owns the first radius output) writes the header
                     dims(1) = probe_nr
                     dims(2) = probe_nt

--- a/src/IO/Spherical_IO.F90
+++ b/src/IO/Spherical_IO.F90
@@ -2287,51 +2287,53 @@ Contains
 
         ! For the moment, every process in column 0 participates in the mpi operation
         ! The plan is to tune this later so that 
-        if (my_row_rank .eq. 0) Call Shell_Slices%OpenFile_Par(this_iter, error)
+        If (my_row_rank .eq. 0) Call Shell_Slices%OpenFile_Par(this_iter, error)
 
-        If (responsible .eq. 1) Then   
-           funit = shell_slices%file_unit
-        If (Shell_Slices%current_rec .eq. 1) Then                
-            
-            If (shell_slices%master) Then            
-                ! The master rank (whoever owns the first output shell level) writes the header
-                dims(1) = ntheta
-                dims(2) = Shell_Slices%nlevels
-                dims(3) =  nq_shell
-                buffsize = 3
-                call MPI_FILE_WRITE(funit, dims, buffsize, MPI_INTEGER, & 
-                    mstatus, ierr) 
+        If ( (responsible .eq. 1) .and. (shell_slices%file_open) ) Then   
 
-                buffsize = nq_shell
-                call MPI_FILE_WRITE(funit,Shell_Slices%oqvals, buffsize, MPI_INTEGER, & 
-                    mstatus, ierr) 
+            funit = shell_slices%file_unit
 
-                allocate(out_radii(1:Shell_Slices%nlevels))
-                Do i = 1, Shell_Slices%nlevels
-                    out_radii(i) = radius(Shell_Slices%levels(i))
-                Enddo
-                buffsize = Shell_Slices%nlevels
-	            call MPI_FILE_WRITE(funit, out_radii, buffsize, MPI_DOUBLE_PRECISION, & 
-                    mstatus, ierr) 
-                DeAllocate(out_radii)
+            If (Shell_Slices%write_header) Then                
                 
+                If (Shell_Slices%master) Then            
+                    ! The master rank (whoever owns the first output shell level) writes the header
+                    dims(1) = ntheta
+                    dims(2) = Shell_Slices%nlevels
+                    dims(3) =  nq_shell
+                    buffsize = 3
+                    Call MPI_FILE_WRITE(funit, dims, buffsize, MPI_INTEGER, & 
+                        mstatus, ierr) 
 
-                allocate(level_inds(1:Shell_Slices%nlevels))
-                Do i = 1, Shell_Slices%nlevels
-                    level_inds(i) = Shell_Slices%levels(i)
-                Enddo
+                    buffsize = nq_shell
+                    Call MPI_FILE_WRITE(funit,Shell_Slices%oqvals, buffsize, MPI_INTEGER, & 
+                        mstatus, ierr) 
 
-	            call MPI_FILE_WRITE(funit, Shell_Slices%levels, buffsize, MPI_INTEGER, & 
-                    mstatus, ierr) 
-                DeAllocate(level_inds)
-                buffsize = ntheta
-	            call MPI_FILE_WRITE(funit, costheta, buffsize, MPI_DOUBLE_PRECISION, & 
-                    mstatus, ierr) 
+                    Allocate(out_radii(1:Shell_Slices%nlevels))
+                    Do i = 1, Shell_Slices%nlevels
+                        out_radii(i) = radius(Shell_Slices%levels(i))
+                    Enddo
+                    buffsize = Shell_Slices%nlevels
+	                Call MPI_FILE_WRITE(funit, out_radii, buffsize, MPI_DOUBLE_PRECISION, & 
+                        mstatus, ierr) 
+                    DeAllocate(out_radii)
+                    
 
+                    Allocate(level_inds(1:Shell_Slices%nlevels))
+                    Do i = 1, Shell_Slices%nlevels
+                        level_inds(i) = Shell_Slices%levels(i)
+                    Enddo
+
+	                Call MPI_FILE_WRITE(funit, Shell_Slices%levels, buffsize, MPI_INTEGER, & 
+                        mstatus, ierr) 
+                    DeAllocate(level_inds)
+                    buffsize = ntheta
+	                Call MPI_FILE_WRITE(funit, costheta, buffsize, MPI_DOUBLE_PRECISION, & 
+                        mstatus, ierr) 
+
+                Endif
             Endif
-        Endif
 
-            ! I might really (really) want to look into file views later.
+            ! Maybe look into file views later.
             ! Depending on the offset size mpi type, disp will crap out past 2GB
             hdisp = 24 ! dimensions+endian+version+record count
             hdisp = hdisp+nq_shell*4 ! nq
@@ -2344,7 +2346,6 @@ Contains
             
             buffsize = Shell_Slices%my_nlevels*ntheta*nphi
             ! The file is striped with time step slowest, followed by q
-
 
             rcount = 0
             Do p = 1, Shell_Slices%nshell_r_ids
@@ -2377,7 +2378,7 @@ Contains
 			DeAllocate(all_shell_slices)
         Endif  ! Responsible
 
-        If (my_row_rank .eq. 0) Call shell_slices%closefile_par()
+        If (my_row_rank .eq. 0) Call Shell_Slices%Closefile_Par()
 
 
 	End Subroutine Write_Shell_Slices
@@ -2404,13 +2405,13 @@ Contains
 		integer(kind=MPI_OFFSET_KIND) :: disp, hdisp, my_rdisp, new_disp, qdisp, full_disp
 		Integer :: mstatus(MPI_STATUS_SIZE)
         sizecheck = sizeof(disp)
-        if (sizecheck .lt. 8) Then
+        If (sizecheck .lt. 8) Then
             if (myid .eq. 0) Then
             Write(6,*)"Warning, MPI_OFFSET_KIND is less than 8 bytes on your system."
             Write(6,*)"Your size (in bytes) is: ", sizecheck
             Write(6,*)"A size of 4 bytes means that shell slices files are effectively limited to 2 GB in size."
             Endif
-        endif 
+        Endif 
         nq_shell = Shell_Slices%nq
         shell_slice_tag = Shell_Slices%mpi_tag
         
@@ -2438,7 +2439,7 @@ Contains
                 ! The file is striped with time step slowest, followed by q
                 rcount = 0
                 Do p = 1, Shell_Slices%nshell_r_ids
-                    if (Shell_Slices%shell_r_ids(p) .lt. my_column_rank) Then
+                    If (Shell_Slices%shell_r_ids(p) .lt. my_column_rank) Then
                         rcount = rcount+ Shell_Slices%nshells_at_rid(p)
                     Endif
                 Enddo
@@ -2456,37 +2457,37 @@ Contains
         funit = Shell_Slices%file_unit
         !////////////////////////////
         !Write a header
-        If (Shell_Slices%current_rec .eq. 1) Then                
+        If (Shell_Slices%file_open) Then                
             
-            If (shell_slices%master .and. (responsible .eq. 1)) Then            
+            If (shell_slices%master .and. shell_slices%write_header) Then            
                 ! The master rank (whoever owns the first output shell level) writes the header
                 dims(1) = ntheta
                 dims(2) = Shell_Slices%nlevels
                 dims(3) =  nq_shell
                 buffsize = 3
-                call MPI_FILE_WRITE(funit, dims, buffsize, MPI_INTEGER, & 
+                Call MPI_FILE_WRITE(funit, dims, buffsize, MPI_INTEGER, & 
                     mstatus, ierr) 
 
                 buffsize = nq_shell
-                call MPI_FILE_WRITE(funit,Shell_Slices%oqvals, buffsize, MPI_INTEGER, & 
+                Call MPI_FILE_WRITE(funit,Shell_Slices%oqvals, buffsize, MPI_INTEGER, & 
                     mstatus, ierr) 
 
-                allocate(out_radii(1:Shell_Slices%nlevels))
+                Allocate(out_radii(1:Shell_Slices%nlevels))
                 Do i = 1, Shell_Slices%nlevels
                     out_radii(i) = radius(Shell_Slices%levels(i))
                 Enddo
                 buffsize = Shell_Slices%nlevels
-	            call MPI_FILE_WRITE(funit, out_radii, buffsize, MPI_DOUBLE_PRECISION, & 
+	            Call MPI_FILE_WRITE(funit, out_radii, buffsize, MPI_DOUBLE_PRECISION, & 
                     mstatus, ierr) 
                 DeAllocate(out_radii)
                 
 
-                allocate(level_inds(1:Shell_Slices%nlevels))
+                Allocate(level_inds(1:Shell_Slices%nlevels))
                 Do i = 1, Shell_Slices%nlevels
                     level_inds(i) = Shell_Slices%levels(i)
                 Enddo
 
-	            call MPI_FILE_WRITE(funit, Shell_Slices%levels, buffsize, MPI_INTEGER, & 
+	            Call MPI_FILE_WRITE(funit, Shell_Slices%levels, buffsize, MPI_INTEGER, & 
                     mstatus, ierr) 
                 DeAllocate(level_inds)
                 buffsize = ntheta
@@ -2572,7 +2573,7 @@ Contains
 
             ! Communication is complete.  Write this q-value using MPI-IO
 
-            If (responsible .eq. 1) Then   
+            If ( (responsible .eq. 1) .and. (Shell_Slices%file_open) ) Then   
 
                 new_disp = disp+qdisp*(qindex-1)+my_rdisp                
                 Call MPI_File_Seek(funit,new_disp,MPI_SEEK_SET,ierr)
@@ -2588,18 +2589,23 @@ Contains
             DeAllocate(rirqs)
             disp = hdisp+full_disp*Shell_Slices%current_rec
             disp = disp-12
-            Call MPI_File_Seek(funit,disp,MPI_SEEK_SET,ierr)
 
+            If (Shell_Slices%file_open) Then
 
-            If (shell_slices%master) Then
-                buffsize = 1
-                Call MPI_FILE_WRITE(funit, simtime, buffsize, & 
-                       MPI_DOUBLE_PRECISION, mstatus, ierr)
-                Call MPI_FILE_WRITE(funit, this_iter, buffsize, & 
-                       MPI_INTEGER, mstatus, ierr)
+                Call MPI_File_Seek(funit,disp,MPI_SEEK_SET,ierr)
+
+                If (Shell_Slices%master) Then
+                    buffsize = 1
+                    Call MPI_FILE_WRITE(funit, simtime, buffsize, & 
+                           MPI_DOUBLE_PRECISION, mstatus, ierr)
+                    Call MPI_FILE_WRITE(funit, this_iter, buffsize, & 
+                           MPI_INTEGER, mstatus, ierr)
+                Endif
+
             Endif
+
         Endif
-        If (my_row_rank .eq. 0) Call shell_slices%closefile_par()
+        If (my_row_rank .eq. 0) Call Shell_Slices%CloseFile_Par()
         If (Shell_Slices%my_nlevels .gt. 0) Then
             DeAllocate(shell_slice_outputs)
             DeAllocate(buff)
@@ -3633,79 +3639,111 @@ Contains
         Integer :: buffsize, funit
         Integer :: mstatus(MPI_STATUS_SIZE)
         integer(kind=MPI_OFFSET_KIND) :: disp
+        Logical :: create_file
+        Logical :: file_exists
 
+        create_file = .false.
+        file_exists = .false.
 
+        self%file_open    = .false.
+        self%write_header = .false.
+
+        ! Determine which file # this data belongs to
         modcheck = self%frequency*self%rec_per_file
-
-
         icomp = iter - (self%cache_size-1)*self%frequency
-
-
         imod = Mod(icomp,modcheck) 
-
-        if (imod .eq. 0) then
+        If (imod .eq. 0) Then
             ibelong = iter
-        else
-            ibelong = icomp-imod+modcheck    ! This iteration belongs in a file with number= ibelong
-        endif
+        Else
+            ibelong = icomp-imod+modcheck    ! Data belongs to file #ibelong
+        Endif
 
-        write(iterstring,i_ofmt) ibelong
+        Write(iterstring,i_ofmt) ibelong
         filename = trim(local_file_path)//trim(self%file_prefix)//trim(iterstring)
 
+        If ( (imod .eq. self%frequency) .or. (self%rec_per_file .eq. 1) ) Then   
+            ! Time to begin a new file 
+            create_file = .true.
+        Else
+            ! We are either:
+            ! (a)  Appending to an existing file or
+            ! (b)  The user has changed the output cadence in between checkpoints.
+            !      In that case, we're "off-cycle" and need to create the file.
 
-        If ( (imod .eq. self%frequency) .or. (self%rec_per_file .eq. 1) ) Then   ! time to begin a new file 
+            ! This sort of filesystem inquiry should be done by only one rank
+            ! (If self%master ... )
+            Inquire(File=filename, Exist=file_exists)
+            If (.not. file_exists) create_file = .true.
 
-            
+        Endif
 
+        If (create_file) Then
+
+            If (self%master) Call stdout%print(' Creating Filename: '//trim(filename))
     	    Call MPI_FILE_OPEN(self%ocomm, filename, & 
                  MPI_MODE_WRONLY + MPI_MODE_CREATE, & 
                  MPI_INFO_NULL, funit, ierr) 
+
             self%file_unit = funit
-            If (self%master) Then     
-                Write(6,*)'Creating Filename: ', filename      
-                buffsize = 1
-                call MPI_FILE_WRITE(self%file_unit, endian_tag, buffsize, MPI_INTEGER, & 
-                    mstatus, ierr)
+            self%write_header = .true.            
 
-                buffsize = 1
-                call MPI_FILE_WRITE(self%file_unit, self%Output_Version, buffsize, MPI_INTEGER, & 
-                    mstatus, ierr)
-                buffsize = 1
-                call MPI_FILE_WRITE(self%file_unit, integer_zero, buffsize, MPI_INTEGER, & 
-                    mstatus, ierr) ! We write zero initially - only update nrec after the data is actually written
-            Endif
-
-            
-            self%current_rec = 1+self%cc
-            
-                       
-            If (ierr .ne. 0) Then
-                next_iter =file_iter+modcheck
-                if (self%master) Write(6,*)'Unable to create file!!: ',filename
-            Endif
         Else
-    		call MPI_FILE_OPEN(self%ocomm, filename, & 
+
+    		Call MPI_FILE_OPEN(self%ocomm, filename, & 
                  MPI_MODE_RDWR, & 
                  MPI_INFO_NULL, funit, ierr) 
+
             self%file_unit = funit
+            self%write_header = .false.
 
-            !Read the previous record number / advance record
-            disp = 8
-            Call MPI_File_Seek(self%file_unit,disp,MPI_SEEK_SET,ierr)
-            Call MPI_FILE_READ(self%file_unit, self%current_rec, 1, MPI_INTEGER, & 
-                & mstatus, ierr)
-
-            self%current_rec = self%current_rec+1+self%cc
-
-            If (ierr .ne. 0) Then
-                next_iter =file_iter+modcheck
-                if (self%master) Then
-                Write(6,*)'Failed to find needed file: ', filename
-                Write(6,*)'Partial diagnostic files are not currently supported.'
-                Write(6,*)'No data will be written until a new file is created at iteration: ', ibelong+self%frequency
-                Endif
-            Endif
         Endif
+
+        If (ierr .eq. 0) Then
+            self%file_open = .true.
+        Else
+            Call stdout%print(' Unable to open file: '//trim(filename))
+        Endif
+
+
+        If (self%file_open) Then
+
+            If (self%write_header) Then
+
+                If (self%master) Then     
+
+                    Write(6,*)'Creating Filename: ', filename      
+                    buffsize = 1
+                    Call MPI_FILE_WRITE(self%file_unit, endian_tag, buffsize, &
+                        & MPI_INTEGER, mstatus, ierr)
+
+                    buffsize = 1
+                    Call MPI_FILE_WRITE(self%file_unit, self%Output_Version, & 
+                        buffsize, MPI_INTEGER, mstatus, ierr)
+
+                    ! We write zero initially --
+                    ! update nrec only after the data is actually written.
+                    buffsize = 1
+                    Call MPI_FILE_WRITE(self%file_unit, integer_zero, &
+                        & buffsize, MPI_INTEGER, mstatus, ierr) 
+                Endif
+                
+                self%current_rec = 1+self%cc
+
+            Else
+
+                !Read the previous record number / advance record
+                disp = 8
+                Call MPI_File_Seek(self%file_unit,disp,MPI_SEEK_SET,ierr)
+                Call MPI_FILE_READ(self%file_unit, self%current_rec, 1, &
+                    & MPI_INTEGER, mstatus, ierr)
+
+                self%current_rec = self%current_rec+1+self%cc
+
+
+            Endif
+
+        Endif
+
     End Subroutine OpenFile_Par
 
 

--- a/src/IO/Spherical_IO.F90
+++ b/src/IO/Spherical_IO.F90
@@ -934,7 +934,7 @@ Contains
  
         if (my_row_rank .eq. 0) Call Point_Probes%OpenFile_Par(this_iter, error)
 
-        If (responsible .eq. 1) Then   
+        If ( (responsible .eq. 1) .and. (Point_Probes%file_open) ) Then   
             funit = Point_Probes%file_unit
             If (Point_Probes%current_rec .eq. ncache) Then                
                 
@@ -946,26 +946,26 @@ Contains
                     dims(4) = nq
 
                     buffsize = 4
-                    CALL MPI_FILE_WRITE(funit, dims, buffsize, MPI_INTEGER, & 
+                    Call MPI_FILE_WRITE(funit, dims, buffsize, MPI_INTEGER, & 
                         mstatus, ierr) 
 
                     buffsize = nq
-                    CALL MPI_FILE_WRITE(funit,Point_Probes%oqvals, buffsize, MPI_INTEGER, & 
+                    Call MPI_FILE_WRITE(funit,Point_Probes%oqvals, buffsize, MPI_INTEGER, & 
                         mstatus, ierr) 
 
                     ! Radial grid -----------------------------------
                     nvals = max(probe_nr,probe_nt)
                     nvals = max(nvals,probe_np)
-                    ALLOCATE(probe_vals(1:nvals))
+                    Allocate(probe_vals(1:nvals))
                     probe_vals(:) = 0
                     Do i = 1, probe_nr
                         probe_vals(i) = radius(Point_Probes%probe_r_global(i))                       
                     Enddo
                     buffsize = probe_nr
 
-                    call MPI_FILE_WRITE(funit, probe_vals, buffsize, MPI_DOUBLE_PRECISION, & 
+                    Call MPI_FILE_WRITE(funit, probe_vals, buffsize, MPI_DOUBLE_PRECISION, & 
                         mstatus, ierr) 
-                    call MPI_FILE_WRITE(funit, Point_Probes%probe_r_global, buffsize, MPI_INTEGER, & 
+                    Call MPI_FILE_WRITE(funit, Point_Probes%probe_r_global, buffsize, MPI_INTEGER, & 
                         mstatus, ierr) 
 
 
@@ -1048,9 +1048,10 @@ Contains
 
                 disp = disp+full_disp 
             Enddo
-			DeAllocate(row_probes)
+
         Endif  ! Responsible
 
+        If (responsible .eq. 1) DeAllocate(row_probes)
         If (my_row_rank .eq. 0) Call Point_Probes%closefile_par()
 
 	End Subroutine Write_Point_Probes

--- a/src/IO/Spherical_IO.F90
+++ b/src/IO/Spherical_IO.F90
@@ -529,7 +529,6 @@ Contains
         fdir = 'Spherical_3D/'
         Call Full_3D%set_file_info(full3d_version,shellslice_nrec,full3d_frequency,fdir)    
 
-        !Write(6,*)'Shell F: ', Shell_Slices%frequency
    End Subroutine Initialize_Spherical_IO
 
     Subroutine Get_Meridional_Slice(qty)
@@ -3710,9 +3709,12 @@ Contains
             !      In that case, we're "off-cycle" and need to create the file.
 
             ! This sort of filesystem inquiry should be done by only one rank
-            ! (If self%master ... )
-            Inquire(File=filename, Exist=file_exists)
-            If (.not. file_exists) create_file = .true.
+            If (self%orank .eq. 0) Then
+                Inquire(File=filename, Exist=file_exists)
+                If (.not. file_exists) create_file = .true.
+            Endif
+
+            Call MPI_Bcast(create_file, 1, MPI_LOGICAL, 0, self%ocomm, ierr)
 
         Endif
 
@@ -3750,7 +3752,7 @@ Contains
 
                 If (self%master) Then     
 
-                    Write(6,*)'Creating Filename: ', filename      
+
                     buffsize = 1
                     Call MPI_FILE_WRITE(self%file_unit, endian_tag, buffsize, &
                         & MPI_INTEGER, mstatus, ierr)
@@ -3784,9 +3786,6 @@ Contains
         Endif
 
     End Subroutine OpenFile_Par
-
-
-
 
     Subroutine CloseFile(self)
         Implicit None


### PR DESCRIPTION
This commit provides a revised version of OpenFile_Par that works correctly with partial output files.   Diagnostic outputs that use openfile_par have been adjusted to make use of obj%file_open and obj%create_header.  They have been verified to function properly with partial records upon restart.
-Nick