### PR TITLE
Makefile now removes installed exectuables using proper directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,6 +62,6 @@ distclean:
 	rm -f $(BUILD)/Makefile
 	rm -f $(BUILD)/Machine_Definitions
 	rm -f $(BUILD)/machine.no_comments
-	@rm -f $(PREFIX)/rayleigh.*
+	@rm -f $(PREFIX)/bin/rayleigh.*
 	@rm -f make.inc
 	@echo "#Following configure, this file contains the definition of the PREFIX variable" >> make.inc


### PR DESCRIPTION
After running "make" and "make install" the rayleigh.* executables are copied to the $PREFIX/bin/ directory, but when running "make distclean" the makefile was removing executables in the $PREFIX/ directory. This does not delete the intended files and could potentially delete files that were meant to be saved. Now the makefile deletes only what it is supposed to.