### PR TITLE
Add cleanWs to post build step

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -57,4 +57,6 @@ pipeline {
       }
     }
   }
+
+  post { always { cleanWs() } }
 }


### PR DESCRIPTION
This tells Jenkins to clean up files created by the build.