### PR TITLE
Critical Bug Fixes:  Ref-advection and L-conservation

### DIFF
--- a/src/Diagnostics/Diagnostics_Angular_Momentum.F90
+++ b/src/Diagnostics/Diagnostics_Angular_Momentum.F90
@@ -34,11 +34,28 @@ Contains
         Implicit None
         Real*8, Intent(InOut) :: buffer(1:,my_r%min:,my_theta%min:,1:)
 
+        Call Compute_Angular_Momentum(buffer)
         Call Compute_Angular_Momentum_Sources(buffer)
         Call Compute_Angular_Momentum_Fluxes(buffer)
 
     End Subroutine Compute_Angular_Momentum_Balance
 
+    Subroutine Compute_Angular_Momentum(buffer)
+        Implicit None
+        Real*8, Intent(InOut) :: buffer(1:,my_r%min:,my_theta%min:,1:)
+        Integer :: r,k, t
+
+        If (compute_quantity(amom_z)) Then
+
+            DO_PSI
+                qty(PSI) = ref%density(r)*radius(r)*sintheta(t) &
+                    & *buffer(PSI,vphi)
+            END_DO
+
+            Call Add_Quantity(qty)
+        Endif
+
+    End Subroutine Compute_Angular_Momentum
 
     Subroutine Compute_Angular_Momentum_Sources(buffer)
         Implicit None

--- a/src/Diagnostics/amom_equation_codes.F
+++ b/src/Diagnostics/amom_equation_codes.F
@@ -57,4 +57,5 @@
     Integer, Parameter :: famom_magtor_r     = amoff+17 !:tex:  $-r\mathrm{sin}\theta c_4\,\overline{B_r}\,\overline{B_\phi}$
     Integer, Parameter :: famom_magtor_theta = amoff+18 ! :tex:  $-r\mathrm{sin}\theta c_4\,\overline{B_\theta}\,\overline{B_\phi}$
 
-
+    ! Angular momentum (z)
+    Integer, Parameter :: amom_z = amoff+19 ! :tex:  $\mathrm{f}_1r\mathrm{sin}\theta v_\phi $

--- a/src/Physics/Sphere_Linear_Terms.F90
+++ b/src/Physics/Sphere_Linear_Terms.F90
@@ -137,6 +137,10 @@ Contains
                 ! T equation
                 Call Initialize_Equation_Coefficients(teq,tvar, 2,lp)
 
+                If (advect_reference_state) Then
+                    Call Initialize_Equation_Coefficients(teq,wvar, 0,lp)
+                Endif
+
                 ! Z equation
                 Call Initialize_Equation_Coefficients(zeq,zvar, 2,lp)
 

--- a/src/Physics/Sphere_Linear_Terms.F90
+++ b/src/Physics/Sphere_Linear_Terms.F90
@@ -40,27 +40,25 @@ Contains
         Integer :: n, r
         !Depending on process layout, some ranks may not participate in the solve
         If (my_num_lm .gt. 0) Then
+
             Call Initialize_Linear_System()
 
             If (strict_L_conservation) Then
+
                 Allocate(Lconservation_weights(1:N_R))
                 Lconservation_weights(1:N_R) = 0.0d0
-                If (chebyshev) Then
-                    amp = Pi / (N_R*1.0d0)
-                    do n = 1, N_R
-                        do r = 1, N_R
-                            arg = (n-1.d0) * (r-1.d0+0.5d0) * amp
-                            T = Cos(arg)
-                            Lconservation_weights(n) = Lconservation_weights(n) + radial_integral_weights(r) * T
-                        enddo
-                    enddo
-                    Lconservation_weights(1) = Lconservation_weights(1)*0.5d0
-                    Lconservation_weights(N_R) = Lconservation_weights(N_r)*0.5d0
-                    Lconservation_weights( (2*N_R)/3+1: ) = 0.0d0  ! De-Alias here for now
-                Else
-                    Lconservation_weights(1:N_R) = radial_integral_weights(1:N_R)
-                Endif
+
+                Do n = 1, N_R
+                    Do r = 1, N_R
+                        T = gridcp%dcheby(1)%data(r,n,0)
+                        Lconservation_weights(n) = Lconservation_weights(n) + radial_integral_weights(r) * T
+                    Enddo
+                Enddo
+
+                Lconservation_weights( (2*N_R)/3+1: ) = 0.0d0  ! De-Alias
+
             Endif
+
         Endif
 
     End Subroutine Linear_Init


### PR DESCRIPTION
This commit provides 2 important bug fixes:
1)  When advect_reference_state was set to True, the array necessary for holding the assocated W coefficients for the Tvar equation was not allocated.   Models previously run with this flag would crash (usually).  Sometimes, they would generate junk results due to memory being written OOB.

2) The strict_L_conservation flag has been fixed.   Over long-time integrations, particularly in models with magnetism and or stable regions, errors arising from the accuracy of the time-stepping scheme can accumulate, even when run with stress-free boundaries.  An integral constraint on the ell=1 toroidal streamfunction can fix this.    Effectiveness of the fix is demonstrated in the image below.  The blue line sits at 1e-2  and the green line sits at 1e11.  The integral constraint appears to be working to near machine precision.

[Angular Momentum Plot](https://drive.google.com/open?id=14KOipcpVALnWVhHKuYcYwgXtVHjR67CP)

