### PR TITLE
Added Lx and Ly quantity codes to Diagnostics_Angular_Momentum; and s…

### DIFF
--- a/src/Diagnostics/Diagnostics_Angular_Momentum.F90
+++ b/src/Diagnostics/Diagnostics_Angular_Momentum.F90
@@ -58,8 +58,9 @@ Contains
         If (compute_quantity(amom_x)) Then
 
             DO_PSI
-                qty(PSI) = ref%density(r)*radius(r)*(-costheta(t) &
-                    & *buffer(PSI,vphi) - sinphi(k)*buffer(PSI,vtheta))
+                qty(PSI) = ref%density(r)*radius(r)*&
+                    & (-costheta(t)*cosphi(k)*buffer(PSI,vphi) -&
+                   & sinphi(k)*buffer(PSI,vtheta))
             END_DO
 
             Call Add_Quantity(qty)
@@ -68,8 +69,9 @@ Contains
         If (compute_quantity(amom_y)) Then
 
             DO_PSI
-                qty(PSI) = ref%density(r)*radius(r)*(-costheta(t) &
-                    & *buffer(PSI,vphi) + cosphi(k)*buffer(PSI,vtheta))
+                qty(PSI) = ref%density(r)*radius(r)*&
+                    (-costheta(t)*sinphi(k)*buffer(PSI,vphi) +&
+                   &cosphi(k)*buffer(PSI,vtheta))
             END_DO
 
             Call Add_Quantity(qty)
@@ -88,8 +90,9 @@ Contains
         If (compute_quantity(amomp_x)) Then
 
             DO_PSI
-                qty(PSI) = ref%density(r)*radius(r)*(-costheta(t) &
-                    & *fbuffer(PSI,vphi) - sinphi(k)*fbuffer(PSI,vtheta))
+                qty(PSI) = ref%density(r)*radius(r)*&
+                    &(-costheta(t)*cosphi(k)*fbuffer(PSI,vphi) -&
+                   &sinphi(k)*fbuffer(PSI,vtheta))
             END_DO
 
             Call Add_Quantity(qty)
@@ -98,8 +101,9 @@ Contains
         If (compute_quantity(amomp_y)) Then
 
             DO_PSI
-                qty(PSI) = ref%density(r)*radius(r)*(-costheta(t) &
-                    & *fbuffer(PSI,vphi) + cosphi(k)*fbuffer(PSI,vtheta))
+                qty(PSI) = ref%density(r)*radius(r)*&
+                    &(-costheta(t)*sinphi(k)*fbuffer(PSI,vphi) +&
+                   &cosphi(k)*fbuffer(PSI,vtheta))
             END_DO
 
             Call Add_Quantity(qty)
@@ -118,8 +122,9 @@ Contains
         If (compute_quantity(amomm_x)) Then
 
             DO_PSI
-                qty(PSI) = ref%density(r)*radius(r)*(-costheta(t) &
-                    & *m0_values(PSI2,vphi) - sinphi(k)*m0_values(PSI2,vtheta))
+                qty(PSI) = ref%density(r)*radius(r)*&
+                    &(-costheta(t)*cosphi(k)*m0_values(PSI2,vphi) -&
+                   &sinphi(k)*m0_values(PSI2,vtheta))
             END_DO
 
             Call Add_Quantity(qty)
@@ -128,8 +133,9 @@ Contains
         If (compute_quantity(amomm_y)) Then
 
             DO_PSI
-                qty(PSI) = ref%density(r)*radius(r)*(-costheta(t) &
-                    & *m0_values(PSI2,vphi) + cosphi(k)*m0_values(PSI2,vtheta))
+                qty(PSI) = ref%density(r)*radius(r)*&
+                    &(-costheta(t)*sinphi(k)*m0_values(PSI2,vphi) +&
+                   &cosphi(k)*m0_values(PSI2,vtheta))
             END_DO
 
             Call Add_Quantity(qty)

--- a/src/Diagnostics/Diagnostics_Angular_Momentum.F90
+++ b/src/Diagnostics/Diagnostics_Angular_Momentum.F90
@@ -55,6 +55,85 @@ Contains
             Call Add_Quantity(qty)
         Endif
 
+        If (compute_quantity(amom_x)) Then
+
+            DO_PSI
+                qty(PSI) = ref%density(r)*radius(r)*(-costheta(t) &
+                    & *buffer(PSI,vphi) - sinphi(k)*buffer(PSI,vtheta))
+            END_DO
+
+            Call Add_Quantity(qty)
+        Endif
+
+        If (compute_quantity(amom_y)) Then
+
+            DO_PSI
+                qty(PSI) = ref%density(r)*radius(r)*(-costheta(t) &
+                    & *buffer(PSI,vphi) + cosphi(k)*buffer(PSI,vtheta))
+            END_DO
+
+            Call Add_Quantity(qty)
+        Endif
+
+        If (compute_quantity(amomp_z)) Then
+
+            DO_PSI
+                qty(PSI) = ref%density(r)*radius(r)*sintheta(t) &
+                    & *fbuffer(PSI,vphi)
+            END_DO
+
+            Call Add_Quantity(qty)
+        Endif
+
+        If (compute_quantity(amomp_x)) Then
+
+            DO_PSI
+                qty(PSI) = ref%density(r)*radius(r)*(-costheta(t) &
+                    & *fbuffer(PSI,vphi) - sinphi(k)*fbuffer(PSI,vtheta))
+            END_DO
+
+            Call Add_Quantity(qty)
+        Endif
+
+        If (compute_quantity(amomp_y)) Then
+
+            DO_PSI
+                qty(PSI) = ref%density(r)*radius(r)*(-costheta(t) &
+                    & *fbuffer(PSI,vphi) + cosphi(k)*fbuffer(PSI,vtheta))
+            END_DO
+
+            Call Add_Quantity(qty)
+        Endif
+
+        If (compute_quantity(amomm_z)) Then
+
+            DO_PSI
+                qty(PSI) = ref%density(r)*radius(r)*sintheta(t) &
+                    & *m0_values(PSI2,vphi)
+            END_DO
+
+            Call Add_Quantity(qty)
+        Endif
+
+        If (compute_quantity(amomm_x)) Then
+
+            DO_PSI
+                qty(PSI) = ref%density(r)*radius(r)*(-costheta(t) &
+                    & *m0_values(PSI2,vphi) - sinphi(k)*m0_values(PSI2,vtheta))
+            END_DO
+
+            Call Add_Quantity(qty)
+        Endif
+
+        If (compute_quantity(amomm_y)) Then
+
+            DO_PSI
+                qty(PSI) = ref%density(r)*radius(r)*(-costheta(t) &
+                    & *m0_values(PSI2,vphi) + cosphi(k)*m0_values(PSI2,vtheta))
+            END_DO
+
+            Call Add_Quantity(qty)
+        Endif
     End Subroutine Compute_Angular_Momentum
 
     Subroutine Compute_Angular_Momentum_Sources(buffer)

--- a/src/Diagnostics/amom_equation_codes.F
+++ b/src/Diagnostics/amom_equation_codes.F
@@ -57,5 +57,19 @@
     Integer, Parameter :: famom_magtor_r     = amoff+17 !:tex:  $-r\mathrm{sin}\theta c_4\,\overline{B_r}\,\overline{B_\phi}$
     Integer, Parameter :: famom_magtor_theta = amoff+18 ! :tex:  $-r\mathrm{sin}\theta c_4\,\overline{B_\theta}\,\overline{B_\phi}$
 
-    ! Angular momentum (z)
+    ! Angular momentum 
+    ! Full
     Integer, Parameter :: amom_z = amoff+19 ! :tex:  $\mathrm{f}_1r\mathrm{sin}\theta v_\phi $
+    Integer, Parameter :: amom_x = amoff+20 ! :tex:  $\mathrm{f}_1r(-\mathrm{sin}\theta v_\phi - \mathrm{cos}\phi v_\theta)$
+    Integer, Parameter :: amom_y = amoff+21 ! :tex:  $\mathrm{f}_1r(-\mathrm{cos}\theta v_\phi + \mathrm{cos}\phi v_\theta)$
+
+    ! Fluctuating
+    Integer, Parameter :: amomp_z = amoff+22 ! :tex:  $\mathrm{f}_1r\mathrm{sin}\theta v_\phi' $
+    Integer, Parameter :: amomp_x = amoff+23 ! :tex:  $\mathrm{f}_1r(-\mathrm{sin}\theta v_\phi' - \mathrm{cos}\phi v_\theta')$
+    Integer, Parameter :: amomp_y = amoff+24 ! :tex:  $\mathrm{f}_1r(-\mathrm{cos}\theta v_\phi' + \mathrm{cos}\phi v_\theta')$
+
+    ! Mean
+    Integer, Parameter :: amomm_z = amoff+25 ! :tex:  $\mathrm{f}_1r\mathrm{sin}\theta \overline{v_\phi} $
+    Integer, Parameter :: amomm_x = amoff+26 ! :tex:  $\mathrm{f}_1r(-\mathrm{sin}\theta \overline{v_\phi} - \mathrm{cos}\phi \overline{v_\theta'}$
+    Integer, Parameter :: amomm_y = amoff+27 ! :tex:  $\mathrm{f}_1r(-\mathrm{cos}\theta\overline{v_\phi} + \mathrm{cos}\phi \overline{v_\theta})$
+

--- a/src/Physics/ProblemSize.F90
+++ b/src/Physics/ProblemSize.F90
@@ -314,9 +314,11 @@ Contains
 	! The range of 0 to just below 2*pi (increasing) agrees with the Meridional
 	! and Equatorial Slices
         delta_phi = two_pi/n_phi
-        phivals = (/(k*delta_phi, k=0,n_phi-1)/)
-        cosphi = cos(phivals)
-        sinphi = sin(phivals)
+        Do k = 1, n_phi
+            phivals(k) = (k-1)*delta_phi
+            cosphi(k) = cos(phivals(k))
+            sinphi(k) = sin(phivals(k))
+        Enddo
 
         Allocate(l_l_plus1(0:l_max))
         Allocate(over_l_l_plus1(0:l_max))

--- a/src/Physics/ProblemSize.F90
+++ b/src/Physics/ProblemSize.F90
@@ -47,8 +47,10 @@ Module ProblemSize
     Integer, Allocatable :: m_values(:)
     Real*8, Allocatable  :: l_l_plus1(:), over_l_l_plus1(:)
     Real*8, Allocatable  :: costheta(:), sintheta(:), cos2theta(:), sin2theta(:), cottheta(:), csctheta(:)
+    Real*8, Allocatable  :: phivals(:), cosphi(:), sinphi(:)
+    Real*8               :: delta_phi
+    Integer              :: k
     Type(Load_Config)    :: my_mp,  my_theta
-
 
     !//////////////////////////////////////////////////////////////
     !  Radial Grid Variables
@@ -301,12 +303,20 @@ Contains
         Allocate(costheta(1:n_theta),cos2theta(1:n_theta))
         Allocate(sintheta(1:n_theta),sin2theta(1:n_theta))
         Allocate(csctheta(1:n_theta), cottheta(1:n_theta))
+        Allocate(phivals(1:n_phi), cosphi(1:n_phi), sinphi(1:n_phi))
         costheta  = coloc    ! coloc computed in init_legendre
         cos2theta = costheta*costheta
         sin2theta = 1-cos2theta
         sintheta  = sqrt(sin2theta)
         csctheta = 1/sintheta
         cottheta = costheta/sintheta
+        ! Calculate spacing of equally distributed phi points, then the phi grid
+	! The range of 0 to just below 2*pi (increasing) agrees with the Meridional
+	! and Equatorial Slices
+        delta_phi = two_pi/n_phi
+        phivals = (/(k*delta_phi, k=0,n_phi-1)/)
+        cosphi = cos(phivals)
+        sinphi = sin(phivals)
 
         Allocate(l_l_plus1(0:l_max))
         Allocate(over_l_l_plus1(0:l_max))


### PR DESCRIPTION
…eparate quantity codes for L due to the convection (m>0) and mean flows (m=0). Also modified Problem_Size to produce the arrays phivals, cosphi, and sinphi.

More notes for this pull request: when the spherical-shell convection community has talked about "angular momentum leaks," we are usually concerned with L_z. However, we should probably also be concerned with L_x and L_y! Also, it may be helpful to see where the possible leakage is entering the system--either into the mean flows or the convection. I've thus added 8 new quantities to Diagnostics_Angular_Momentum. Nick added amom_z, and I have added amom_x, amom_y, and the corresponding codes for amomp (fluctuating flows) and amomm (mean flows). 

Here's to hoping they all stay zero!