### PR TITLE
Added directory python_util, enclosing routine write_reference write …

### DIFF
--- a/python_util/write_reference.py
+++ b/python_util/write_reference.py
@@ -1,0 +1,63 @@
+#
+#  Copyright (C) 2018 by the authors of the RAYLEIGH code.
+#
+#  This file is part of RAYLEIGH.
+#
+#  RAYLEIGH is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 3, or (at your option)
+#  any later version.
+#
+#  RAYLEIGH is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with RAYLEIGH; see the file LICENSE.  If not see
+#  <http://www.gnu.org/licenses/>.
+#
+
+# The routine write_reference in this module takes a filename and
+# writes radial profiles of the reference state in binary form
+# to that filename, such that Rayleigh can interpret that binary file
+# specified through 
+#
+# reference_type=4 
+# custom_reference_file = [filename]
+#
+# ...in the Reference_Namelist of main_input.
+
+import numpy as np
+
+def write_reference(filename, radius, rho, dlnrho, d2lnrho, pressure,\
+        temperature, dlnT, dsdr, entropy, gravity):
+
+    # first write the
+    # two int32 binary numbers (unformatted): 314 and n_r. Then write
+    # 10*n_r float64 numbers, representing (in order):
+    # radius, density, dlnrho, d2lnrho, pressure, 
+    # temperature dlnT, dsdr, entropy, gravity
+    # n_r here should be >> n_r from Rayleigh so that
+    # Rayleigh can interpolate your possibly fine-structured 
+    # reference state onto its grid
+    # the radius array may be linearly spaced; Rayleigh will interpolate
+
+    f = open(filename, "wb")
+    # may need to specify the data type for a successful read on
+    # Rayleigh's end
+    sigpi = np.array(314, dtype=np.int32)
+    nr = np.array(len(radius), dtype=np.int32)
+    f.write(sigpi.tobytes())
+    f.write(nr.tobytes())
+    f.write(radius.tobytes())
+    f.write(rho.tobytes())
+    f.write(dlnrho.tobytes())
+    f.write(d2lnrho.tobytes())
+    f.write(pressure.tobytes())
+    f.write(temperature.tobytes())
+    f.write(dlnT.tobytes())
+    f.write(dsdr.tobytes())
+    f.write(entropy.tobytes())
+    f.write(gravity.tobytes())
+    f.close()

--- a/src/Physics/TransportCoefficients.F90
+++ b/src/Physics/TransportCoefficients.F90
@@ -116,11 +116,6 @@ Contains
             kappa_top = ref%script_K_top
         Endif
 
-        If (reference_type .eq. 4) Then
-            nu_top = rayleigh_constants(5)*rayleigh_functions(1,3)
-            kappa_top = rayleigh_constants(6)*rayleigh_functions(1,5)
-        Endif
-
         Call Initialize_Nu()    ! Viscosity
         Call Initialize_Kappa() ! Thermal Diffusivity
 
@@ -133,7 +128,6 @@ Contains
 
         If (magnetism) Then
             If (.not. Dimensional_Reference) eta_top   = ref%script_H_top
-            If (reference_type .eq. 4) eta_top = rayleigh_constants(7)*rayleigh_functions(1,7)
             Call Initialize_Eta()    ! Magnetic Diffusivity
             If (ohmic_heating) Then
                 Allocate(ohmic_heating_coeff(1:N_R))
@@ -243,11 +237,6 @@ Contains
                 dlnu(:) = 0.0d0
             Case(2)
                 Call vary_with_density(nu,dlnu,nu_top, nu_power)
-            Case(3)
-                !Call get_custom_profile(nu,dlnu,custom_nu_file)
-                nu(:) = rayleigh_constants(5)*rayleigh_functions(:,3)
-                dlnu(:) = rayleigh_functions(:,11)
-                nu_top = nu(1)
 
         End Select
     End Subroutine Initialize_Nu
@@ -259,11 +248,6 @@ Contains
                 dlnkappa(:) = 0.0d0
             Case(2)
                 Call vary_with_density(kappa,dlnkappa,kappa_top, kappa_power)
-            Case(3)
-                !Call get_custom_profile(kappa,dlnkappa,custom_kappa_file)
-                kappa(:) = rayleigh_constants(5)*rayleigh_functions(:,5)
-                dlnkappa(:) = rayleigh_functions(:,12)
-                kappa_top = kappa(1)
         End Select
     End Subroutine Initialize_Kappa
 
@@ -276,24 +260,6 @@ Contains
                 dlneta(:) = 0.0d0
             Case(2)
                 Call vary_with_density(eta,dlneta,eta_top, eta_power)
-            Case(3)
-
-                !Call get_custom_profile(eta,dlneta,custom_eta_file)
-                !eta(:) = eta(:)*eta_top !this assume profile is 1 at the top
-
-                eta(:) = rayleigh_constants(7)*rayleigh_functions(:,7)
-                dlneta(:) = rayleigh_functions(:,13)
-                eta_top = eta(1)
-
-                If (my_rank .eq. 0) then
-                    Allocate(tmp_arr(1:N_R,1:3))
-                    tmp_arr(:,1) = radius(:)
-                    tmp_arr(:,2) = eta(:)
-                    tmp_arr(:,3) = dlneta(:)
-                    Call Write_Profile(tmp_arr,eta_file)
-                    DeAllocate(tmp_arr)
-                Endif
-
         End Select
     End Subroutine Initialize_Eta
 


### PR DESCRIPTION
…custom reference profiles in binary such that Rayleigh likes reading them; Modified Custom_Reference to properly read in custom reference profiles, and removed the rayleigh_functions/rayleigh_constants framework from both ReferenceState and TransportCoefficients

MORE NOTES: Originally it looked like the Custom_Reference routine was geared toward reading variables into the arrays rayleigh_functions and rayleigh_constants, but this wasn't explicitly done in the code. Also TransportCoefficients disagreed on the dimensions for rayleigh_functions, since it expected the reference profiles AND the transport profiles to be there, while ReferenceState only allocated for the reference profiles. 

I have things set up now so that Custom_Reference properly reads in the reference state (not the transport coefficients) from the file "custom_reference_file" (specified in the Reference_Namelist of main_input) and interpolates and/or reverses the grid in this file, so that users can supply reference states on a linearly spaced, super-fine grid (I have been using nr_ref = 5000, and increasing radius) and Rayleigh will interpolate. 

I propose that if we also desire capability to read in custom transport coefficients, this is done in a separate routine Custom_Transport in TransportCoefficients, and specified in the Transport_Namelist of main_input. 

Finally, I created a Python routine write_reference so that users can easily convert the custom reference states they generate into a binary form that Rayleigh can understand. It didn't seem to belong in "post_processing" so I created a new directory "python_utils," which I am envisioning will eventually more Python routines that aren't associated with post-processing (e.g., Chebyshev derivatives/integrals, interpolation schemes, etc.) Happy to modify if this new directory is undesirable. 