### PR TITLE
turbke_offset is now referenced properly to meq_offset.

### DIFF
--- a/src/Diagnostics/turbKE_codes.F
+++ b/src/Diagnostics/turbKE_codes.F
@@ -1,7 +1,7 @@
     !//////////////////////////////////////////////////////////////////////////
     !///////////////////////////////////////////////////
     !       Turbulent KE Outputs
-    Integer, Parameter :: turbke_offset = custom_offset+500
+    Integer, Parameter :: turbke_offset = meq_off+700 ! :OFFSET CODE:
 
     Integer, Parameter :: production_buoyant_pKE   = turbke_offset + 1  ! :tex: $\mathrm{f}_2{\Theta^\prime}{v^\prime}_r$
     Integer, Parameter :: production_shear2_pKE    = turbke_offset + 2  ! :tex: $-\mathrm{f}_1{v^\prime_i}{v^\prime_j}\overline{e}_{ij}$


### PR DESCRIPTION
This adjustment references the turbulent kinetic energy codes to the magnetic energy codes.  Between these two code sets is the custom diagnostic block.  This was causing issues in the auto generation of quantity code tables (anything after the custom code block would fail to compile).