### PR TITLE
Fix parallel test error

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,8 +2,8 @@
 
 pipeline {
   agent {
-    docker {
-      image 'geodynamics/rayleigh-buildenv-bionic:latest'
+    dockerfile {
+      dir 'docker/rayleigh-buildenv-bionic'
     }
   }
 
@@ -42,8 +42,6 @@ pipeline {
         sh '''
           sed \
             --in-place \
-            -e 's/nprow = 2/nprow = 1/' \
-            -e 's/npcol = 2/npcol = 1/' \
             -e 's/max_iterations = 40000/max_iterations = 400/' \
             main_input
         '''
@@ -51,8 +49,7 @@ pipeline {
         sh '''
           # This export avoids a warning about
           # a discovered, but unconnected infiniband network.
-          export OMPI_MCA_btl=self,tcp
-          ./bin/rayleigh.dbg
+          mpirun -np 4 ./bin/rayleigh.dbg
         '''
       }
     }

--- a/docker/rayleigh-buildenv-bionic/Dockerfile
+++ b/docker/rayleigh-buildenv-bionic/Dockerfile
@@ -10,7 +10,7 @@ RUN apt update && \
     libblas-dev \
     libfftw3-dev \
     liblapack-dev \
-    libopenmpi-dev \
+    libmpich-dev \
     make \
     nano \
     wget


### PR DESCRIPTION
It looks like the problems we had with using OpenMPI inside the docker container that we use for testing do not occur with MPICH (at least locally when I run the container on my laptop). I would like to see if that is also the case on the jenkins server. If this works then we can start running some more test models for every pull request.

Please do not merge this until I have verified that it is ready.