### PR TITLE
Add an automatic test for the documentation

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,6 +12,19 @@ pipeline {
   }
 
   stages {
+    stage('Build documentation') {
+      options {
+        timeout(time: 15, unit: 'MINUTES')
+      }
+      steps {
+        sh '''
+          cd doc
+          make html
+          make latexpdf
+        '''
+      }
+    }
+
     stage('Build') {
       options {
         timeout(time: 15, unit: 'MINUTES')

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -27,7 +27,7 @@ author = 'Nick Featherstone'
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = [
+extensions = ['sphinx.ext.mathjax',
 ]
 
 master_doc = 'index'

--- a/docker/rayleigh-buildenv-bionic/Dockerfile
+++ b/docker/rayleigh-buildenv-bionic/Dockerfile
@@ -13,7 +13,15 @@ RUN apt update && \
     libmpich-dev \
     make \
     nano \
-    wget
+    wget \
+    sphinx-common \
+    texlive-base \
+    texlive-generic-extra \
+    texlive-latex-base \
+    texlive-latex-recommended \
+    texlive-latex-extra \
+    lmodern \
+    latexmk
 
 # Export compilers
 ENV CC mpicc


### PR DESCRIPTION
This is a first simple way to test that no PR breaks the Sphinx build. While readthedocs would show us a broken build after its broken, this should prevent us from merging documentation that does not compile. It does not prevent documentation that formats incorrectly, and it also does not automatically update the documentation.