### PR TITLE
Fix a sphinx warning

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -51,7 +51,7 @@ html_theme = 'alabaster'
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+html_static_path = []
 
 latex_elements = {
 # The paper size ('letterpaper' or 'a4paper').


### PR DESCRIPTION
This removes a warning during building the sphinx documentation. We currently have no static files for the html documentation and no directory `_static`.