### PR TITLE
Clear output from Jupyter notebooks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,11 @@ clean:
 	@$(MAKE) --no-print-directory --directory=$(BUILD) clean_exec
 	@$(MAKE) --no-print-directory --directory=$(BUILD) clean
 
+IPYNB = $(shell find . -iname '*.ipynb')
+
+clear_ipynb: $(IPYNB)
+	nbstripout $^
+
 .PHONY: install
 install:
 	@echo "Installing executables into: " $(PREFIX)"/bin"

--- a/etc/check_ipynb_cleared
+++ b/etc/check_ipynb_cleared
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+ERR=0
+IPYNB="$(find . -iname '*.ipynb')"
+for x in ${IPYNB}
+do
+        if ! nbstripout < "$x" | diff -q - "$x" > /dev/null
+        then
+                echo "$x" still contains output
+                ERR=1
+        fi
+done
+
+return $ERR

--- a/etc/check_ipynb_cleared
+++ b/etc/check_ipynb_cleared
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 ERR=0
-IPYNB="$(find . -iname '*.ipynb')"
+IPYNB="$(git ls-files|grep '\.ipynb$')"
 for x in ${IPYNB}
 do
         if ! nbstripout < "$x" | diff -q - "$x" > /dev/null


### PR DESCRIPTION
This adds a script to check that output is cleared from Jupyter notebooks. There is also a make target to clear the output in all notebooks.

Ideally, we would include the check in the test suite, possible with a whitelist of notebooks that we store with output.