### PR TITLE
Prevent a warning about python2 code

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -56,7 +56,7 @@ html_static_path = []
 latex_elements = {
 # The paper size ('letterpaper' or 'a4paper').
 'papersize': 'letterpaper',
-'babel': '\usepackage[english]{babel}',
+'babel': '\\usepackage[english]{babel}',
 
 # The font size ('10pt', '11pt' or '12pt').
 'pointsize': '11pt',


### PR DESCRIPTION
This fixes a warning about python2 code for sphinx. Not sure why, but tested to work on 2 different systems.