### PR TITLE
Add a Publications List to the documentation

### DIFF
--- a/doc/source/User_Guide/index.rst
+++ b/doc/source/User_Guide/index.rst
@@ -15,3 +15,4 @@ Rayliegh User Manual
    diagnostics
    io_redirection
    ensemble_mode
+   publications

--- a/doc/source/User_Guide/overview.rst
+++ b/doc/source/User_Guide/overview.rst
@@ -2,7 +2,7 @@
 
    \clearpage
 
-.. _sec:installation:
+.. _sec:Overview:
 
 Overview
 ==========
@@ -45,15 +45,14 @@ Please cite the code as:
 
 .. code-block::
 
-  @Software{nicholas_featherstone_2018_1158290,
-  author = "Featherstone, N.",
-  title="Rayleigh Version 0.9.0",
-  year="2018",
-  organization="Computational Infrastructure for Geodynamics",
-  address="Davis, CA",
-  optkeywords="Rayleigh",
-  doi="http://doi.org/10.5281/zenodo.1158290",
-  opturl="https://doi.org/10.5281/zenodo.1158290"}
+  @Software{nicholas_featherstone_2018_1236565,
+	author = "Featherstone, N.",
+	title="Rayleigh 0.9.1",
+	year="2018",
+	organization="",
+	optkeywords="Rayleigh",
+	doi="http://doi.org/10.5281/zenodo.1236565",
+	opturl="https://doi.org/10.5281/zenodo.1236565"}
 
 Please also cite the following reference:
 

--- a/doc/source/User_Guide/publications.bib
+++ b/doc/source/User_Guide/publications.bib
@@ -1,0 +1,66 @@
+%
+% CAUTION!!!
+% Entries will appear in the order the are entered in this file.
+%
+% Add software citation below
+%
+@misc{nicholas_featherstone_2018_1158290,
+   author = "Featherstone, N.",
+   title="Rayleigh Version 0.9.0",
+   year="2018",
+   organization="Computational Infrastructure for Geodynamics",
+   address="Davis, CA",
+   optkeywords="Rayleigh",
+   doi="http://doi.org/10.5281/zenodo.1158290",
+   opturl="https://doi.org/10.5281/zenodo.1158290"
+}
+
+@misc{nicholas_featherstone_2018_1236565,
+  	author = "Featherstone, N.",
+  	title="Rayleigh 0.9.1",
+  	year="2018",
+  	organization="",
+  	optkeywords="Rayleigh",
+  	doi="http://doi.org/10.5281/zenodo.1236565",
+  	opturl="https://doi.org/10.5281/zenodo.1236565"
+}
+
+%
+% ADD PUBLICATIONS BELOW
+%
+% 2019
+%
+% 2018
+%
+% 2017
+%
+% 2016
+%
+
+@Article{Featherstone_Hindmam_2016,
+    author = "Featherstone, N.A. and Hindman, B.W.",
+    title="The Spectral Amplitude Of Stellar Convection And Its Scaling In The High-Rayleigh-Number Regime",
+    year="2016",
+    journal="The Astrophysical Journal",
+    volume="818",
+    number="1",
+    pages="32",
+    optkeywords="Rayleigh",
+    issn="1538-4357",
+    doi="http://doi.org/10.3847/0004-637X/818/1/32",
+    opturl="http://stacks.iop.org/0004-637X/818/i=1/a=32?key=crossref.a90f82507dd0eeb7a6e7562d1e4b0210"
+}
+
+@Article{Matsui_etal_2016,
+	 author = "Matsui, H. and Heien, E. and Aubert, J. and Aurnou, J.M. and Avery, M. and Brown, B. and Buffett, B.A. and Busse, F. and Christensen, U.R. and Davies, C.J. and Featherstone, N. and Gastine, T. and Glatzmaier, G.A. and Gubbins, D. and Guermond, J.-L. and Hayashi, Y.-Y. and Hollerbach, R. and Hwang, L.J. and Jackson, A. and Jones, C.A. and Jiang, W. and Kellogg, L.H. and Kuang, W. and Landeau, M. and Marti, P.H. and Olson, P. and Ribeiro, A. and Sasaki, Y. and Schaeffer, N. and Simitev, R.D. and Sheyko, A. and Silva, L. and Stanley, S. and Takahashi, F. and Takehiro, S.-ichi and Wicht, J. and Willis, A.P.",
+	  title="Performance benchmarks for a next generation numerical dynamo model",
+	 year="2016",
+	 journal="Geochemistry, Geophysics, Geosystems",
+	 volume="17",
+	 number="5",
+	 pages="1586-1607",
+	 optkeywords="Calypso",
+	 issn="1525-2027",
+	 doi="http://doi.org/10.1002/2015GC006159",
+	 opturl="http://doi.wiley.com/10.1002/2015GC006159"
+}

--- a/doc/source/User_Guide/publications.rst
+++ b/doc/source/User_Guide/publications.rst
@@ -1,0 +1,39 @@
+.. raw:: latex
+
+
+   \clearpage
+
+
+Publications
+============
+
+A list of publications using the Rayleigh code.
+
+Software Citation
+-----------------
+:cite:`nicholas_featherstone_2018_1158290`
+:cite:`nicholas_featherstone_2018_1236565`
+
+Publications by Year
+--------------------
+2019
+^^^^
+  none .... yet
+
+2018
+^^^^
+  blank
+
+2017
+^^^^
+  blank
+
+2016
+^^^^
+:cite:`Featherstone_Hindmam_2016`
+:cite:`Matsui_etal_2016`
+
+All Publications (unsorted)
+---------------------------
+
+.. bibliography:: publications.bib

--- a/doc/source/User_Guide/publications.rst
+++ b/doc/source/User_Guide/publications.rst
@@ -11,18 +11,27 @@ A list of publications using the Rayleigh code.
 
 Software Citation
 -----------------
-:cite:`nicholas_featherstone_2018_1158290`
-:cite:`nicholas_featherstone_2018_1236565`
+
+**List:** :cite:`nicholas_featherstone_2018_1236565`, :cite:`nicholas_featherstone_2018_1158290`
+
+
+.. bibliography:: software.bib
 
 Publications by Year
 --------------------
 2019
 ^^^^
-  none .... yet
+**List:** :cite:`Buffett+Matsui2019`
+
+.. bibliography:: publications2019.bib
 
 2018
 ^^^^
-  blank
+**List:**
+:cite:`Karak_etal2018`, :cite:`Miquel_etal2018`, :cite:`Orvedahl_etal2018`
+
+
+.. bibliography:: publications2018.bib
 
 2017
 ^^^^
@@ -30,10 +39,7 @@ Publications by Year
 
 2016
 ^^^^
-:cite:`Featherstone_Hindmam_2016`
-:cite:`Matsui_etal_2016`
+**List:** :cite:`Featherstone_Hindmam_2016`, :cite:`Matsui_etal_2016`, :cite:`OMara_etal2016`
 
-All Publications (unsorted)
----------------------------
 
-.. bibliography:: publications.bib
+.. bibliography:: publications2016.bib

--- a/doc/source/User_Guide/publications2016.bib
+++ b/doc/source/User_Guide/publications2016.bib
@@ -2,40 +2,23 @@
 % CAUTION!!!
 % Entries will appear in the order the are entered in this file.
 %
-% Add software citation below
+% Add Publications for 2016 ONLY
 %
-@misc{nicholas_featherstone_2018_1158290,
-   author = "Featherstone, N.",
-   title="Rayleigh Version 0.9.0",
-   year="2018",
-   organization="Computational Infrastructure for Geodynamics",
-   address="Davis, CA",
-   optkeywords="Rayleigh",
-   doi="http://doi.org/10.5281/zenodo.1158290",
-   opturl="https://doi.org/10.5281/zenodo.1158290"
+@Article{Featherstone+Hindman2016,
+  author="Featherstone, N. A.
+  and Hindman, B. W.",
+  title="The Emergence Of Solar Supergranulation As A Natural Consequence Of Rotationally Constrained Interior Convection",
+  journal="The Astrophysical Journal",
+  year="2016",
+  volume="830",
+  number="1",
+  pages="L15",
+  optkeywords="Rayleigh",
+  optnote="exported from refbase (https://geodynamics.org/cig/refbase/show.php?record=1442), last updated on Mon, 10 Apr 2017 11:05:43 -0700",
+  issn="2041-8213",
+  doi="10.3847/2041-8205/830/1/L15",
+  opturl="http://stacks.iop.org/2041-8205/830/i=1/a=L15?key=crossref.b9fcd6b0ca6169fe7d0be8513d56f369"
 }
-
-@misc{nicholas_featherstone_2018_1236565,
-  	author = "Featherstone, N.",
-  	title="Rayleigh 0.9.1",
-  	year="2018",
-  	organization="",
-  	optkeywords="Rayleigh",
-  	doi="http://doi.org/10.5281/zenodo.1236565",
-  	opturl="https://doi.org/10.5281/zenodo.1236565"
-}
-
-%
-% ADD PUBLICATIONS BELOW
-%
-% 2019
-%
-% 2018
-%
-% 2017
-%
-% 2016
-%
 
 @Article{Featherstone_Hindmam_2016,
     author = "Featherstone, N.A. and Hindman, B.W.",
@@ -63,4 +46,19 @@
 	 issn="1525-2027",
 	 doi="http://doi.org/10.1002/2015GC006159",
 	 opturl="http://doi.wiley.com/10.1002/2015GC006159"
+}
+
+@Article{OMara_etal2016,
+  author="O'Mara, B.
+  and Miesch, M. S.
+  and Featherstone, N. A.
+  and Augustson, K. C.",
+  title="Velocity amplitudes in global convection simulations: The role of the Prandtl number and near-surface driving",
+  journal="Advances in Space Research",
+  year="2016",
+  optkeywords="Rayleigh",
+  optnote="exported from refbase (https://geodynamics.org/cig/refbase/show.php?record=1121), last updated on Thu, 21 Apr 2016 10:52:02 -0700",
+  issn="0273-1177",
+  doi="10.1016/j.asr.2016.03.038",
+opturl="http://linkinghub.elsevier.com/retrieve/pii/S0273117716300953"
 }

--- a/doc/source/User_Guide/publications2018.bib
+++ b/doc/source/User_Guide/publications2018.bib
@@ -1,0 +1,59 @@
+%
+% CAUTION!!!
+% Entries will appear in the order the are entered in this file.
+%
+% Add Publications for 2018 ONLY
+%
+
+@Article{Karak_etal2018,
+author="Karak, B. B.
+and Miesch, M.
+and Bekki, Y.",
+title="Consequences of high effective Prandtl number on solar differential rotation and convective velocity",
+journal="Physics of Fluids",
+year="2018",
+volume="30",
+number="4",
+pages="046602",
+optkeywords="Rayleigh",
+optnote="exported from refbase (https://geodynamics.org/cig/refbase/show.php?record=1614), last updated on Tue, 19 Jun 2018 19:49:37 -0700",
+issn="1070-6631",
+doi="10.1063/1.5022034",
+opturl="http://aip.scitation.org/doi/10.1063/1.5022034"
+}
+
+@Article{Miquel_etal2018,
+author="Miquel, B.
+and Xie, J-H
+and Featherstone, N.
+and Julien, K.
+and Knobloch, E.",
+title="Equatorially trapped convection in a rapidly rotating shallow shell",
+journal="Physical Review Fluids",
+year="2018",
+volume="3",
+number="5",
+optkeywords="Rayleigh",
+optnote="exported from refbase (https://geodynamics.org/cig/refbase/show.php?record=1616), last updated on Tue, 19 Jun 2018 19:51:40 -0700",
+issn="2469-990X",
+doi="10.1103/PhysRevFluids.3.053801",
+opturl="https://link.aps.org/doi/10.1103/PhysRevFluids.3.053801"
+}
+
+@Article{Orvedahl_etal2018,
+author="Orvedahl, R. J.
+and Calkins, M. A.
+and Featherstone, N. A.
+and Hindman, B. W.",
+title="Prandtl-number Effects in High-Rayleigh-number Spherical Convection",
+journal="The Astrophysical Journal",
+year="2018",
+volume="856",
+number="1",
+pages="13",
+optkeywords="Rayleigh",
+abstract="Convection is the predominant mechanism by which energy and angular momentum are transported in the outer portion of the Sun. The resulting overturning motions are also the primary energy source for the solar magnetic field. An accurate solar dynamo model therefore requires a complete description of the convective motions, but these motions remain poorly understood. Studying stellar convection numerically remains challenging; it occurs within a parameter regime that is extreme by computational standards. The fluid properties of the convection zone are characterized in part by the Prandtl number \#\#IMG\#\# [http://ej.iop.org/images/0004-637X/856/1/13/apjaaaeb5ieqn1.gif] \${\backslash}Pr \$ {\^A}~={\^A}~$\nu$ / $\kappa$ , where $\nu$ is the kinematic viscosity and $\kappa$ is the thermal diffusion; in stars, \#\#IMG\#\# [http://ej.iop.org/images/0004-637X/856/1/13/apjaaaeb5ieqn2.gif] \${\backslash}Pr \$ is extremely low, \#\#IMG\#\# [http://ej.iop.org/images/0004-637X/856/1/13/apjaaaeb5ieqn3.gif] \${\backslash}Pr \${\^A}~??{\^A}{\^A}{\^A}~10 -7 . The influence of \#\#IMG\#\# [http://ej.iop.org/images/0004-637X/856/1/13/apjaaaeb5ieqn4.gif] \${\backslash}Pr \$ on the convective motions at the heart of the dynamo is not well understood since most numerical studies are limited to using \#\#IMG\#\# [http://ej.iop.org/images/0004-637X/856/1/13/apjaaaeb5ieqn5.gif] \${\backslash}Pr \${\^A}~??{\^A}{\^A}{\^A}~1. We systematically vary \#\#IMG\#\# [http://ej.iop.org/images/0004-637X/856/1/13/apjaaaeb5ieqn6.gif] \${\backslash}Pr \$ and the degree of thermal forcing, characterized through a Rayleigh number, to explore its influence on the convective dynamics. For sufficiently large thermal driving, the simulations reach a so-called convective free-fall state where diffusion no longer plays an important role in the interior dynamics. Simulations with a lower \#\#IMG\#\# [http://ej.iop.org/images/0004-637X/856/1/13/apjaaaeb5ieqn7.gif] \${\backslash}Pr \$ generate faster convective flows and broader ranges of scales for equivalent levels of thermal forcing. Characteristics of the spectral distribution of the velocity remain largely insensitive to changes in \#\#IMG\#\# [http://ej.iop.org/images/0004-637X/856/1/13/apjaaaeb5ieqn8.gif] \${\backslash}Pr \$ . Importantly, we find that \#\#IMG\#\# [http://ej.iop.org/images/0004-637X/856/1/13/apjaaaeb5ieqn9.gif] \${\backslash}Pr \$ plays a key role in determining when the free-fall regime is reached by controlling the thickness of the thermal boundary layer.",
+optnote="exported from refbase (https://geodynamics.org/cig/refbase/show.php?record=1615), last updated on Wed, 27 Mar 2019 13:53:43 -0700",
+doi="10.3847/1538-4357/aaaeb5",
+opturl="http://stacks.iop.org/0004-637X/856/i=1/a=13"
+}

--- a/doc/source/User_Guide/publications2019.bib
+++ b/doc/source/User_Guide/publications2019.bib
@@ -1,0 +1,21 @@
+%
+% CAUTION!!!
+% Entries will appear in the order the are entered in this file.
+%
+% Add Publications for 2019 ONLY
+%
+@Article{Buffett+Matsui2019,
+author="Buffett, B.
+and Matsui, H.",
+title="Equatorially trapped waves in Earth{\textquoteright}s core",
+journal="Geophysical Journal International",
+year="2019",
+volume="218",
+number="2",
+pages="1210--1225",
+optkeywords="Rayleigh",
+optnote="exported from refbase (https://geodynamics.org/cig/refbase/show.php?record=1739), last updated on Thu, 20 Jun 2019 08:58:07 -0700",
+issn="0956-540X",
+doi="10.1093/gji/ggz233",
+opturl="https://academic.oup.com/gji/article/218/2/1210/5491334"
+}

--- a/doc/source/User_Guide/software.bib
+++ b/doc/source/User_Guide/software.bib
@@ -1,0 +1,27 @@
+%
+% CAUTION!!!
+% Entries will appear in the order the are entered in this file.
+%
+% Add software citation below
+%
+
+@misc{nicholas_featherstone_2018_1236565,
+  	author = "Featherstone, N.",
+  	title="Rayleigh 0.9.1",
+  	year="2018",
+  	organization="",
+  	optkeywords="Rayleigh",
+  	doi="http://doi.org/10.5281/zenodo.1236565",
+  	opturl="https://doi.org/10.5281/zenodo.1236565"
+}
+
+@misc{nicholas_featherstone_2018_1158290,
+   author = "Featherstone, N.",
+   title="Rayleigh Version 0.9.0",
+   year="2018",
+   organization="Computational Infrastructure for Geodynamics",
+   address="Davis, CA",
+   optkeywords="Rayleigh",
+   doi="http://doi.org/10.5281/zenodo.1158290",
+   opturl="https://doi.org/10.5281/zenodo.1158290"
+}

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -27,7 +27,7 @@ author = 'Nick Featherstone'
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = ['sphinx.ext.mathjax',
+extensions = ['sphinx.ext.mathjax', 'sphinxcontrib.bibtex'
 ]
 
 master_doc = 'index'

--- a/docker/rayleigh-buildenv-bionic/Dockerfile
+++ b/docker/rayleigh-buildenv-bionic/Dockerfile
@@ -21,7 +21,10 @@ RUN apt update && \
     texlive-latex-recommended \
     texlive-latex-extra \
     lmodern \
+    python3-pip \
     latexmk
+
+RUN pip3 install sphinxcontrib-bibtex
 
 # Export compilers
 ENV CC mpicc


### PR DESCRIPTION
Adds a  list of publications to the end of the documentation and fixes a few minor bugs. 

This appears to be a relatively new feature so some work arounds were implemented to have it render in a usable manner. Please note the following. New publications should be added to 2 files:

1.  publicationsYYYY.bib (or software.bib). Add publications to the appropriate .bib file. Publications will print in the order they appear in this file.
2. publications.rst. Add appropriate key under the correct year. 
    
Needs the the following extension installed:
    sphinxcontrib-bibtex

See documentation here: https://build-me-the-docs-please.readthedocs.io/en/latest/Using_Sphinx/UsingBibTeXCitationsInSphinx.html
