### PR TITLE
Add animations to pdf documentation

### DIFF
--- a/doc/source/vids.rst
+++ b/doc/source/vids.rst
@@ -5,9 +5,16 @@ Video Gallery
 
     <iframe width="560" height="315" src="https://www.youtube.com/embed/1KArtuLYUmY" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
+.. raw:: latex
+
+   \url{https://www.youtube.com/embed/1KArtuLYUmY}
 
 Another video  
 
 .. raw:: html
 
     <iframe width="560" height="315" src="https://www.youtube.com/embed/3iRggdo3i0I" frameborder="0" allow="accelerometer;  encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+
+.. raw:: latex
+
+   \url{https://www.youtube.com/embed/3iRggdo3i0I}


### PR DESCRIPTION
This adds an alternative link to the animations in the .pdf documentation. Not as fancy as the html version, but at least is shows a clickable link.