### PR TITLE
Automatically check python notebooks for output

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -17,6 +17,10 @@ pipeline {
         timeout(time: 15, unit: 'MINUTES')
       }
       steps {
+        // First make sure notebooks do not contain output
+        sh 'make clear_ipynb && git diff --exit-code --name-only'
+
+        // Now build the new documentation
         sh '''
           cd doc
           make html

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-include make.inc
+-include make.inc
 SRC=src
 BUILD=$(SRC)/build
 

--- a/docker/rayleigh-buildenv-bionic/Dockerfile
+++ b/docker/rayleigh-buildenv-bionic/Dockerfile
@@ -22,7 +22,6 @@ RUN apt update && \
     texlive-latex-recommended \
     texlive-latex-extra \
     lmodern \
-    python3-pip \
     latexmk
 
 RUN pip3 install sphinxcontrib-bibtex nbstripout

--- a/post_processing/Diagnostic_Plotting.ipynb
+++ b/post_processing/Diagnostic_Plotting.ipynb
@@ -328,9 +328,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Loop over all files and concatenate their data into a single array\n",
@@ -370,9 +368,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "#The indices associated with our various outputs are stored in a lookup table\n",
@@ -409,9 +405,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "sizetuple=(10,3)\n",
@@ -559,9 +553,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "nfiles = len(files)\n",
@@ -754,9 +746,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "\n",
@@ -804,9 +794,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "#Subtrace the ell=0 component from temperature at each radius\n",
@@ -879,9 +867,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "source": [
     "VII.  Simulation Slices \n",
     "============\n",
@@ -1307,9 +1293,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "source": [
     "VIII.  Spherical Harmonic Spectra\n",
     "===================\n",
@@ -1804,9 +1788,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": []
   }


### PR DESCRIPTION
This PR activates an additional check on the tester to automatically fail if one of the python notebooks in the repository contains output cells with output. This output can be large, is reproducible, and should therefore not be included in the repository.