### PR TITLE
Add readthedocs configuration file

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,19 @@
+# .readthedocs.yml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+  configuration: doc/source/conf.py
+
+# Optionally build your docs in additional formats such as PDF and ePub
+formats: all
+
+# Optionally set the version of Python and requirements required to build your docs
+python:
+  version: 3.7
+  install:
+    - requirements: doc/requirements.txt

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,0 +1,1 @@
+sphinxcontrib-bibtex


### PR DESCRIPTION
Our documentation now requires a certain sphinx extension that is not activated by default on readthedocs. This PR adds configuration files that ensure the correct extensions are installed by readthedocs before building the documentation.