### PR TITLE
Grid info

### DIFF
--- a/post_processing/rayleigh_diagnostics.py
+++ b/post_processing/rayleigh_diagnostics.py
@@ -350,6 +350,58 @@ class TransportCoeffs:
 
         fd.close()
 
+class GridInfo:
+    """Rayleigh Grid Structure
+    ----------------------------------
+    self.n_r        : number of radial points
+    self.n_theta    : number of latitudinal points
+    self.n_phi      : number of zonal points
+    self.radius     : radial coordinates
+    self.rweights   : radial integration weights
+    self.theta      : (co)latitudinal coordinates
+    self.costheta   : cos(theta)
+    self.sintheta   : sin(theta)
+    self.tweights   : latitudinal integration weights
+    self.phi        : zonal coordinates
+    self.dphi       : zonal integration weight(s) (all 2*PI/n_phi)
+    """
+
+    def __init__(self, filename='none', path='./'):
+        """filename  : The reference state file to read.
+           path      : The directory where the file is located \
+                   (if full path not in filename
+        """
+        if (filename == 'none'):
+            the_file = path + 'grid_info'
+        else:
+            the_file = path+filename
+        fd = open(the_file, 'rb')
+        # We read an integer to assess which endian the file was 
+        # written in...
+        bs = check_endian(fd, 314, 'int32')
+        nr = swapread(fd, dtype='int32', count=1, swap=bs)
+        ntheta = swapread(fd, dtype='int32', count=1, swap=bs)
+        nphi = swapread(fd, dtype='int32', count=1, swap=bs)
+        self.nr = nr
+        self.ntheta = ntheta
+        self.nphi = nphi
+        self.radius = swapread(fd, dtype='float64', count=nr, swap=bs)
+        self.rweights = swapread(fd, dtype='float64', count=nr, swap=bs)
+        self.theta = swapread(fd, dtype='float64', count=ntheta, swap=bs)
+        self.costheta = swapread(fd, dtype='float64', count=ntheta,\
+                swap=bs)
+        self.sintheta = swapread(fd, dtype='float64', count=ntheta,\
+                swap=bs)
+        self.tweights = swapread(fd, dtype='float64', count=ntheta,\
+                swap=bs)
+        self.phi = swapread(fd, dtype='float64', count=nphi,\
+                swap=bs)
+        self.dphi = swapread(fd, dtype='float64', count=1, swap=bs)
+        self.names = ['nr', 'ntheta', 'nphi', 'radius', 'rweights',\
+                'theta', 'costheta', 'sintheta', 'tweights', 'phi',\
+                'dphi']        
+
+        fd.close()
 class G_Avgs:
     """Rayleigh GlobalAverage Structure
     ----------------------------------

--- a/post_processing/rayleigh_diagnostics.py
+++ b/post_processing/rayleigh_diagnostics.py
@@ -165,7 +165,7 @@ class RayleighProfile:
 
     def __init__(self,filename='none'):
         """filename  : The reference state file to read.
-           path      : The directory where the file is located (if full path not in filename
+           path      : The directory where the file is located (if full path not in filename)
         """
         if (filename != 'none'):
             
@@ -201,7 +201,7 @@ class RayleighArray:
 
     def __init__(self,filename ='none'):
         """filename  : The reference state file to read.
-           path      : The directory where the file is located (if full path not in filename
+           path      : The directory where the file is located (if full path not in filename)
         """
 
         if (filename == 'none'):
@@ -257,7 +257,7 @@ class ReferenceState:
 
     def __init__(self,filename='none',path='./'):
         """filename  : The reference state file to read.
-           path      : The directory where the file is located (if full path not in filename
+           path      : The directory where the file is located (if full path not in filename)
         """
         if (filename == 'none'):
             the_file = path+'reference'
@@ -315,7 +315,7 @@ class TransportCoeffs:
 
     def __init__(self,filename='none',path='./'):
         """filename  : The reference state file to read.
-           path      : The directory where the file is located (if full path not in filename
+           path      : The directory where the file is located (if full path not in filename)
         """
         if (filename == 'none'):
             the_file = path+'transport'
@@ -357,19 +357,22 @@ class GridInfo:
     self.n_theta    : number of latitudinal points
     self.n_phi      : number of zonal points
     self.radius     : radial coordinates
-    self.rweights   : radial integration weights
+    self.rweights   : radial integration weights: to average over radius with weighting r^2,
+    	i.e. sum(f(radius(i))*rweights(i)) = 
+    			int_(rmin)^(rmax) f(r) r^2 dr / ((1/3)(rmax^3 - rmin^3))
     self.theta      : (co)latitudinal coordinates
     self.costheta   : cos(theta)
     self.sintheta   : sin(theta)
-    self.tweights   : latitudinal integration weights
+    self.tweights   : latitudinal integration weights: to average over colatitude with 
+    	weighting sin(theta), i.e. sum(f(theta(i))*tweights(i)) = 
+    	int_0^pi f(theta) sin(theta) dtheta / 2   														
     self.phi        : zonal coordinates
-    self.dphi       : zonal integration weight(s) (all 2*PI/n_phi)
+    self.pweights   : zonal integration weight(s) (all 1/n_phi, since uniform grid)
     """
 
     def __init__(self, filename='none', path='./'):
         """filename  : The reference state file to read.
-           path      : The directory where the file is located \
-                   (if full path not in filename
+           path      : The directory where the file is located (if full path not in filename)
         """
         if (filename == 'none'):
             the_file = path + 'grid_info'
@@ -396,12 +399,13 @@ class GridInfo:
                 swap=bs)
         self.phi = swapread(fd, dtype='float64', count=nphi,\
                 swap=bs)
-        self.dphi = swapread(fd, dtype='float64', count=1, swap=bs)
+        self.pweights = swapread(fd, dtype='float64', count=nphi, swap=bs)
         self.names = ['nr', 'ntheta', 'nphi', 'radius', 'rweights',\
                 'theta', 'costheta', 'sintheta', 'tweights', 'phi',\
                 'dphi']        
 
         fd.close()
+        
 class G_Avgs:
     """Rayleigh GlobalAverage Structure
     ----------------------------------
@@ -417,7 +421,7 @@ class G_Avgs:
 
     def __init__(self,filename='none',path='G_Avgs/'):
         """filename  : The reference state file to read.
-           path      : The directory where the file is located (if full path not in filename
+           path      : The directory where the file is located (if full path not in filename)
         """
         if (filename == 'none'):
             the_file = path+'00000001'
@@ -468,7 +472,7 @@ class Shell_Avgs:
     """
     def __init__(self,filename='none',path='Shell_Avgs/',ntheta=0):
         """filename  : The reference state file to read.
-           path      : The directory where the file is located (if full path not in filename
+           path      : The directory where the file is located (if full path not in filename)
         """
         if (filename == 'none'):
             the_file = path+'00000001'
@@ -545,7 +549,7 @@ class AZ_Avgs:
 
     def __init__(self,filename='none',path='AZ_Avgs/'):
         """filename  : The reference state file to read.
-           path      : The directory where the file is located (if full path not in filename
+           path      : The directory where the file is located (if full path not in filename)
         """
         if (filename == 'none'):
             the_file = path+'00000001'
@@ -608,7 +612,7 @@ class Point_Probes:
 
     def __init__(self,filename='none',path='Point_Probes/'):
         """filename  : The reference state file to read.
-           path      : The directory where the file is located (if full path not in filename
+           path      : The directory where the file is located (if full path not in filename)
         """
         if (filename == 'none'):
             the_file = path+'00000001'
@@ -708,7 +712,7 @@ class Meridional_Slices:
 
     def __init__(self,filename='none',path='Meridional_Slices/'):
         """filename  : The reference state file to read.
-           path      : The directory where the file is located (if full path not in filename
+           path      : The directory where the file is located (if full path not in filename)
         """
         if (filename == 'none'):
             the_file = path+'00000001'
@@ -781,7 +785,7 @@ class Equatorial_Slices:
 
     def __init__(self,filename='none',path='Equatorial_Slices/'):
         """filename  : The reference state file to read.
-           path      : The directory where the file is located (if full path not in filename
+           path      : The directory where the file is located (if full path not in filename)
         """
         if (filename == 'none'):
             the_file = path+'00000001'
@@ -869,7 +873,7 @@ class Shell_Slices:
 
     def __init__(self,filename='none',path='Shell_Slices/',slice_spec = [], rec0 = False):
         """filename   : The reference state file to read.
-           path       : The directory where the file is located (if full path not in filename
+           path       : The directory where the file is located (if full path not in filename)
            slice_spec : Optional list of [time index, quantity code, radial index].  If 
                         specified, only a single shell is read.  time indexing and radial 
                         indexing start at 0
@@ -1040,7 +1044,7 @@ class SPH_Modes:
     def __init__(self,filename='none',path='SPH_Modes/'):
         """
            filename  : The reference state file to read.
-           path      : The directory where the file is located (if full path not in filename
+           path      : The directory where the file is located (if full path not in filename)
         """
         if (filename == 'none'):
             the_file = path+'00000001'
@@ -1166,7 +1170,7 @@ class Shell_Spectra:
     def __init__(self,filename='none',path='Shell_Spectra/'):
         """
            filename  : The reference state file to read.
-           path      : The directory where the file is located (if full path not in filename
+           path      : The directory where the file is located (if full path not in filename)
         """
         if (filename == 'none'):
             the_file = path+'00000001'

--- a/src/Diagnostics/Diagnostics_Interface.F90
+++ b/src/Diagnostics/Diagnostics_Interface.F90
@@ -271,8 +271,9 @@ Contains
 
     Subroutine Initialize_Diagnostics()
         Implicit None
-        Integer :: i, isize
+        Integer :: i, isize, n_phi, sig=314
         Real*8 :: delr
+        Character*120 :: grid_file
 
         Allocate(tweights(1:n_theta))
         tweights(:) = gl_weights(:)/2.0d0
@@ -295,6 +296,30 @@ Contains
 
             rweights = rweights/sum(rweights)
 
+        Endif
+
+        If (my_rank .eq. 0) Then
+            grid_file = Trim(my_path)//'grid_info'
+            Open(unit=15, file=grid_file, form='unformatted',&
+               &status='replace', access='stream')
+            Write(15) sig
+            Write(15) n_r
+            Write(15) n_theta 
+            n_phi = 2*n_theta
+            Write(15) n_phi
+            Write(15) (radius(i), i=1, n_r)
+            Write(15) (rweights(i), i=1, n_r)
+            ! renormalize rweights to sum to shell_depth
+            Write(15) (acos(costheta(i)), i=1, n_theta)
+            Write(15) (costheta(i), i=1, n_theta)
+            Write(15) (sintheta(i), i=1, n_theta)
+            Write(15) (tweights(i), i=1, n_theta)
+            ! renormalize tweights to sum to 2. (integral of sin(theta)
+            ! from theta=0 to theta=pi
+            ! Write out the phi grid for completeness
+            Write(15) ((i-1)*two_pi/n_phi - pi, i=1, n_phi)
+            Write(15) (two_pi/n_phi)
+            Close(15)
         Endif
 
         Call Initialize_Spherical_IO(radius,sintheta,rweights,tweights,costheta,my_path)

--- a/src/Diagnostics/Diagnostics_Interface.F90
+++ b/src/Diagnostics/Diagnostics_Interface.F90
@@ -271,7 +271,7 @@ Contains
 
     Subroutine Initialize_Diagnostics()
         Implicit None
-        Integer :: i, isize, n_phi, sig=314
+        Integer :: i, isize, n_phi, sig_pi = 314
         Real*8 :: delr
         Character*120 :: grid_file
 
@@ -302,7 +302,7 @@ Contains
             grid_file = Trim(my_path)//'grid_info'
             Open(unit=15, file=grid_file, form='unformatted',&
                &status='replace', access='stream')
-            Write(15) sig
+            Write(15) sig_pi
             Write(15) n_r
             Write(15) n_theta 
             n_phi = 2*n_theta
@@ -317,8 +317,8 @@ Contains
             ! renormalize tweights to sum to 2. (integral of sin(theta)
             ! from theta=0 to theta=pi
             ! Write out the phi grid for completeness
-            Write(15) ((i-1)*two_pi/n_phi - pi, i=1, n_phi)
-            Write(15) (two_pi/n_phi)
+            Write(15) ((i-1)*two_pi/n_phi, i=1, n_phi)
+            Write(15) (1.0d0/n_phi, i=1, n_phi)
             Close(15)
         Endif
 


### PR DESCRIPTION
@gassmoeller, sorry I did some bad things to my Github branch of grid_info, and so had to delete the branch and create it again. This seems to have removed the original pull request #120 , so I am making a new one. This version is based off the current master branch, so that should make things easier. 

I tried to address all your comments regarding #120 : 

regarding "sig," I renamed this "sig_pi" which appears elsewhere in the code for all output structures. This is just the digit 314 ("pi"), so that Python can tell the endianness of the binary file.

regarding the closing parentheses, these were missing from ALL the classes in rayleigh_diagnostics.py! I have put in all the missing parentheses

I made GridInfo class attribute dphi --> pweights, for consistency in notation. I also define pweights as a length n_phi array of the uniform values 1/n_phi. This is consistent with the r/theta integral weights, which are really averaging weights. I also made a note in the class definition what the radial/theta integral weights really are, since it is not immediately obvious. They are related to the radial/theta integrals, but not in 1-1 correspondence if, say, you want to integrate directly with respect to r or theta without taking a weighted average.

I added the missing space you noticed. 

I also noticed I had erroneously made the phi array begin at -pi instead of 0. I believe the way Rayleigh indices things (Equatorial_Slices, Meridional_Slices, Shell_Slices, etc.) the index 0 corresponds to phi = 0 and index n_phi - 1 corresponds to 2*pi*(n_phi - 1)/n_phi. 

Thanks for reviewing,

Loren