### PR TITLE
fix typo in title

### DIFF
--- a/doc/source/User_Guide/index.rst
+++ b/doc/source/User_Guide/index.rst
@@ -1,4 +1,4 @@
-Rayliegh User Manual
+Rayleigh User Manual
 =====================
 
 .. toctree::


### PR DESCRIPTION
This fixes a small but prominent error in the user manual.