### PR TITLE
Allow variadic arguments to dev_build.

### DIFF
--- a/dev_build
+++ b/dev_build
@@ -1,4 +1,4 @@
 make distclean
-./configure -devel
+./configure -devel "$@"
 make
 make install


### PR DESCRIPTION
Super simple change to allow the `dev_build` script to accept variable numbers of arguments to be passed to configure.  This is a wish list item of @feathern that I'm just disentangling from another branch I'm debugging.