### PR TITLE
Add a tester for convert_full3d_to_vtk.py.

### DIFF
--- a/docker/rayleigh-buildenv-bionic/Dockerfile
+++ b/docker/rayleigh-buildenv-bionic/Dockerfile
@@ -30,7 +30,9 @@ RUN apt update && \
     python-scipy \
     python3-scipy \
     python-funcsigs \
-    python3-funcsigs
+    python3-funcsigs \
+    python-vtk6 \
+    python3-vtk7
 
 RUN pip3 install sphinxcontrib-bibtex nbstripout nbsphinx jupyter-client ipykernel
 

--- a/docker/rayleigh-buildenv-bionic/Dockerfile
+++ b/docker/rayleigh-buildenv-bionic/Dockerfile
@@ -14,6 +14,7 @@ RUN apt update && \
     make \
     nano \
     wget \
+    python-pip \
     python3-pip \
     sphinx-common \
     texlive-base \
@@ -26,15 +27,11 @@ RUN apt update && \
     latexmk \
     pandoc \
     python-numpy \
-    python3-numpy \
     python-scipy \
-    python3-scipy \
-    python-funcsigs \
-    python3-funcsigs \
-    python-vtk6 \
-    python3-vtk7
+    python-funcsigs
 
 RUN pip3 install sphinxcontrib-bibtex nbstripout nbsphinx jupyter-client ipykernel
+RUN pip2 install vtk
 
 # Export compilers
 ENV CC mpicc

--- a/tests/generic_input/run_test.sh
+++ b/tests/generic_input/run_test.sh
@@ -6,6 +6,7 @@ cd tests/generic_input
 # for the Christensen et al., 2001 benchmark case 1
 cd base
 mpirun -np 4 ../../../bin/rayleigh.dbg
+../../../post_processing/convert_full3d_to_vtu.py
 cd ..
 
 # next we run the same thing but using generic input files to set the initial conditions
@@ -18,6 +19,7 @@ cd script
 PYTHONPATH=../../../pre_processing:$PYTHONPATH python generate_magnetic_input.py
 # finally we run Rayleigh
 mpirun -np 4 ../../../bin/rayleigh.dbg
+../../../post_processing/convert_full3d_to_vtu.py
 cd ..
 
 # after both versions have run, we test the output for errors

--- a/tests/generic_input/test_output.py
+++ b/tests/generic_input/test_output.py
@@ -3,7 +3,11 @@
 from rayleigh_diagnostics import Spherical_3D_multi
 import numpy as np
 import sys
+import vtk
 
+error = False
+
+# test using the raw data imported from the output files
 base = Spherical_3D_multi('00000001_0501', path='base/Spherical_3D/')
 script = Spherical_3D_multi('00000001_0501', path='script/Spherical_3D/')
 maxabsdiff = 0.0
@@ -11,8 +15,42 @@ for k in base.vals.keys():
   maxabsdiffk = np.abs(base.vals[k] - script.vals[k]).max() 
   print("Maximum difference ({}) = {}".format(k, maxabsdiffk,))
   maxabsdiff = max(maxabsdiff, maxabsdiffk)
+
 if maxabsdiff > 1.e-10:
   print("ERROR: [magnetic_]init_type 1 and [magnetic_]init_type 8 produced different initial conditions (within a tolerance of 1.e-10)!")
+  error = True
+
+# test using the data written to vtk by the convert script
+gridreader = vtk.vtkXMLUnstructuredGridReader()
+
+gridreader.SetFileName("base/Spherical_3D/full3d_00000001.vtu")
+gridreader.Update()
+ugradbase = gridreader.GetOutput()
+
+gridreader.SetFileName("script/Spherical_3D/full3d_00000001.vtu")
+gridreader.Update()
+ugridscript = gridreader.GetOutput()
+
+pdatabase = ugradbase.GetPointData()
+fnames = [pdatabase.GetArrayName(i) for i in range(pdatabase.GetNumberOfArrays())]
+
+pdatascript = ugridscript.GetPointData()
+
+maxabsdiff = 0.0
+for k in fnames:
+  sdatabase = pdatabase.GetScalars(k)
+  database = np.asarray([sdatabase.GetTuple1(i) for i in range(sdatabase.GetNumberOfTuples())])
+  sdatascript = pdatascript.GetScalars(k)
+  datascript = np.asarray([sdatascript.GetTuple1(i) for i in range(sdatascript.GetNumberOfTuples())])
+  maxabsdiffk = np.abs(database - datascript).max()
+  maxabsdiff = max(maxabsdiff, maxabsdiffk)
+  print("Maximum vtk difference ({}) = {}".format(k, maxabsdiffk,))
+
+if maxabsdiff > 1.e-10:
+  print("ERROR: [magnetic_]init_type 1 and [magnetic_]init_type 8 produced different initial vtks (within a tolerance of 1.e-10)!")
+  error = True
+
+if error:
   sys.exit(1)
 sys.exit(0)
 


### PR DESCRIPTION
This piggybacks on the generic_input test by converting the full 3d output to vtk and then testing the contents of the resulting files match.