### PR TITLE
add configure option to use mpif.h

### DIFF
--- a/configure
+++ b/configure
@@ -174,6 +174,12 @@ function displayhelp {
     echo "      <BLAS ROOT>/lib/libopenblas.a"
     echo ""
 
+    echo "  --mpi-f77 ; -mpi-f77:"
+    echo "      Set this flag to use mpif.h instead of the MPI F90 module."
+    echo "      This can be useful on systems where the current compiler does not"
+    echo "      match the one used to compile MPI."
+    echo ""
+
     echo "  --prefix=<RAYLEIGH PREFIX>: "
     echo "      Specifies the directory in which to place Rayleigh's executables"
     echo "      when "make install" is run.  By default, executables are placed in"
@@ -352,6 +358,10 @@ do
       USEOPENBLAS="TRUE";
       ;;
 
+    --mpi-f77 | -mpi-f77 )
+      USEMPIF77="TRUE";
+      ;;
+
     --with-lapack=*)
       LPROOT=`expr "x$option" : "x-*with-lapack=\(.*\)"`;
       ;;
@@ -435,6 +445,12 @@ else
 
   OPT_FLAGS=$(opt_flags $FVERSION)
   DBG_FLAGS=$(dbg_flags $FVERSION)
+
+  if [ "$USEMPIF77" == "TRUE" ]
+  then
+          OPT_FLAGS="$OPT_FLAGS -DUSE_MPI_F77_BINDINGS"
+          DBG_FLAGS="$DBG_FLAGS -DUSE_MPI_F77_BINDINGS"
+  fi
 
   if [ "$CUSTOMOPT" == "TRUE" ]
   then

--- a/src/Parallel_Framework/Ra_MPI_Base.F90
+++ b/src/Parallel_Framework/Ra_MPI_Base.F90
@@ -19,7 +19,11 @@
 !
 
 Module Ra_MPI_Base
+#ifdef USE_MPI_F77_BINDINGS
+    Include 'mpif.h'
+#else
     Use MPI
+#endif
 
     Type communicator
         Integer :: comm    ! The mpi handle for this group


### PR DESCRIPTION
Falling back to the F77 MPI bindings can help to compile the code on
systems where the current compiler does not match the one used to
compile MPI. This is not the default, of course.