### PR TITLE
improve debug builds

### DIFF
--- a/configure
+++ b/configure
@@ -49,7 +49,7 @@ function dbg_flags {
   fi
   if [[ $1 == "GNU" ]]
   then
-    echo '-O0 -fbounds-check -fbacktrace -ffixed-line-length-132 -DGNU_COMPILER'
+    echo '-O0 -g -fbounds-check -fbacktrace -ffixed-line-length-132 -DGNU_COMPILER'
   fi
 }
 

--- a/configure
+++ b/configure
@@ -49,7 +49,7 @@ function dbg_flags {
   fi
   if [[ $1 == "GNU" ]]
   then
-    echo '-O0 -g -fbounds-check -fbacktrace -ffixed-line-length-132 -DGNU_COMPILER'
+    echo '-O0 -g -fbounds-check -ffpe-trap=invalid,zero,overflow -fbacktrace -ffixed-line-length-132 -DGNU_COMPILER'
   fi
 }
 

--- a/dev_build
+++ b/dev_build
@@ -1,4 +1,4 @@
 make distclean
 ./configure -devel "$@"
-make
+make -j
 make install


### PR DESCRIPTION
This adds a few options to help track down the origin of NaNs. Is there any occasion where Rayleigh produces NaNs in regular operation? In that case we might want to switch off the floating-point exception traps.