### PR TITLE
Fix dependency file for tester

### DIFF
--- a/src/Makefile.fdeps
+++ b/src/Makefile.fdeps
@@ -58,6 +58,7 @@ ProblemSize.o : ProblemSize.F90 Timers.o BufferedOutput.o Math_Constants.o Cheby
 Ra_MPI_Base.o : Ra_MPI_Base.F90 
 ReferenceState.o : ReferenceState.F90 General_MPI.o Math_Utility.o Math_Constants.o Controls.o ProblemSize.o 
 Run_Param_Header.dbg.o : Run_Param_Header.dbg.F 
+Run_Param_Header.opt.o : Run_Param_Header.opt.F 
 Run_Parameters.o : Run_Parameters.F90 TransportCoefficients.o ReferenceState.o TestSuite.o Initial_Conditions.o BoundaryConditions.o Spherical_IO.o ProblemSize.o Parallel_Framework.o Controls.o 
 SendReceive.o : SendReceive.F90 Ra_MPI_Base.o 
 Spectral_Derivatives.o : Spectral_Derivatives.F90 Structures.o 


### PR DESCRIPTION
One of the PRs this week changed the dependencies without updating the depency file (maybe it is also just the build type of the tester?). This should fix the results. Only merge if the tester succeeds.