### PR TITLE
Fixed reference-state advection bug.

### DIFF
--- a/src/Physics/Sphere_Spectral_Space.F90
+++ b/src/Physics/Sphere_Spectral_Space.F90
@@ -168,8 +168,9 @@ Contains
         Call Add_Derivative(weq,wvar,1,wsp%p1b,wsp%p1a,dwdr)
         Call Add_Derivative(weq,wvar,2,wsp%p1b,wsp%p1a,d2wdr2)
 
-
-
+        If (advect_reference_state) Then
+            Call Add_Derivative(teq,wvar,0,wsp%p1b,wsp%p1a,wvar)
+        Endif
         !//////////////////////////////
         !  P Terms
 


### PR DESCRIPTION
This PR fixes a bug where reference-state advection was improperly implemented.   The term v dot grad dsdr is linear and implemented semi-implicitly through the CN scheme.   As it stood, only the implicit portion (left-hand side) was implemented.  The explicit portion (right-hand side) had been omitted.   The RHS is now properly addressed through this PR.