### PR TITLE
Fixed dim polytrope

### DIFF
--- a/src/Physics/PDE_Coefficients.F90
+++ b/src/Physics/PDE_Coefficients.F90
@@ -386,6 +386,7 @@ Contains
     Subroutine Polytropic_Reference()
         Real*8 :: zeta_0,  c0, c1, d
         Real*8 :: rho_c, P_c, T_c,denom
+	Real*8 :: thermo_gamma, volume_specific_heat
         Real*8 :: beta
         Real*8 :: Gravitational_Constant = 6.67d-8 ! cgs units
         Real*8, Allocatable :: zeta(:), gravity(:)
@@ -453,6 +454,10 @@ Contains
         ! Initialize reference structure
         Gravity = Gravitational_Constant * poly_mass / Radius**2
 
+	! The following is needed to calculate the entropy gradient
+	thermo_gamma = 5.0d0/3.0d0
+	volume_specific_heat = pressure_specific_heat / thermo_gamma
+
         Ref%Density = rho_c * zeta**poly_n
 
         Ref%dlnrho = - poly_n * c1 * d / (zeta * Radius**2)
@@ -461,7 +466,7 @@ Contains
         Ref%Temperature = T_c * zeta
         Ref%dlnT = -(c1*d/Radius**2)/zeta
 
-        Ref%dsdr = 0.d0
+        Ref%dsdr = volume_specific_heat * (Ref%dlnT - (thermo_gamma - 1.0d0) * Ref%dlnrho)
 
         Ref%Buoyancy_Coeff = gravity/Pressure_Specific_Heat*ref%density
 


### PR DESCRIPTION
<img width="1158" alt="Energy_fluxes_comparing_stable_polytropes" src="https://user-images.githubusercontent.com/15314072/62753458-e847f980-ba28-11e9-9b84-156e04977c7b.png">

Previously the entropy gradient dsdr was set to zero in the Polytropic_Reference() routine of PDE_Coefficients.F90. It should only be zero if poly_n = 1.5 (albeit the most common--i.e., solar--case). I replaced it with the correct dsdr from the First Law of Thermodynamics. This distinction is important, since before Rayleigh was effectively unable to run the stable polytrope case. 

I am attaching a figure showing the difference; this case has poly_n = 4.5 and advect_reference_state = .true., one with the old version of the code (dsdr0) and one with the new fix. For the old code, there is still still convection, when clearly there shouldn't be as the case is (very) stable to convection. For the fixed code, there is a purely conductive state, as there should be. 

The same dsdr = 0 happens in Polytropic_ReferenceND(), but I was unsure of the correct form of dsdr given the non-dimensionalization, so @feathern said he would look at this one.