### PR TITLE
direct attribute access in equation_coefficients

### DIFF
--- a/post_processing/reference_tools.py
+++ b/post_processing/reference_tools.py
@@ -6,6 +6,12 @@ class equation_coefficients:
     nconst = 10
     nfunc = 14
     version=1
+    c_dict    = {'two_omega':1, 'buoy_fact':2, 'p_fact':3, 'lorentz_fact':4, 'visc_fact':5,
+                 'diff_fact':6, 'resist_fact':7, 'nu_heat_fact':8, 'ohm_heat_fact':9,
+                 'luminosity':10}
+    f_dict    = {'density':1, 'buoy':2, 'nu':3, 'temperature':4, 'kappa':5, 'heating':6,
+                 'eta':7, 'd_ln_rho':8, 'd2_ln_rho':9, 'd_ln_T':10, 'd_ln_nu':11, 'd_ln_kappa':12,
+                 'd_ln_eta':13, 'ds_dr':14}
 
     def __init__(self,radius=[], file=None):
         if (len(radius) != 0):
@@ -18,12 +24,6 @@ class equation_coefficients:
             self.constants = numpy.zeros(self.nconst     , dtype='float64' )
             self.cset      = numpy.zeros(self.nconst     , dtype='int32'   )
             self.fset      = numpy.zeros(self.nfunc      , dtype='int32'   )
-            self.c_dict    = {'two_omega':1, 'buoy_fact':2, 'p_fact':3, 'lorentz_fact':4, 'visc_fact':5,
-                 'diff_fact':6, 'resist_fact':7, 'nu_heat_fact':8, 'ohm_heat_fact':9,
-                 'luminosity':10}
-            self.f_dict    = {'density':1, 'buoy':2, 'nu':3, 'temperature':4, 'kappa':5, 'heating':6,
-                 'eta':7, 'd_ln_rho':8, 'd2_ln_rho':9, 'd_ln_T':10, 'd_ln_nu':11, 'd_ln_kappa':12,
-                 'd_ln_eta':13, 'ds_dr':14}          
         elif (file != None):
             self.read(filename=file)
             

--- a/post_processing/reference_tools.py
+++ b/post_processing/reference_tools.py
@@ -35,6 +35,14 @@ class equation_coefficients:
         else:
             raise AttributeError("'{}' has no attribute '{}'".format(self.__class__, name))
 
+    def __setattr__(self, name, value):
+        if name in self.f_dict:
+            self.set_function(value, name)
+        elif name in self.c_dict:
+            self.set_constant[name]
+        else:
+            super().__setattr__(name, value)
+
     def set_function(self,y,f_name):
 
         if (isinstance(f_name,str)):

--- a/post_processing/reference_tools.py
+++ b/post_processing/reference_tools.py
@@ -26,7 +26,15 @@ class equation_coefficients:
             self.fset      = numpy.zeros(self.nfunc      , dtype='int32'   )
         elif (file != None):
             self.read(filename=file)
-            
+
+    def __getattr__(self, name):
+        if name in self.f_dict:
+            return self.functions[self.f_dict[name] - 1]
+        elif name in self.c_dict:
+            return self.constants[self.c_dict[name] - 1]
+        else:
+            return AttributeError
+
     def set_function(self,y,f_name):
 
         if (isinstance(f_name,str)):

--- a/post_processing/reference_tools.py
+++ b/post_processing/reference_tools.py
@@ -50,7 +50,7 @@ class equation_coefficients:
         else:
             fi = f_name
 
-        self.functions[fi-1,:] = y[:]
+        self.functions[fi-1,:] = y
         self.fset[fi-1] = 1
         
     def set_constant(self,c,c_name):

--- a/post_processing/reference_tools.py
+++ b/post_processing/reference_tools.py
@@ -33,7 +33,7 @@ class equation_coefficients:
         elif name in self.c_dict:
             return self.constants[self.c_dict[name] - 1]
         else:
-            return AttributeError
+            raise AttributeError("'{}' has no attribute '{}'".format(self.__class__, name))
 
     def set_function(self,y,f_name):
 


### PR DESCRIPTION
This allows us to directly reference functions and coefficients by name
from the equation_coefficients class.
    
Example:
```python
cref = rt.equation_coefficients(file='equation_coefficients')
cref.density
```