### PR TITLE
Set equation coefs reftype1

### DIFF
--- a/src/Physics/PDE_Coefficients.F90
+++ b/src/Physics/PDE_Coefficients.F90
@@ -405,7 +405,7 @@ Contains
     Subroutine Polytropic_Reference()
         Real*8 :: zeta_0,  c0, c1, d
         Real*8 :: rho_c, P_c, T_c,denom
-    Real*8 :: thermo_gamma, volume_specific_heat
+        Real*8 :: thermo_gamma, volume_specific_heat
         Real*8 :: beta
         Real*8 :: Gravitational_Constant = 6.67d-8 ! cgs units
         Real*8, Allocatable :: zeta(:), gravity(:)
@@ -503,7 +503,7 @@ Contains
         Else
             ref%Lorentz_Coeff = 0.0d0
             ref%ohmic_amp(1:N_R) = 0.0d0
-        Endif   
+        Endif 
 
     End Subroutine Polytropic_Reference
 

--- a/src/Physics/PDE_Coefficients.F90
+++ b/src/Physics/PDE_Coefficients.F90
@@ -400,27 +400,6 @@ Contains
             ref%ohmic_amp(1:N_R) = 0.0d0
         Endif
 
-        ! Set the equation coefficients (apart from the ones having to do with diffusivities and heating)
-        ! for proper output to the equation_coefficients file
-        ra_functions(:,1) = ref%density
-        ra_functions(:,2) = gravity*ref%density
-        ra_functions(:,4) = ref%temperature
-        ra_functions(:,8) = ref%dlnrho
-        ra_functions(:,9) = ref%d2lnrho        
-        ra_functions(:,10) = ref%dlnT
-        ra_functions(:,14) = ref%dsdr     
-                        
-        ra_constants(1) = ref%Coriolis_Coeff
-        ra_constants(2) = Modified_Rayleigh_Number
-        ra_constants(3) = 1.0d0
-        ra_constants(4) = ref%Lorentz_Coeff
-        ra_constants(8) = Ekman_Number*Dissipation_Number/Modified_Rayleigh_Number
-        If (magnetism) Then
-        	ra_constants(9) = Ekman_Number**2*Dissipation_Number/(Magnetic_Prandtl_Number**2*Modified_Rayleigh_Number)
-        Else
-        	ra_constants(9) = 0.0d0
-        Endif
-
     End Subroutine Polytropic_ReferenceND
 
     Subroutine Polytropic_Reference()
@@ -524,24 +503,7 @@ Contains
         Else
             ref%Lorentz_Coeff = 0.0d0
             ref%ohmic_amp(1:N_R) = 0.0d0
-        Endif
-        
-        ! Set the equation coefficients (apart from the ones having to do with diffusivities and heating)
-        ! for proper output to the equation_coefficients file
-        ra_functions(:,1) = ref%density
-        ra_functions(:,2) = ref%Buoyancy_Coeff
-        ra_functions(:,4) = ref%temperature
-        ra_functions(:,8) = ref%dlnrho
-        ra_functions(:,9) = ref%d2lnrho        
-        ra_functions(:,10) = ref%dlnT
-        ra_functions(:,14) = ref%dsdr     
-                        
-        ra_constants(1) = ref%Coriolis_Coeff
-        ra_constants(2) = 1.0d0
-        ra_constants(3) = 1.0d0
-        ra_constants(4) = ref%Lorentz_Coeff
-        ra_constants(8) = 1.0d0
-        ra_constants(9) = ref%Lorentz_Coeff       
+        Endif   
 
     End Subroutine Polytropic_Reference
 
@@ -1203,8 +1165,10 @@ Contains
 
         ! For reference_type = 4, the equation coefficients have already been set in 
         ! read_custom_reference_file()
-        ! f_3, f_5, f_7, c_5, c_6, c_7 have already been set in initialize_diffusivity()
-        If (reference_type .ne. 4) Then
+        ! For reference_type = 1, the coefficients have been set in Constant_Reference()
+        ! In all cases, f_3, f_5, f_7, c_5, c_6, c_7 have already been set in 
+        ! Initialize_Diffusivity()
+        If (reference_type .eq. 2 .or. reference_type .eq. 3) Then
             ra_constants(1) = ref%coriolis_coeff
             ra_constants(2) = 1.0d0 ! buoyancy coefficient
             ra_constants(3) = 1.0d0 ! dpdr_w

--- a/src/Physics/PDE_Coefficients.F90
+++ b/src/Physics/PDE_Coefficients.F90
@@ -300,6 +300,25 @@ Contains
             eta_Top     = 0.0d0
             ref%ohmic_amp(1:N_R) = 0.0d0
         Endif
+        
+        ! Set the equation coefficients (apart from the ones having to do with diffusivities)
+        ! for proper output to the equation_coefficients file
+        ra_functions(:,1) = ref%density
+        ra_functions(:,2) = (radius(i)/radius(1))**gravity_power
+        ra_functions(:,4) = ref%temperature
+        ra_functions(:,6) = 0.0d0
+        ra_functions(:,8) = ref%dlnrho
+        ra_functions(:,9) = ref%d2lnrho        
+        ra_functions(:,10) = ref%dlnT
+        ra_functions(:,14) = ref%dsdr     
+                        
+        ra_constants(1) = ref%Coriolis_Coeff
+        ra_constants(2) = Rayleigh_Number/Prandtl_Number
+        ra_constants(3) = pscaling
+        ra_constants(4) = ref%Lorentz_Coeff
+        ra_constants(8) = 0.0d0
+        ra_constants(9) = 0.0d0
+        ra_constants(10) = 0.0d0
 
     End Subroutine Constant_Reference
 
@@ -381,6 +400,27 @@ Contains
             ref%ohmic_amp(1:N_R) = 0.0d0
         Endif
 
+        ! Set the equation coefficients (apart from the ones having to do with diffusivities and heating)
+        ! for proper output to the equation_coefficients file
+        ra_functions(:,1) = ref%density
+        ra_functions(:,2) = gravity*ref%density
+        ra_functions(:,4) = ref%temperature
+        ra_functions(:,8) = ref%dlnrho
+        ra_functions(:,9) = ref%d2lnrho        
+        ra_functions(:,10) = ref%dlnT
+        ra_functions(:,14) = ref%dsdr     
+                        
+        ra_constants(1) = ref%Coriolis_Coeff
+        ra_constants(2) = Modified_Rayleigh_Number
+        ra_constants(3) = 1.0d0
+        ra_constants(4) = ref%Lorentz_Coeff
+        ra_constants(8) = Ekman_Number*Dissipation_Number/Modified_Rayleigh_Number
+        If (magnetism) Then
+        	ra_constants(9) = Ekman_Number**2*Dissipation_Number/(Magnetic_Prandtl_Number**2*Modified_Rayleigh_Number)
+        Else
+        	ra_constants(9) = 0.0d0
+        Endif
+
     End Subroutine Polytropic_ReferenceND
 
     Subroutine Polytropic_Reference()
@@ -454,9 +494,9 @@ Contains
         ! Initialize reference structure
         Gravity = Gravitational_Constant * poly_mass / Radius**2
 
-	! The following is needed to calculate the entropy gradient
-	thermo_gamma = 5.0d0/3.0d0
-	volume_specific_heat = pressure_specific_heat / thermo_gamma
+		! The following is needed to calculate the entropy gradient
+		thermo_gamma = 5.0d0/3.0d0
+		volume_specific_heat = pressure_specific_heat / thermo_gamma
 
         Ref%Density = rho_c * zeta**poly_n
 
@@ -485,6 +525,23 @@ Contains
             ref%Lorentz_Coeff = 0.0d0
             ref%ohmic_amp(1:N_R) = 0.0d0
         Endif
+        
+        ! Set the equation coefficients (apart from the ones having to do with diffusivities and heating)
+        ! for proper output to the equation_coefficients file
+        ra_functions(:,1) = ref%density
+        ra_functions(:,2) = ref%Buoyancy_Coeff
+        ra_functions(:,4) = ref%temperature
+        ra_functions(:,8) = ref%dlnrho
+        ra_functions(:,9) = ref%d2lnrho        
+        ra_functions(:,10) = ref%dlnT
+        ra_functions(:,14) = ref%dsdr     
+                        
+        ra_constants(1) = ref%Coriolis_Coeff
+        ra_constants(2) = 1.0d0
+        ra_constants(3) = 1.0d0
+        ra_constants(4) = ref%Lorentz_Coeff
+        ra_constants(8) = 1.0d0
+        ra_constants(9) = ref%Lorentz_Coeff       
 
     End Subroutine Polytropic_Reference
 

--- a/src/Physics/PDE_Coefficients.F90
+++ b/src/Physics/PDE_Coefficients.F90
@@ -304,7 +304,7 @@ Contains
         ! Set the equation coefficients (apart from the ones having to do with diffusivities)
         ! for proper output to the equation_coefficients file
         ra_functions(:,1) = ref%density
-        ra_functions(:,2) = (radius(i)/radius(1))**gravity_power
+        ra_functions(:,2) = (radius(:)/radius(1))**gravity_power
         ra_functions(:,4) = ref%temperature
         ra_functions(:,6) = 0.0d0
         ra_functions(:,8) = ref%dlnrho
@@ -405,7 +405,7 @@ Contains
     Subroutine Polytropic_Reference()
         Real*8 :: zeta_0,  c0, c1, d
         Real*8 :: rho_c, P_c, T_c,denom
-	Real*8 :: thermo_gamma, volume_specific_heat
+    Real*8 :: thermo_gamma, volume_specific_heat
         Real*8 :: beta
         Real*8 :: Gravitational_Constant = 6.67d-8 ! cgs units
         Real*8, Allocatable :: zeta(:), gravity(:)
@@ -473,9 +473,9 @@ Contains
         ! Initialize reference structure
         Gravity = Gravitational_Constant * poly_mass / Radius**2
 
-		! The following is needed to calculate the entropy gradient
-		thermo_gamma = 5.0d0/3.0d0
-		volume_specific_heat = pressure_specific_heat / thermo_gamma
+        ! The following is needed to calculate the entropy gradient
+        thermo_gamma = 5.0d0/3.0d0
+        volume_specific_heat = pressure_specific_heat / thermo_gamma
 
         Ref%Density = rho_c * zeta**poly_n
 

--- a/src/Physics/PDE_Coefficients.F90
+++ b/src/Physics/PDE_Coefficients.F90
@@ -503,7 +503,7 @@ Contains
         Else
             ref%Lorentz_Coeff = 0.0d0
             ref%ohmic_amp(1:N_R) = 0.0d0
-        Endif 
+        Endif
 
     End Subroutine Polytropic_Reference
 


### PR DESCRIPTION
This is the second in a series of commits to properly set the equation coefficients in the "equation_coefficients" binary file. The first dealt with the diffusion coefficients, (c_5, f_3), (c_6, f_5), and (c_7, f_7) and was approved. This deals with the other c's/f's in the non-dimensional boussinesq case (reference_type = 1 and the Constant_Reference() subroutine). 