### PR TITLE
Ref mod2

### DIFF
--- a/src/Physics/PDE_Coefficients.F90
+++ b/src/Physics/PDE_Coefficients.F90
@@ -975,10 +975,21 @@ Contains
     ! IV.  Subroutines used to define the transport coefficients
 
     Subroutine Initialize_Transport_Coefficients()
+        Implicit None
+        Real*8, Allocatable :: temp_functions(:,:), temp_constants(:)
+        Logical :: restore
+
+        restore = .false.
+
         Call Allocate_Transport_Coefficients
 
         If ((.not. custom_reference_read) .and. &
             ((nu_type .eq. 3) .or. (kappa_type .eq. 3) .or. (eta_type .eq. 3))) Then
+            Allocate(temp_functions(1:n_r, 1:n_ra_functions))
+            Allocate(temp_constants(1:n_ra_constants))
+            temp_functions(:,:) = ra_functions(:,:)
+            temp_constants(:) = ra_constants(:)
+            restore = .true.
             Call Read_Custom_Reference_File(custom_reference_file)
         EndIf
 
@@ -1000,6 +1011,33 @@ Contains
         Else
             eta(:)    = 0.0d0 ! eta was already allocated, but never initialized since this
             dlneta(:) = 0.0d0 ! run has magnetism = False. Explicitly set eta to zero
+        Endif
+
+        If (restore) Then
+
+            If (eta_type .eq. 3) Then
+                temp_functions(:,7)  = ra_functions(:,7)
+                temp_functions(:,13) = ra_functions(:,13)
+                temp_constants(7)    = ra_constants(7)
+            Endif
+
+            If (kappa_type .eq. 3) Then
+                temp_functions(:,5)  = ra_functions(:,5)
+                temp_functions(:,12) = ra_functions(:,12)
+                temp_constants(6)    = ra_constants(6)
+            Endif
+
+            If (nu_type .eq. 3) Then
+                temp_functions(:,3)  = ra_functions(:,3)
+                temp_functions(:,11) = ra_functions(:,11)
+                temp_constants(5)    = ra_constants(5)
+            Endif
+
+            ra_constants(:) = temp_constants(:)
+            ra_functions(:,:) = temp_functions(:,:)
+            DeAllocate(temp_functions, temp_constants)
+
+
         Endif
 
         Call Compute_Diffusion_Coefs()

--- a/src/Physics/PDE_Coefficients.F90
+++ b/src/Physics/PDE_Coefficients.F90
@@ -1094,6 +1094,7 @@ Contains
                     xtop = x(1)
                     ! Nothing to be done here for functions and constants -- completely set
                 ElseIf ((ra_function_set(fi) .eq. 1) .and. (ra_constant_set(ci) .eq. 0)) Then
+                    ra_constants(ci) = xtop
                     x(:) = xtop*ra_functions(:,fi)
                     dlnx(:) = ra_functions(:,dlnfi)
                     xtop = x(1)


### PR DESCRIPTION
This PR follows onto [PR 215](https://github.com/geodynamics/Rayleigh/pull/215 ).   It prevents rayleigh functions and constants from being overwritten by those read in from a custom diffusivity file used in tandem with one of the Rayleigh-provided reference states.  Only those constants/functions pertaining the a custom diffusivity (specified via nu{kappa,eta}_type =3) are now overwritten by the contents of the coefficient file.  Prior to this PR, anything in the coefficient file (say density) would overwrite values previously set through initialize_reference_state.