### PR TITLE
Set heating coefs

### DIFF
--- a/src/Physics/BoundaryConditions.F90
+++ b/src/Physics/BoundaryConditions.F90
@@ -271,6 +271,9 @@ Contains
             Endif
 
             ref%heating = ref%heating*(lum_top-lum_bottom)
+            ! If the code has reached this point, c_10 was not defined in
+            ! initialize_reference_heating and needs to be defined here
+            ra_constants(10) = lum_top - lum_bottom
             !If something has been set inconsistenly, this will result
             ! in zero reference heating
          Endif

--- a/src/Physics/PDE_Coefficients.F90
+++ b/src/Physics/PDE_Coefficients.F90
@@ -1207,7 +1207,8 @@ Contains
         ! read_custom_reference_file()
         ! For reference_type = 1, the coefficients have been set in Constant_Reference()
         ! In all cases, f_3, f_5, f_7, c_5, c_6, c_7 have already been set in 
-        ! Initialize_Diffusivity()
+        ! Initialize_Diffusivity() and c_10 and f_6 have been set in
+        ! Initialize_Reference_Heating()
         If (reference_type .eq. 2 .or. reference_type .eq. 3) Then
             ra_constants(1) = ref%coriolis_coeff
             ra_constants(2) = 1.0d0 ! buoyancy coefficient
@@ -1215,12 +1216,10 @@ Contains
             ra_constants(4) = ref%lorentz_coeff
             ra_constants(8) = 1.0d0 ! multiplies viscous heating
             ra_constants(9) = 1.0d0 ! multiplies ohmic heating
-            ra_constants(10) = 1.0d0 ! multiplies volumetric heating
 
             ra_functions(:,1) = ref%density(:)
             ra_functions(:,2) = ref%buoyancy_coeff(:)
             ra_functions(:,4) = ref%temperature(:)
-            ra_functions(:,6) = ref%heating(:)*ref%density(:)*ref%temperature(:)
             ra_functions(:,8) = ref%dlnrho(:)
             ra_functions(:,9) = ref%d2lnrho(:)
             ra_functions(:,10) = ref%dlnT(:)

--- a/src/Physics/PDE_Coefficients.F90
+++ b/src/Physics/PDE_Coefficients.F90
@@ -92,6 +92,7 @@ Module PDE_Coefficients
     Real*8  :: Luminosity = 0.0d0 ! specifies the integral of the heating function
     Real*8  :: Heating_Integral = 0.0d0  !same as luminosity (for non-star watchers)
     Real*8  :: Heating_EPS = 1.0D-12  !Small number to test whether luminosity specified
+    Logical :: adjust_reference_heating = .false.  ! Flag used to decide if luminosity determined via boundary conditions
 
     Type(ReferenceInfo) :: ref
 
@@ -538,13 +539,16 @@ Contains
         !Otherwise, we will use the boundary thermal flux
         !To establish the integral
         If (heating_type .gt. 0)Then
+            adjust_reference_heating = .true.
             If (abs(Luminosity) .gt. heating_eps) Then
+                adjust_reference_heating = .false.
                 ref%heating = ref%heating*Luminosity
                 ! and here is a good time to set c_10
                 ra_constants(10) = Luminosity
             Endif
 
             If (abs(Heating_Integral) .gt. heating_eps) Then
+                adjust_reference_heating = .false.
                 ref%heating = ref%heating*Heating_Integral
                 ! ... or set c_10 here
                 ra_constants(10) = Heating_Integral              

--- a/src/Physics/PDE_Coefficients.F90
+++ b/src/Physics/PDE_Coefficients.F90
@@ -530,6 +530,9 @@ Contains
         ! Heating Q_H is normalized so that:
         ! Int_volume rho T Q_H dV = 1 
 
+        ! Here is a good time set f_6
+        ra_functions(:, 6) = ref%heating
+
         !If luminosity or heating_integral has been set,
         !we set the integral of ref%heating using that.
 
@@ -540,11 +543,15 @@ Contains
             If (abs(Luminosity) .gt. heating_eps) Then
                 adjust_reference_heating = .false.
                 ref%heating = ref%heating*Luminosity
+                ! and here is a good time to set c_10
+                ra_constants(10) = Luminosity
             Endif
 
             If (abs(Heating_Integral) .gt. heating_eps) Then
                 adjust_reference_heating = .false.
                 ref%heating = ref%heating*Heating_Integral
+                ! ... or set c_10 here
+                ra_constants(10) = Heating_Integral              
             Endif
         Endif
     End Subroutine Initialize_Reference_Heating

--- a/src/Physics/PDE_Coefficients.F90
+++ b/src/Physics/PDE_Coefficients.F90
@@ -531,7 +531,7 @@ Contains
         ! Int_volume rho T Q_H dV = 1 
 
         ! Here is a good time set f_6
-        ra_functions(:, 6) = ref%heating
+        ra_functions(:, 6) = ref%heating(:)*ref%density(:)*ref%temperature(:)
 
         !If luminosity or heating_integral has been set,
         !we set the integral of ref%heating using that.

--- a/src/Physics/PDE_Coefficients.F90
+++ b/src/Physics/PDE_Coefficients.F90
@@ -92,7 +92,6 @@ Module PDE_Coefficients
     Real*8  :: Luminosity = 0.0d0 ! specifies the integral of the heating function
     Real*8  :: Heating_Integral = 0.0d0  !same as luminosity (for non-star watchers)
     Real*8  :: Heating_EPS = 1.0D-12  !Small number to test whether luminosity specified
-    Logical :: adjust_reference_heating = .false.  ! Flag used to decide if luminosity determined via boundary conditions
 
     Type(ReferenceInfo) :: ref
 
@@ -539,16 +538,13 @@ Contains
         !Otherwise, we will use the boundary thermal flux
         !To establish the integral
         If (heating_type .gt. 0)Then
-            adjust_reference_heating = .true.
             If (abs(Luminosity) .gt. heating_eps) Then
-                adjust_reference_heating = .false.
                 ref%heating = ref%heating*Luminosity
                 ! and here is a good time to set c_10
                 ra_constants(10) = Luminosity
             Endif
 
             If (abs(Heating_Integral) .gt. heating_eps) Then
-                adjust_reference_heating = .false.
                 ref%heating = ref%heating*Heating_Integral
                 ! ... or set c_10 here
                 ra_constants(10) = Heating_Integral              

--- a/src/Physics/PDE_Coefficients.F90
+++ b/src/Physics/PDE_Coefficients.F90
@@ -306,7 +306,6 @@ Contains
         ra_functions(:,1) = ref%density
         ra_functions(:,2) = (radius(:)/radius(1))**gravity_power
         ra_functions(:,4) = ref%temperature
-        ra_functions(:,6) = 0.0d0
         ra_functions(:,8) = ref%dlnrho
         ra_functions(:,9) = ref%d2lnrho        
         ra_functions(:,10) = ref%dlnT
@@ -318,7 +317,6 @@ Contains
         ra_constants(4) = ref%Lorentz_Coeff
         ra_constants(8) = 0.0d0
         ra_constants(9) = 0.0d0
-        ra_constants(10) = 0.0d0
 
     End Subroutine Constant_Reference
 


### PR DESCRIPTION
This is the fix I mentioned to set c_10 and f_6. I believe it should work in all cases. f_6 should always volume-integrate to 1, leaving c_10 to be the heating_integral or luminosity set in main_input. 

This pull request has three commits to make it modular in case I screwed something up. 

1. The first commit gets rid of the setting of c_10 and f_6 in the subroutine Constant_Reference(), as @orvedahl, @feathern, and I discussed. 

2. The second commit sets c_10 and f_6 in Initialize_Reference_Heating()--this should work for all cases, but please comment if I am mistaken. 

3. The third commit gets rid of what appears to be a no longer used flag: adjust_reference_heating. I think this flag used to normalize the heating based on the desired luminosity AND whatever energy is lost (or possibly pumped in?) through the boundaries by conduction if fixed-flux boundary conditions were set. I personally think it's good the code no longer does this, since now the user is required to know what they are doing when setting fixed-flux conditions coupled with internal heating. But if the logic was removed by mistake somewhere along the line, I figured I should call attention to it. It's a separate commit so can easily be removed from this pull request if need be.  