### PR TITLE
add option to cause orderly shutdown by touching a file

### DIFF
--- a/doc/source/User_Guide/running.rst
+++ b/doc/source/User_Guide/running.rst
@@ -209,6 +209,17 @@ will run for is determined by the value of the namelist
 *max_time_minutes minutes* or when it has run for *max_iterations time
 steps* – whichever occurs first.
 
+An orderly shutdown of Rayleigh can be manually triggered by creating a file
+with the name set in **terminate_file** (i.e., running the command *touch
+terminate* in the default setting). If the file is found, Rayleigh will stop
+after the next time step and write a checkpoint file. The existence of
+**terminate_file** is checked every **terminate_check_interval** iterations.
+The check can be switched off completely by setting
+**terminate_check_interval** to -1. With the appropriate job script this
+feature can be used to easily restart the code with new settings without losing
+the current allocation in the queuing system. A **terminate_file** left over
+from a previous run is automatically deleted when the code starts.
+
 Time-step size in Rayleigh is controlled by the Courant-Friedrichs-Lewy
 condition (CFL; as determined by the fluid velocity and Alfvén speed). A
 safety factor of **cflmax** is applied to the maximum time step

--- a/src/Physics/Controls.F90
+++ b/src/Physics/Controls.F90
@@ -107,17 +107,19 @@ Module Controls
     ! I/O Controls
     ! What is normally sent to standard out can, if desired, be sent to a file instead
     Integer :: stdout_flush_interval = 50  ! Lines stored before stdout buffer is flushed to stdout_unit
+    Integer :: terminate_check_interval = 50  ! check for presence of terminate_file every n-th time step
     Character*120 :: stdout_file = 'nofile'
     Character*120 :: jobinfo_file = 'jobinfo.txt'
+    Character*120 :: terminate_file = 'terminate'
 
-    Namelist /IO_Controls_Namelist/ stdout_flush_interval,stdout_file,jobinfo_file
+    Namelist /IO_Controls_Namelist/ stdout_flush_interval,terminate_check_interval,stdout_file,jobinfo_file,terminate_file
 
     !///////////////////////////////////////////////////////////////////////////
     ! This array may be used for various purposes related to passing messages to the
     ! full pool of processes
     Real*8, Allocatable :: global_msgs(:)
     Real*8 :: kill_signal = 0.0d0  ! Signal will be passed in Real*8 buffer, but should be integer-like
-    Integer :: nglobal_msgs = 4  ! timestep, elapsed since checkpoint, kill_signal/global message, simulation time
+    Integer :: nglobal_msgs = 5  ! timestep, elapsed since checkpoint, kill_signal/global message, simulation time, terminate file found
 
 
     Integer :: nicknum = 5   ! DO NOT LEAVE THIS HERE -- TEMPORARY LOCATION (AND NAME)
@@ -203,5 +205,7 @@ Contains
         Implicit None
         stdout_flush_interval = 50
         stdout_file = 'nofile'
+        terminate_check_interval = 50
+        terminate_file = 'terminate'
     End Subroutine Restore_IO_Defaults
 End Module Controls

--- a/src/Physics/Main.F90
+++ b/src/Physics/Main.F90
@@ -108,6 +108,7 @@ Contains
     Subroutine Initialize_Directory_Structure()
         Implicit None
         Integer :: ecode
+        Logical :: file_exists
         If (my_rank .eq. 0) Then
             Call Make_Directory(Trim(my_path)//'G_Avgs',ecode)
             Call Make_Directory(Trim(my_path)//'Shell_Avgs',ecode)
@@ -122,6 +123,13 @@ Contains
             Call Make_Directory(Trim(my_path)//'Meridional_Slices',ecode)
             Call Make_Directory(Trim(my_path)//'SPH_Modes',ecode)
             Call Make_Directory(Trim(my_path)//'Point_Probes',ecode)
+
+            !Delete possibly existing terminate file from last run
+            Inquire(file=Trim(my_path)//Trim(terminate_file),exist=file_exists)
+            If (file_exists) Then
+               Open(unit=25,file=Trim(my_path)//Trim(terminate_file))
+               close(unit=25,status='delete')
+            Endif
         Endif
     End Subroutine Initialize_Directory_Structure
 

--- a/src/Physics/Sphere_Driver.F90
+++ b/src/Physics/Sphere_Driver.F90
@@ -196,7 +196,7 @@ Contains
                 last_iteration = iteration !force loop to end
             Endif
 
-            If (global_msgs(5) .ne. 0.0d0) Then
+            If (global_msgs(5) .ge. 0.5d0) Then
                 If (my_rank .eq. 0) Then
                     Call stdout%print(' Termination file was found. Cleaning up.')
                 Endif


### PR DESCRIPTION
This makes it possible to cause Rayleigh to exit and write a checkpoint
file by touching a file called "terminate" in the run directory. This is
convenient for restarting with new options without losing any progress.
With the right logic in the job script, even the current allocation in
the queue can be kept.

As checks for the existence of a file can be costly on some parallel
file systems, the default is to check only every 50 iterations. This can
be configured with `terminate_check_interval`.

The section "Running the code" in the documentation has been updated to
describe this feature.