### PR TITLE
output iter/sec on every iteration

### DIFF
--- a/doc/source/User_Guide/io_redirection.rst
+++ b/doc/source/User_Guide/io_redirection.rst
@@ -43,3 +43,8 @@ force a text-buffer flush. Unexpected crashes and sudden termination by
 the system job scheduler do not force a buffer flush. Note that the
 default value of stdout_file is **‘nofile’**. If this value is
 specified, output will directed to normal stdout.
+
+To save on disk space for logs of very long runs, the number of status outputs
+can be reduced by specifying **statusline_interval** in the
+**io_controls_namelist**. This causes only every n-th status line to be
+written.

--- a/doc/source/User_Guide/running.rst
+++ b/doc/source/User_Guide/running.rst
@@ -215,10 +215,11 @@ terminate* in the default setting). If the file is found, Rayleigh will stop
 after the next time step and write a checkpoint file. The existence of
 **terminate_file** is checked every **terminate_check_interval** iterations.
 The check can be switched off completely by setting
-**terminate_check_interval** to -1. With the appropriate job script this
-feature can be used to easily restart the code with new settings without losing
-the current allocation in the queuing system. A **terminate_file** left over
-from a previous run is automatically deleted when the code starts.
+**terminate_check_interval** to -1. Both of these options are set in the
+**io_controls_namelist**. With the appropriate job script this feature can be
+used to easily restart the code with new settings without losing the current
+allocation in the queuing system. A **terminate_file** left over from
+a previous run is automatically deleted when the code starts.
 
 Time-step size in Rayleigh is controlled by the Courant-Friedrichs-Lewy
 condition (CFL; as determined by the fluid velocity and Alfvén speed). A

--- a/src/Physics/Controls.F90
+++ b/src/Physics/Controls.F90
@@ -108,11 +108,13 @@ Module Controls
     ! What is normally sent to standard out can, if desired, be sent to a file instead
     Integer :: stdout_flush_interval = 50  ! Lines stored before stdout buffer is flushed to stdout_unit
     Integer :: terminate_check_interval = 50  ! check for presence of terminate_file every n-th time step
+    Integer :: statusline_interval = 1  ! output status information only every n-th time step
     Character*120 :: stdout_file = 'nofile'
     Character*120 :: jobinfo_file = 'jobinfo.txt'
     Character*120 :: terminate_file = 'terminate'
 
-    Namelist /IO_Controls_Namelist/ stdout_flush_interval,terminate_check_interval,stdout_file,jobinfo_file,terminate_file
+    Namelist /IO_Controls_Namelist/ stdout_flush_interval,terminate_check_interval,statusline_interval, &
+       stdout_file,jobinfo_file,terminate_file
 
     !///////////////////////////////////////////////////////////////////////////
     ! This array may be used for various purposes related to passing messages to the
@@ -207,5 +209,6 @@ Contains
         stdout_file = 'nofile'
         terminate_check_interval = 50
         terminate_file = 'terminate'
+        statusline_interval = 1
     End Subroutine Restore_IO_Defaults
 End Module Controls

--- a/src/Physics/Sphere_Driver.F90
+++ b/src/Physics/Sphere_Driver.F90
@@ -75,7 +75,8 @@ Contains
         Real*8  :: captured_time, max_time_seconds
         Logical :: terminate_file_exists
         Character*14 :: tmstr
-        Character*8 :: istr, dtfmt ='(ES10.4)'
+        Character*10 :: wtmstr, wtmstr_cpu
+        Character*8 :: istr, dtfmt ='(ES10.4)', wtmfmt='(G8.2E1)'
         Character*7 :: fmtstr = '(F14.4)', ifmtstr = '(i8.8)'
         
 
@@ -162,7 +163,15 @@ Contains
             If (my_rank .eq. 0) Then
                 Write(istr,ifmtstr)iteration
                 Write(tmstr,dtfmt)deltat
-                Call stdout%print(' On iteration : '//istr//'    DeltaT :   '//tmstr)
+                If (stopwatch(walltime)%delta .ne. 0.0d0) Then
+                   Write(wtmstr,wtmfmt) 1.0d0 / stopwatch(walltime)%delta
+                   Write(wtmstr_cpu,wtmfmt) 1.0d0 / (stopwatch(walltime)%delta * ncpu)
+                Else
+                   Write(wtmstr,wtmfmt) -1.0d0
+                   Write(wtmstr_cpu,wtmfmt) -1.0d0
+                Endif
+                Call stdout%print(' On iteration : '//istr//'    DeltaT :   '//tmstr//'  '&
+                   //adjustr(wtmstr)//' iter/sec, '//adjustr(wtmstr_cpu)//' iter/(sec*ncpu)')
             Endif
             Call rlm_spacea()
 

--- a/src/Physics/Sphere_Driver.F90
+++ b/src/Physics/Sphere_Driver.F90
@@ -160,7 +160,7 @@ Contains
             Call Post_Solve() ! Linear Solve Configuration
 
 
-            If (my_rank .eq. 0) Then
+            If (my_rank .eq. 0 .and. mod(iteration,statusline_interval) .eq. 0) Then
                 Write(istr,ifmtstr)iteration
                 Write(tmstr,dtfmt)deltat
                 If (stopwatch(walltime)%delta .ne. 0.0d0) Then

--- a/src/Physics/Sphere_Driver.F90
+++ b/src/Physics/Sphere_Driver.F90
@@ -74,7 +74,8 @@ Contains
         Integer :: io=15, ierr
         Real*8  :: captured_time, max_time_seconds
         Logical :: terminate_file_exists
-        Character*11 :: tmstr
+        Character*14 :: tmstr
+        Character*11 :: dtstr
         Character*9 :: wtmstr
         Character*8 :: istr
         Character(len=*), parameter :: dtfmt ='(ES11.4)', wtmfmt='(ES9.3E1)', &
@@ -163,13 +164,13 @@ Contains
 
             If (my_rank .eq. 0 .and. mod(iteration,statusline_interval) .eq. 0) Then
                 Write(istr,ifmtstr)iteration
-                Write(tmstr,dtfmt)deltat
+                Write(dtstr,dtfmt)deltat
                 If (stopwatch(walltime)%delta .ne. 0.0d0) Then
                    Write(wtmstr,wtmfmt) 1.0d0 / stopwatch(walltime)%delta
                 Else
                    Write(wtmstr,wtmfmt) 0.0d0
                 Endif
-                Call stdout%print(' On iteration : '//istr//' DeltaT : '//tmstr//' Iter/sec : '&
+                Call stdout%print(' On iteration : '//istr//' DeltaT : '//dtstr//' Iter/sec : '&
                    //adjustr(wtmstr))
             Endif
             Call rlm_spacea()

--- a/src/Physics/Sphere_Driver.F90
+++ b/src/Physics/Sphere_Driver.F90
@@ -74,10 +74,11 @@ Contains
         Integer :: io=15, ierr
         Real*8  :: captured_time, max_time_seconds
         Logical :: terminate_file_exists
-        Character*14 :: tmstr
-        Character*10 :: wtmstr, wtmstr_cpu
-        Character*8 :: istr, dtfmt ='(ES10.4)', wtmfmt='(G8.2E1)'
-        Character*7 :: fmtstr = '(F14.4)', ifmtstr = '(i8.8)'
+        Character*11 :: tmstr
+        Character*9 :: wtmstr
+        Character*8 :: istr
+        Character(len=*), parameter :: dtfmt ='(ES11.4)', wtmfmt='(ES9.3E1)', &
+           fmtstr = '(F14.4)', ifmtstr = '(i8.8)'
         
 
         ! Register handle_sig as the signal-handling 
@@ -165,13 +166,11 @@ Contains
                 Write(tmstr,dtfmt)deltat
                 If (stopwatch(walltime)%delta .ne. 0.0d0) Then
                    Write(wtmstr,wtmfmt) 1.0d0 / stopwatch(walltime)%delta
-                   Write(wtmstr_cpu,wtmfmt) 1.0d0 / (stopwatch(walltime)%delta * ncpu)
                 Else
-                   Write(wtmstr,wtmfmt) -1.0d0
-                   Write(wtmstr_cpu,wtmfmt) -1.0d0
+                   Write(wtmstr,wtmfmt) 0.0d0
                 Endif
-                Call stdout%print(' On iteration : '//istr//'    DeltaT :   '//tmstr//'  '&
-                   //adjustr(wtmstr)//' iter/sec, '//adjustr(wtmstr_cpu)//' iter/(sec*ncpu)')
+                Call stdout%print(' On iteration : '//istr//' DeltaT : '//tmstr//' Iter/sec : '&
+                   //adjustr(wtmstr))
             Endif
             Call rlm_spacea()
 

--- a/src/Utility/BufferedOutput.F90
+++ b/src/Utility/BufferedOutput.F90
@@ -91,7 +91,7 @@ Contains
             imax = self%current_index
         Endif
         Do i = 1, imax
-            Write(self%file_unit,*)Trim(self%lines(i))
+            Write(self%file_unit,'(A)')Trim(self%lines(i))
         Enddo
 
         If (self%file_unit .ne. 6) Close(self%file_unit)


### PR DESCRIPTION
This allows us to monitor the code performance during a run. It also
includes iter/(sec*ncpu), which is a basic indicator of scaling
efficiency when changing the number of processes.

The new status line looks like this:
```
  On iteration : 00000004    DeltaT :   1.0000E+03            0.23 iter/sec,       0.12 iter/(sec*ncpu)
```

I normally use sec/iter instead of iter/sec, but I picked the later to be consistent with the timing output when the code terminates.

This uses an existing timer (`walltime`), so it should not incur any significant overhead.

As this is quite a prominent change in the log output, I think we should collect a few opinions before merging.