### PR TITLE
Set equation coefs reftype2

### DIFF
--- a/src/Physics/PDE_Coefficients.F90
+++ b/src/Physics/PDE_Coefficients.F90
@@ -503,6 +503,23 @@ Contains
             ref%ohmic_amp(1:N_R) = 0.0d0
         Endif
 
+        ! Set the equation coefficients (apart from the ones having to do with diffusivities and heating)
+        ! for proper output to the equation_coefficients file
+        ra_functions(:,1) = ref%density
+        ra_functions(:,2) = ref%Buoyancy_Coeff
+        ra_functions(:,4) = ref%temperature
+        ra_functions(:,8) = ref%dlnrho
+        ra_functions(:,9) = ref%d2lnrho        
+        ra_functions(:,10) = ref%dlnT
+        ra_functions(:,14) = ref%dsdr     
+                        
+        ra_constants(1) = ref%Coriolis_Coeff
+        ra_constants(2) = 1.0d0
+        ra_constants(3) = 1.0d0
+        ra_constants(4) = ref%Lorentz_Coeff
+        ra_constants(8) = 1.0d0
+        ra_constants(9) = ref%Lorentz_Coeff       
+
     End Subroutine Polytropic_Reference
 
     Subroutine Initialize_Reference_Heating()
@@ -1209,11 +1226,12 @@ Contains
 
         ! For reference_type = 4, the equation coefficients have already been set in 
         ! read_custom_reference_file()
-        ! For reference_type = 1, the coefficients have been set in Constant_Reference()
+        ! For reference_type = 1,2,  the coefficients have been set in Constant_Reference()
+        ! and Polytropic_Reference()
         ! In all cases, f_3, f_5, f_7, c_5, c_6, c_7 have already been set in 
         ! Initialize_Diffusivity() and c_10 and f_6 have been set in
         ! Initialize_Reference_Heating()
-        If (reference_type .eq. 2 .or. reference_type .eq. 3) Then
+        If (reference_type .eq. 3) Then
             ra_constants(1) = ref%coriolis_coeff
             ra_constants(2) = 1.0d0 ! buoyancy coefficient
             ra_constants(3) = 1.0d0 ! dpdr_w


### PR DESCRIPTION
This should properly set the equation coefficients for reference_type = 2 (Polytropic, dimensional). This leaves only the routine Polytropic_ReferenceND() to modify, which @feathern says he'll do (although, Nick I did do this routine as well if you'd like to see my branch before I or you make another pull request). 

Right now, the Finalize_Equation_Coefficients() routine only modifies ra_constants() and ra_functions() for reference_type = 3. After reference_type = 3 sets the functions/constants itself, we should probably eliminate Finalize_Equation_Coefficients() and have simply a call to Write_Equation_Coefficients() in Main.F90. 

Please review to make sure I set the coefficients right!