### PR TITLE
Set equation coefs reftype3

### DIFF
--- a/src/Physics/Main.F90
+++ b/src/Physics/Main.F90
@@ -87,7 +87,7 @@ Contains
         Call Initialize_Boundary_Conditions()
         Call Initialize_Transport_Coefficients()
 
-        Call Finalize_Equation_Coefficients()
+        Call Write_Equation_Coefficients_File()
 
         Call Initialize_Diagnostics()
 

--- a/src/Physics/PDE_Coefficients.F90
+++ b/src/Physics/PDE_Coefficients.F90
@@ -741,7 +741,7 @@ Contains
         If (present(filename)) Then
             ref_file = Trim(my_path)//filename
         Else
-            ref_file = 'reference'
+            ref_file = 'equation_coefficients'
         Endif
 
         If (my_rank .eq. 0) Then
@@ -1238,17 +1238,6 @@ Contains
         kappa_power = 0
 
     End Subroutine Restore_Transport_Defaults
-
-    Subroutine Finalize_Equation_Coefficients()
-        Implicit None
-        Character*120 :: filename
-
-        ! All equation coefficients should be finalized in the various subroutines by this
-        ! point; here just write the equation coefficients to file
-        filename = Trim(my_path)//"equation_coefficients"
-        Call Write_Equation_Coefficients_File(filename)
-
-    End Subroutine Finalize_Equation_Coefficients
 
     Subroutine Compute_Diffusion_Coefs()
         Implicit None

--- a/src/Physics/PDE_Coefficients.F90
+++ b/src/Physics/PDE_Coefficients.F90
@@ -1243,31 +1243,9 @@ Contains
         Implicit None
         Character*120 :: filename
 
-        ! For reference_type = 4, the equation coefficients have already been set in 
-        ! read_custom_reference_file()
-        ! For reference_type = 1,2,  the coefficients have been set in Constant_Reference()
-        ! and Polytropic_Reference()
-        ! In all cases, f_3, f_5, f_7, c_5, c_6, c_7 have already been set in 
-        ! Initialize_Diffusivity() and c_10 and f_6 have been set in
-        ! Initialize_Reference_Heating()
-        If (reference_type .eq. 3) Then
-            ra_constants(1) = ref%coriolis_coeff
-            ra_constants(2) = 1.0d0 ! buoyancy coefficient
-            ra_constants(3) = 1.0d0 ! dpdr_w
-            ra_constants(4) = ref%lorentz_coeff
-            ra_constants(8) = 1.0d0 ! multiplies viscous heating
-            ra_constants(9) = 1.0d0 ! multiplies ohmic heating
-
-            ra_functions(:,1) = ref%density(:)
-            ra_functions(:,2) = ref%buoyancy_coeff(:)
-            ra_functions(:,4) = ref%temperature(:)
-            ra_functions(:,8) = ref%dlnrho(:)
-            ra_functions(:,9) = ref%d2lnrho(:)
-            ra_functions(:,10) = ref%dlnT(:)
-            ra_functions(:,14) = ref%dsdr(:)
-        Endif
+        ! All equation coefficients should be finalized in the various subroutines by this
+        ! point; here just write the equation coefficients to file
         filename = Trim(my_path)//"equation_coefficients"
-
         Call Write_Equation_Coefficients_File(filename)
 
     End Subroutine Finalize_Equation_Coefficients

--- a/src/Physics/PDE_Coefficients.F90
+++ b/src/Physics/PDE_Coefficients.F90
@@ -398,6 +398,25 @@ Contains
             ref%ohmic_amp(1:N_R) = 0.0d0
         Endif
 
+        ! Set the equation coefficients (apart from the ones having to do with diffusivities and heating)
+        ! for proper output to the equation_coefficients file
+        ra_functions(:,1) = ref%density
+        ra_functions(:,2) = gravity*ref%density
+        ra_functions(:,4) = ref%temperature
+        ra_functions(:,8) = ref%dlnrho
+        ra_functions(:,9) = ref%d2lnrho        
+        ra_functions(:,10) = ref%dlnT
+        ra_functions(:,14) = ref%dsdr     
+                        
+        ra_constants(1) = ref%Coriolis_Coeff
+        ra_constants(2) = Modified_Rayleigh_Number
+        ra_constants(3) = 1.0d0
+        ra_constants(4) = ref%Lorentz_Coeff
+        ra_constants(8) = Ekman_Number*Dissipation_Number/Modified_Rayleigh_Number
+        If (magnetism) Then
+        	ra_constants(9) = Ekman_Number**2*Dissipation_Number/(Magnetic_Prandtl_Number**2*Modified_Rayleigh_Number)
+        Endif ! if not magnetism, ra_constants(9) was initialized to zero
+
     End Subroutine Polytropic_ReferenceND
 
     Subroutine Polytropic_Reference()


### PR DESCRIPTION
After this pull request, all default reference_types should properly initialize the equation_coefficients. @feathern (or someone else!) please verify the constants/functions in PolytropicReferenceND(). 

The 1st commit adds the setting ra_function/ra_constants in PolytropicReferenceND().

the 2nd commit modifies Finalize_Equation_Coefficients() to only write the equation_coefficients file (and not "finalize" anything), since theoretically all the functions/constants will have been set by this point. 

The 3rd commit removes the finalize_equation_coefficients() routine entirely, since now this routine is theoretically unnecessary. Main.F90 then calls Write_Equation_Coefficients_File() directly. This is a bit more of a substantial change (modifying "Main") and so is a separate commit that can be easily reverted. I have tested at least for reference_type=2 and it seems to produce an identical equation_coefficients file, as it should. 