### PR TITLE
Fixed typo

### DIFF
--- a/doc/source/User_Guide/devel_environment.rst
+++ b/doc/source/User_Guide/devel_environment.rst
@@ -58,7 +58,7 @@ If you stop here, you will have to do this every time you activate your developm
 you only need to add two small scripts to radev/etc/conda/activate.d and radev/etc/conda/deactivate.d directories.   Scripts in these
 directories are automatically executed when your conda environment is activated and deactivated, respectively.  
 
-Change to your activate.d directory (for me, this was /custom/software/miniconda3/envs/radev/etc/activate.d) and create a file named
+Change to your activate.d directory (for me, this was /custom/software/miniconda3/envs/radev/etc/conda/activate.d) and create a file named
 activate_mkl.sh with the following three lines:
 
 .. code-block:: bash


### PR DESCRIPTION
This fixes a very small typo in the MKLROOT instructions of the development environment section.  I noticed it when following along on a new OS just now.  I'm going to approve/merge this since the change is tiny and it's related to an old commit of my own.