### PR TITLE
do not link against LAPACK if using OPENBLAS

### DIFF
--- a/configure
+++ b/configure
@@ -776,7 +776,7 @@ else
     #BLAS
     if [[ $USEOPENBLAS == "TRUE" ]]
     then
-	# OPENBLAS already comes with LAPACK
+    # OPENBLAS already comes with LAPACK
         if [[ $STATICBLAS == "TRUE" ]]
         then
           BLASLINK="-L$BLASROOT/lib/libopenblas.a"
@@ -790,15 +790,13 @@ else
         else
           BLASLINK="-L$BLASROOT/lib -lblas"
         fi
-
-	#LAPACK
-	if [[ $STATICLAPACK == "TRUE" ]]
-	then
-	LAPACKLINK="-L$LPROOT/lib/liblapack.a"
-	else
-	LAPACKLINK="-L$LPROOT/lib -llapack"
-	fi
-
+        #LAPACK
+        if [[ $STATICLAPACK == "TRUE" ]]
+        then
+            LAPACKLINK="-L$LPROOT/lib/liblapack.a"
+        else
+            LAPACKLINK="-L$LPROOT/lib -llapack"
+        fi
     fi
     
     #FFTW

--- a/configure
+++ b/configure
@@ -801,7 +801,7 @@ else
 
     fi
     
-    #LAPACK
+    #FFTW
     if [[ $STATICFFTW == "TRUE" ]]
     then
         FFTWLINK="-L$FFTWROOT/lib/libfftw3.a"

--- a/configure
+++ b/configure
@@ -776,6 +776,7 @@ else
     #BLAS
     if [[ $USEOPENBLAS == "TRUE" ]]
     then
+	# OPENBLAS already comes with LAPACK
         if [[ $STATICBLAS == "TRUE" ]]
         then
           BLASLINK="-L$BLASROOT/lib/libopenblas.a"
@@ -789,16 +790,17 @@ else
         else
           BLASLINK="-L$BLASROOT/lib -lblas"
         fi
+
+	#LAPACK
+	if [[ $STATICLAPACK == "TRUE" ]]
+	then
+	LAPACKLINK="-L$LPROOT/lib/liblapack.a"
+	else
+	LAPACKLINK="-L$LPROOT/lib -llapack"
+	fi
+
     fi
     
-    #LAPACK
-    if [[ $STATICLAPACK == "TRUE" ]]
-    then
-        LAPACKLINK="-L$LPROOT/lib/liblapack.a"
-    else
-        LAPACKLINK="-L$LPROOT/lib -llapack"
-    fi
-
     #LAPACK
     if [[ $STATICFFTW == "TRUE" ]]
     then


### PR DESCRIPTION
`libopenblas` already comes with a full set of LAPACK routines included. While you can link another LAPACK library at the same time, this might override the (possibly) more optimized functions from OPENBLAS. Also this way Rayleigh doesn't compile on systems that only provide `libopenblas` but not `liblapack`.

This patch avoids linking against `liblapack` if the `--openblas` option is set.

OPENBLAS can be compiled in a non-default mode that does not include LAPACK. I have never seen this on any production system. If this is a concern, we could add an additional option or maybe even an automatic detection.