### PR TITLE
Move call that generates jobinfo.txt

### DIFF
--- a/src/Physics/Main.F90
+++ b/src/Physics/Main.F90
@@ -54,13 +54,13 @@ Program Main!
 
     Call Main_Input()
     Call Benchmark_Input_Reset() ! Sets run parameters to benchmark parameters if benchmark_mode .ge. 0
-    Call Write_Run_Parameters()  ! write input parameters and other build information
 
     If (test_mode) Then
         Call Init_ProblemSize()
         Call Test_Lib()
     Else
         Call Main_Initialization()
+        Call Write_Run_Parameters()  ! write input parameters and other build information
         Call Main_Loop_Sphere()
     Endif
     Call Finalization()


### PR DESCRIPTION
The jobinfo.txt file is a simple record of what was requested in the namelist. But if the namelist tried to set both stress_free_top and no_slip_top to be True, Rayleigh will choose only one. The fact that Rayleigh does a few consistency checks on the namelist values is not reflected in the jobinfo.txt file.

This pull request moves when the jobinfo.txt file is created to take into account the instances when Rayleigh changes some input parameters. As a result, the jobinfo.txt file contains a record of what Rayleigh is actually using.