### PR TITLE
Dipole Field Boundary Conditions

### DIFF
--- a/src/Physics/BoundaryConditions.F90
+++ b/src/Physics/BoundaryConditions.F90
@@ -125,11 +125,6 @@ Contains
             C1m1_bottom = 0.0d0 ! For the time being, we don't
             C1m1_top =  0.0d0   ! worry about phasing in longitude.
 
-            If (my_rank .eq. 0) Then
-                Write(6,*)'c10_bottom, c10_top : ', 2*c10_bottom, 2*c10_top
-                Write(6,*)'c11_bottom, c11_top : ', 2*c11_bottom, 2*c11_top
-            Endif
-
         Endif
 
         Call Generate_Boundary_Mask()

--- a/src/Physics/BoundaryConditions.F90
+++ b/src/Physics/BoundaryConditions.F90
@@ -126,8 +126,8 @@ Contains
             C1m1_top =  0.0d0   ! worry about phasing in longitude.
 
             If (my_rank .eq. 0) Then
-                Write(6,*)'c10_bottom, c10_top : ', c10_bottom, c10_top
-                Write(6,*)'c11_bottom, c11_top : ', c11_bottom, c11_top
+                Write(6,*)'c10_bottom, c10_top : ', 2*c10_bottom, 2*c10_top
+                Write(6,*)'c11_bottom, c11_top : ', 2*c11_bottom, 2*c11_top
             Endif
 
         Endif

--- a/src/Physics/BoundaryConditions.F90
+++ b/src/Physics/BoundaryConditions.F90
@@ -125,6 +125,11 @@ Contains
             C1m1_bottom = 0.0d0 ! For the time being, we don't
             C1m1_top =  0.0d0   ! worry about phasing in longitude.
 
+            If (my_rank .eq. 0) Then
+                Write(6,*)'c10_bottom, c10_top : ', c10_bottom, c10_top
+                Write(6,*)'c11_bottom, c11_top : ', c11_bottom, c11_top
+            Endif
+
         Endif
 
         Call Generate_Boundary_Mask()

--- a/src/Physics/Initial_Conditions.F90
+++ b/src/Physics/Initial_Conditions.F90
@@ -899,14 +899,14 @@ Contains
             tempfield%s2b(mp)%data(:,:,:,:) = 0.0d0
             If (m .eq. 0) Then
                 Do r = my_r%min, my_r%max
-                    tempfield%s2b(mp)%data(1,r,1,1) = C10_bottom/radius(r)
+                    tempfield%s2b(mp)%data(1,r,1,1) = C10_bottom*rmin/radius(r)
                 Enddo
             Endif
 
             If (m .eq. 1) Then
                 Do r = my_r%min, my_r%max
-                    tempfield%s2b(mp)%data(1,r,1,1) = C11_bottom/radius(r)
-                    tempfield%s2b(mp)%data(1,r,2,1) = C1m1_bottom/radius(r)
+                    tempfield%s2b(mp)%data(1,r,1,1) = C11_bottom*rmin/radius(r)
+                    tempfield%s2b(mp)%data(1,r,2,1) = C1m1_bottom*rmin/radius(r)
                 Enddo
             Endif
 

--- a/tests/generic_input/run_test.sh
+++ b/tests/generic_input/run_test.sh
@@ -31,8 +31,8 @@ cd ..
 # then again onto the same thing but using generic input files to set the boundary conditions
 cd bcs_script
 ../../../pre_processing/rayleigh_spectral_input.py -m 0 0 0 0.0+0.j -o zero_init_vol
-../../../pre_processing/rayleigh_spectral_input.py -m 1 0 1.6012041063972628 -m 1 1 0.39928267284505065+0.j -o ctop_init_bc
-../../../pre_processing/rayleigh_spectral_input.py -m 1 0 4.5748688754207520 -m 1 1 1.140807636700145+0.j -o cbottom_init_bc
+../../../pre_processing/rayleigh_spectral_input.py -m 1 0 2.7612577758722892 -m 1 1 0.68855830481546920+0.j -o ctop_init_bc
+../../../pre_processing/rayleigh_spectral_input.py -m 1 0 7.8893079310636853 -m 1 1 1.9673094423299125+0.j -o cbottom_init_bc
 ../../../pre_processing/rayleigh_spectral_input.py -e '5.0' -o five_init_bc
 ../../../pre_processing/rayleigh_spectral_input.py -e '-5.0' -o mfive_init_bc
 mpirun -np 4 ../../../bin/rayleigh.dbg

--- a/tests/generic_input/run_test.sh
+++ b/tests/generic_input/run_test.sh
@@ -31,8 +31,8 @@ cd ..
 # then again onto the same thing but using generic input files to set the boundary conditions
 cd bcs_script
 ../../../pre_processing/rayleigh_spectral_input.py -m 0 0 0 0.0+0.j -o zero_init_vol
-../../../pre_processing/rayleigh_spectral_input.py -m 1 0 2.973662220170157 -m 1 1 0.5243368809294343+0.j -o ctop_init_bc
-../../../pre_processing/rayleigh_spectral_input.py -m 1 0 8.496177771914736 -m 1 1 1.4981053740840984+0.j -o cbottom_init_bc
+../../../pre_processing/rayleigh_spectral_input.py -m 1 0 2.973662220170157 -m 1 1 0.7415243282628127+0.j -o ctop_init_bc
+../../../pre_processing/rayleigh_spectral_input.py -m 1 0 8.496177771914736 -m 1 1 2.1186409378937510+0.j -o cbottom_init_bc
 ../../../pre_processing/rayleigh_spectral_input.py -e '5.0' -o five_init_bc
 ../../../pre_processing/rayleigh_spectral_input.py -e '-5.0' -o mfive_init_bc
 mpirun -np 4 ../../../bin/rayleigh.dbg

--- a/tests/generic_input/run_test.sh
+++ b/tests/generic_input/run_test.sh
@@ -31,8 +31,8 @@ cd ..
 # then again onto the same thing but using generic input files to set the boundary conditions
 cd bcs_script
 ../../../pre_processing/rayleigh_spectral_input.py -m 0 0 0 0.0+0.j -o zero_init_vol
-../../../pre_processing/rayleigh_spectral_input.py -m 1 0 2.7612577758722892 -m 1 1 0.68855830481546920+0.j -o ctop_init_bc
-../../../pre_processing/rayleigh_spectral_input.py -m 1 0 7.8893079310636853 -m 1 1 1.9673094423299125+0.j -o cbottom_init_bc
+../../../pre_processing/rayleigh_spectral_input.py -m 1 0 5.5225155517445783 -m 1 1 1.3771166096309384+0.j -o ctop_init_bc
+../../../pre_processing/rayleigh_spectral_input.py -m 1 0 15.778615862127371 -m 1 1 3.9346188846598249+0.j -o cbottom_init_bc
 ../../../pre_processing/rayleigh_spectral_input.py -e '5.0' -o five_init_bc
 ../../../pre_processing/rayleigh_spectral_input.py -e '-5.0' -o mfive_init_bc
 mpirun -np 4 ../../../bin/rayleigh.dbg

--- a/tests/generic_input/run_test.sh
+++ b/tests/generic_input/run_test.sh
@@ -31,8 +31,8 @@ cd ..
 # then again onto the same thing but using generic input files to set the boundary conditions
 cd bcs_script
 ../../../pre_processing/rayleigh_spectral_input.py -m 0 0 0 0.0+0.j -o zero_init_vol
-../../../pre_processing/rayleigh_spectral_input.py -m 1 0 2.973662220170157 -m 1 1 0.7415243282628127+0.j -o ctop_init_bc
-../../../pre_processing/rayleigh_spectral_input.py -m 1 0 8.496177771914736 -m 1 1 2.1186409378937510+0.j -o cbottom_init_bc
+../../../pre_processing/rayleigh_spectral_input.py -m 1 0 1.6012041063972628 -m 1 1 0.39928267284505065+0.j -o ctop_init_bc
+../../../pre_processing/rayleigh_spectral_input.py -m 1 0 4.5748688754207520 -m 1 1 1.140807636700145+0.j -o cbottom_init_bc
 ../../../pre_processing/rayleigh_spectral_input.py -e '5.0' -o five_init_bc
 ../../../pre_processing/rayleigh_spectral_input.py -e '-5.0' -o mfive_init_bc
 mpirun -np 4 ../../../bin/rayleigh.dbg


### PR DESCRIPTION
This pull requests fixes one bug and adds one feature:
1.) The value of br_bottom set when  impose_dipole_field = .true. was not reflected in the dipole initialization routine.  Moreover, the coefficient for C(ell=1, m=1) was wrong by a factor of sqrt(2), causing a tilted dipole to have a lower amplitude than one purely aligned with the z-axes.  These inconsistencies have been fixed.

2.)  A dipole naturally satisfies the potential field boundary condition at the upper boundary.  This means there is no inconsistency between using potential match at the top and imposed dipole field at the lower boundary.   This can now be done by setting dipole_field_bottom = .true. in boundary conditions namelist.