### PR TITLE
Changed Diagnostics/Diagnostics_Thermal_Equation.F90 so that vol_heat…

### DIFF
--- a/src/Diagnostics/Diagnostics_Thermal_Energies.F90
+++ b/src/Diagnostics/Diagnostics_Thermal_Energies.F90
@@ -39,7 +39,7 @@ Contains
 
         If (compute_quantity(thermal_energy_full) .or. compute_quantity(thermal_energy_sq)) Then
             DO_PSI
-                qty(PSI) = fbuffer(PSI,tvar)*ref%density(r)*ref%temperature(r)
+                qty(PSI) = buffer(PSI,tvar)*ref%density(r)*ref%temperature(r)
             END_DO
             If (compute_quantity(thermal_energy_full)) Call Add_Quantity(qty)
             If (compute_quantity(thermal_energy_sq)) Then


### PR DESCRIPTION
…_flux is always computed, independent of heating_type

There was a bug in the vol_heat_flux diagnostic introduced by the recent custom reference machinery:  when heating is set through custom reference, the "heating_type" remains its default 0; in that case the diagnostic vol_heat_flux gets assigned to zero, regardless of what the heating actually is. I removed the if-statement surrounding whether the integral is computed; if heating_type = 0, then the integral calculating the flux should still be correct since ref%heating will also be initialized to zero. 

I also removed the if-statement surrounding the vol_heating (block just above vol_heat_flux) that checked whether ref%heating was allocated; it seems that it is always allocated (and zero by default). 

I can modify as needed if I messed anything up. But the fix seems to work for the heating set by Lydia's custom reference routine for Anelastic_Dim_CZ, for a regular heating_type=1, and for heating_type=0. 