### PR TITLE
fixed exit status / seg-fault issue

### DIFF
--- a/src/Parallel_Framework/Parallel_Framework.F90
+++ b/src/Parallel_Framework/Parallel_Framework.F90
@@ -298,13 +298,16 @@ Contains
 
 
 
-    Subroutine Finalize_Framework(self)
+    Subroutine Finalize_Framework(self,ecode)
         Class(Parallel_Interface) :: self
-        Integer :: error
+        Integer, Intent(In), Optional :: ecode
+        Integer :: error,exit_status
+        exit_status=0
+        If (present(ecode)) exit_status = ecode
         self%n1p = 0    ! This line is here purely so that the intel compiler does not
         ! throw an unused variable warning when warn-all is used.
         Call Exit_Comm_Lib(error)
-        !STOP
+        Call Exit(exit_status)
     End Subroutine Finalize_Framework
 
 End Module Parallel_Framework

--- a/src/Physics/ProblemSize.F90
+++ b/src/Physics/ProblemSize.F90
@@ -449,11 +449,12 @@ Contains
 
     Subroutine Halt_On_Error()
 
-        Integer :: esize, i,j,tmp
+        Integer :: esize, i,j,tmp, ecode
         Character*6 :: istr, istr2
         Character*12 :: dstring
         Character*8 :: dofmt = '(ES12.5)'
         If (maxval(perr) .gt. 0) Then
+            ecode = maxval(perr)
             If (my_rank .eq. 0) Then
                 Call stdout%print(' /////////////////////////////////////////////////////////////////')
                 Call stdout%print(' The following errors(s) were detected during grid initialization: ')
@@ -522,7 +523,7 @@ Contains
 
                 Call stdout%finalize()
             Endif
-            Call pfi%exit()
+            Call pfi%exit(ecode)
         Endif
     End Subroutine Halt_On_Error
 End Module ProblemSize


### PR DESCRIPTION
This PR fixes a segmentation fault caused by Rayleigh not exiting properly in some instances after the parallel framework is finalized.  I noticed this when trying to run with npcol > nr (not allowed).  In that case, MPI is finalized, but the code continues to try to run and ultimately attempts to reference an unallocated array.  A proper call to Fortran's intrinsic Exit function now follows the MPI finalization in Parallel_Framework.F90.  

In addition, a non-zero error code is now passed to the shell when an error is encountered in the grid/process-configuration consistency check at initialization.  The error code reported now isn't particularly meaningful, but it's non-zero as it should be.

To see the issue and the resolution, try both the master branch and this PR version via:
mpiexec -np 16 ./rayleigh.dbg -nprow 2 -npcol 8 -nr 4
For the PR version, running echo $? afterward will tell you the error code.