### PR TITLE
N ell

### DIFF
--- a/doc/source/User_Guide/running.rst
+++ b/doc/source/User_Guide/running.rst
@@ -160,15 +160,24 @@ line (overriding the values in main_input) via:
 
    mpiexec -np 8 ./rayleigh.opt -nr 48 -ntheta 96
 
-If desired, the maximal spherical harmonic degree
-:math:`\ell_\mathrm{max}\equiv N_\ell-1` can be specified in lieu of
-:math:`N_\theta`. The example above may equivalently be written:
+If desired, the number of spherical harmonic degrees :math:`N_\ell` or the maximal spherical harmonic degree
+:math:`\ell_\mathrm{max}\equiv N_\ell-1` may be specified in lieu of
+:math:`N_\theta`.  The example above may equivalently be written as
 
 ::
 
    &problemsize_namelist
     n_r = 48
     l_max = 63
+   /
+
+or
+
+::
+
+   &problemsize_namelist
+    n_r = 48
+    n_l = 64
    /
 
 The radial domain bounds are determined by the namelist variables

--- a/src/Parallel_Framework/Parallel_Framework.F90
+++ b/src/Parallel_Framework/Parallel_Framework.F90
@@ -298,13 +298,16 @@ Contains
 
 
 
-    Subroutine Finalize_Framework(self)
+    Subroutine Finalize_Framework(self,ecode)
         Class(Parallel_Interface) :: self
-        Integer :: error
+        Integer, Intent(In), Optional :: ecode
+        Integer :: error,exit_status
+        exit_status=0
+        If (present(ecode)) exit_status = ecode
         self%n1p = 0    ! This line is here purely so that the intel compiler does not
         ! throw an unused variable warning when warn-all is used.
         Call Exit_Comm_Lib(error)
-        !STOP
+        Call Exit(exit_status)
     End Subroutine Finalize_Framework
 
 End Module Parallel_Framework

--- a/src/Physics/ProblemSize.F90
+++ b/src/Physics/ProblemSize.F90
@@ -449,11 +449,12 @@ Contains
 
     Subroutine Halt_On_Error()
 
-        Integer :: esize, i,j,tmp
+        Integer :: esize, i,j,tmp, ecode
         Character*6 :: istr, istr2
         Character*12 :: dstring
         Character*8 :: dofmt = '(ES12.5)'
         If (maxval(perr) .gt. 0) Then
+            ecode = maxval(perr)
             If (my_rank .eq. 0) Then
                 Call stdout%print(' /////////////////////////////////////////////////////////////////')
                 Call stdout%print(' The following errors(s) were detected during grid initialization: ')
@@ -522,7 +523,7 @@ Contains
 
                 Call stdout%finalize()
             Endif
-            Call pfi%exit()
+            Call pfi%exit(ecode)
         Endif
     End Subroutine Halt_On_Error
 End Module ProblemSize

--- a/src/Physics/ProblemSize.F90
+++ b/src/Physics/ProblemSize.F90
@@ -41,8 +41,8 @@ Module ProblemSize
     !//////////////////////////////////////////////////////////////
     ! Horizontal Grid Variables
     Integer              :: n_theta = -1, n_phi
-    Integer              :: l_max = -1
-    Integer              :: m_max, n_l, n_m
+    Integer              :: l_max = -1, n_l=-1
+    Integer              :: m_max, n_m
     Logical              :: dealias = .True.
     Integer, Allocatable :: m_values(:)
     Real*8, Allocatable  :: l_l_plus1(:), over_l_l_plus1(:)
@@ -87,7 +87,7 @@ Module ProblemSize
 
 
     Namelist /ProblemSize_Namelist/ n_r,n_theta, nprow, npcol,rmin,rmax,npout, &
-            &  precise_bounds,grid_type, l_max, &
+            &  precise_bounds,grid_type, l_max, n_l, &
             &  aspect_ratio, shell_depth, ncheby, domain_bounds, dealias_by, &
             &  n_uniform_domains, uniform_bounds
 Contains
@@ -252,8 +252,8 @@ Contains
         rmax = domain_bounds(bounds_count)
 
         shell_volume = four_pi*one_third*(rmax**3-rmin**3)
-        If (l_max .le. 0) Then
 
+        If ( (l_max .le. 0) .and. (n_l .le. 0) ) Then
 
             If (dealias) Then
                 l_max = (2*n_theta-1)/3
@@ -261,7 +261,8 @@ Contains
                 l_max = n_theta-1
             Endif
 
-        Else
+        Else 
+            If (l_max .le. 0) l_max = n_l-1
             !base n_theta on l_max
             If (dealias) Then
                 n_theta = (3*(l_max+1))/2
@@ -269,7 +270,6 @@ Contains
                 n_theta = l_max+1
             Endif
         Endif
-
 
         n_phi = 2*n_theta
         m_max = l_max


### PR DESCRIPTION
This PR adds n_l (l_max+1) to the problemsize namelist.   This may be specified in lieu of l_max or n_theta.  I'm adding thing because n_l, not n_theta nor l_max, is the fundamental parameter of interest for load-balancing in the horizontal direction.  It is also the fundamental descriptor of degrees of freedom in the horizontal direction.   I have also updated the documentation.

One note.  Something odd happened because earlier, I accidentally implemented the exit functionality from the previous PR into my main branch.  Those changes seem to be appearing here and are identical to the ones just approved.   I'm going to get the main branch of my fork back in sync before submitting anymore PR's after this one.