### PR TITLE
throw an error message if unknown options are passed to configure

### DIFF
--- a/configure
+++ b/configure
@@ -430,6 +430,11 @@ do
       BLANKMACHINE="TRUE";
       ;;
 
+    *)
+      echo "unknown option: $option"
+      exit 1
+      ;;
+
     esac
 done
 echo ""


### PR DESCRIPTION
After wondering why Rayleigh didn't compile for a while, I figured that it should really throw an error if you pass unknown options to `configure` instead of silently ignoring options with a typo.