### PR TITLE
Precision Module

### DIFF
--- a/src/Makefile.fdeps
+++ b/src/Makefile.fdeps
@@ -51,12 +51,13 @@ Load_Balance.o : Load_Balance.F90 MPI_LAYER.o
 MPI_LAYER.o : MPI_LAYER.F90 All_to_All.o Ra_MPI_Base.o 
 Main.o : Main.F90 Run_Parameters.o Benchmarking.o Fourier_Transform.o Timers.o Sphere_Driver.o Sphere_Linear_Terms.o Checkpointing.o TestSuite.o Diagnostics_Interface.o Input.o ProblemSize.o Parallel_Framework.o Initial_Conditions.o Fields.o Controls.o MakeDir.o 
 MakeDir.o : MakeDir.F90 
-Math_Constants.o : Math_Constants.F90 
+Math_Constants.o : Math_Constants.F90 Ra_Precision.o 
 Math_Utility.o : Math_Utility.F90 
 PDE_Coefficients.o : PDE_Coefficients.F90 General_MPI.o Math_Utility.o Math_Constants.o Controls.o ProblemSize.o 
 Parallel_Framework.o : Parallel_Framework.F90 BufferedOutput.o Structures.o Load_Balance.o General_MPI.o MPI_LAYER.o 
 ProblemSize.o : ProblemSize.F90 Timers.o BufferedOutput.o Math_Constants.o Chebyshev_Polynomials.o Controls.o Spectral_Derivatives.o Legendre_Polynomials.o Parallel_Framework.o 
 Ra_MPI_Base.o : Ra_MPI_Base.F90 
+Ra_Precision.o : Ra_Precision.F90 
 Run_Param_Header.dbg.o : Run_Param_Header.dbg.F 
 Run_Param_Header.opt.o : Run_Param_Header.opt.F 
 Run_Parameters.o : Run_Parameters.F90 PDE_Coefficients.o TestSuite.o Initial_Conditions.o BoundaryConditions.o Spherical_IO.o ProblemSize.o Parallel_Framework.o Controls.o 

--- a/src/Math_Layer/Ra_Precision.F90
+++ b/src/Math_Layer/Ra_Precision.F90
@@ -18,21 +18,11 @@
 !  <http://www.gnu.org/licenses/>.
 !
 
-Module Math_Constants
-    Use Ra_Precision
+Module Ra_Precision
+    Use, Intrinsic :: ISO_Fortran_Env
     Implicit None
-    Real*8 :: One_Third = 1.0d0/3.0d0
-    Real*8 :: Pi  = 3.1415926535897932384626433832795028841972d0
-    Real*8 :: four_pi, over_eight_pi, two_pi
-    Real*8 :: Half = 0.5d0
-    Real*8 :: Zero = 0.0d0
-    Real*8 :: one=1.0d0
-    Real*8 :: two=2.0d0
-Contains
-    Subroutine Set_Math_Constants()
-        Implicit None
-        four_pi = 4.0d0*pi
-        two_pi = 2.0d0*pi
-        over_eight_pi = 1.0d0/(8.0d0*pi)
-    End Subroutine Set_Math_Constants
-End Module Math_Constants
+    Integer, Parameter :: Ra_dp  = REAL64
+    Integer, Parameter :: Ra_int = INT32
+    
+
+End Module Ra_Precision

--- a/src/object_list
+++ b/src/object_list
@@ -1,4 +1,4 @@
-DSOBJ = Structures.o BufferedOutput.o cmkdir.o MakeDir.o
+DSOBJ = Ra_Precision.o Structures.o BufferedOutput.o cmkdir.o MakeDir.o
 PFOBJ = Ra_MPI_Base.o All_to_All.o SendReceive.o ISendReceive.o General_MPI.o MPI_LAYER.o Load_Balance.o \
         Parallel_Framework.o Spherical_Buffer.o General_IO.o
 MOBJ  = Math_Constants.o Timing.o Finite_Difference.o Chebyshev_Polynomials.o \


### PR DESCRIPTION
This PR adds a precision module to Rayleigh.   The current syntax used by Rayleigh when declaring variables is Real*8 instead of Real(Kind=X).  The former is outdated and not considered portable.   I would like to move toward a more portable format where all variables are declared with kind=x, and where x is taken from the ISO_Fortran_Env intrinsic module.

This PR is intended to lay groundwork for updating the variable declarations.  It only adds a precision module to Rayleigh that provides double-precision (ra_dp) and 4-byte-integer (ra_int) kinds.  The module Ra_Precision sits at the base of the dependency tree and is currently only "used" by Math_Constants, and only through a use statement.  Math_Constants doesn't actually use ra_dp or ra_int.   This was done so that "make fdeps" didn't run into any issues.

This should be very safe to approve/merge.

I will look into automating the changes to variable declarations in a later PR.

-Nick