### PR TITLE
Important I/O Performance Adjustment

### DIFF
--- a/post_processing/rayleigh_diagnostics.py
+++ b/post_processing/rayleigh_diagnostics.py
@@ -602,7 +602,7 @@ class Shell_Avgs:
 
         if (version >= 6):
             npcol = swapread(fd,dtype='int32',count=1,swap=bs)
-            print('new version npcol is: ', npcol)
+
         self.version = version
         self.niter = nrec
         self.nq = nq

--- a/post_processing/rayleigh_diagnostics.py
+++ b/post_processing/rayleigh_diagnostics.py
@@ -600,6 +600,9 @@ class Shell_Avgs:
         nr = swapread(fd,dtype='int32',count=1,swap=bs)
         nq = swapread(fd,dtype='int32',count=1,swap=bs)
 
+        if (version >= 6):
+            npcol = swapread(fd,dtype='int32',count=1,swap=bs)
+            print('new version npcol is: ', npcol)
         self.version = version
         self.niter = nrec
         self.nq = nq
@@ -617,9 +620,20 @@ class Shell_Avgs:
             if (self.version == 1):
                 tmp = np.reshape(swapread(fd,dtype='float64',count=nq*nr,swap=bs),(nr,nq), order = 'F')
                 self.vals[:,:,i] = tmp
-            if (self.version > 1):
+            elif (self.version < 6):
                 tmp = np.reshape(swapread(fd,dtype='float64',count=nq*nr*4,swap=bs),(nr,4,nq), order = 'F')
                 self.vals[:,:,:,i] = tmp
+            else:
+                rind=0
+                nr_base = nr//npcol
+                nr_mod = nr % npcol
+                for j in range(npcol):
+                    nrout= nr_base
+                    if (j < nr_mod) :
+                        nrout=nrout+1
+                    tmp = np.reshape(swapread(fd,dtype='float64',count=nq*nrout*4,swap=bs),(nrout,4,nq), order = 'F')
+                    self.vals[rind:rind+nrout,:,:,i] = tmp[:,:,:]
+                    rind=rind+nrout
             self.time[i] = swapread(fd,dtype='float64',count=1,swap=bs)
             self.iters[i] = swapread(fd,dtype='int32',count=1,swap=bs)
 

--- a/src/IO/Parallel_IO.F90
+++ b/src/IO/Parallel_IO.F90
@@ -1561,7 +1561,7 @@ Contains
                         
                         fdisp = self%file_disp(j)+hdisp
                         bdisp = self%buffer_disp(j)
-                        If (self%orank .eq. 0) Write(6,*)'checking j = ', j,bdisp, self%buffsize, size(self%buffer)
+                        If (self%orank .eq. 0) Write(6,*)'checking j = ', j,bdisp, self%buffsize, size(self%buffer), fdisp
                         Call MPI_File_Seek( funit, fdisp, MPI_SEEK_SET, ierr) 
                         Call MPI_FILE_WRITE(funit, self%buffer(bdisp), & 
                             self%buffsize, MPI_DOUBLE_PRECISION, mstatus, ierr)

--- a/src/IO/Parallel_IO.F90
+++ b/src/IO/Parallel_IO.F90
@@ -1556,8 +1556,9 @@ Contains
                 If (self%write_mode .gt. 1) Call self%gather_data(j)  ! Communicate single cache item at a time
 
                 If (self%output_rank) Then
-
+     
                     If (self%buffsize .ne. 0) Then
+                        If (self%orank .eq. 0) Write(6,*)'checking j = ', j
                         fdisp = self%file_disp(j)+hdisp
                         bdisp = self%buffer_disp(j)
                         Call MPI_File_Seek( funit, fdisp, MPI_SEEK_SET, ierr) 

--- a/src/IO/Parallel_IO.F90
+++ b/src/IO/Parallel_IO.F90
@@ -1558,9 +1558,10 @@ Contains
                 If (self%output_rank) Then
      
                     If (self%buffsize .ne. 0) Then
-                        If (self%orank .eq. 0) Write(6,*)'checking j = ', j
+                        
                         fdisp = self%file_disp(j)+hdisp
                         bdisp = self%buffer_disp(j)
+                        If (self%orank .eq. 0) Write(6,*)'checking j = ', j,bdisp, self%buffsize, size(self%buffer)
                         Call MPI_File_Seek( funit, fdisp, MPI_SEEK_SET, ierr) 
                         Call MPI_FILE_WRITE(funit, self%buffer(bdisp), & 
                             self%buffsize, MPI_DOUBLE_PRECISION, mstatus, ierr)


### PR DESCRIPTION
This PR addresses a potential performance issue resulting from the revised parallel I/O.  The small write sizes associated with Shell_Avgs and G_Avgs outputs can lead to significantly diminished I/O performance on Lustre file systems (as seen on Pleiades; possibly other file systems as well).   These two outputs are now striped differently, with each process writing all of its data at once, as opposed to one quantity-code at a time.  The drawback is that the data ordering for Shell_Avgs now depends on the process configuration (specifically the value of npcol).  New metadata has been added to Shell_Avgs and rayleigh_diagnostics.py has been updated to facilitate reading this new striping pattern.

Version numbers of both outputs have been updated from 5 to 6.

I note that Point_Probes are also typically comprised of many small writes and could also likely benefit from a similar adjustment.   However, the number of radial points varies based on the point-probe grid, and so  some additional thought/coding will need to go into that update.