### PR TITLE
Portable & Complete Checkpoints

### DIFF
--- a/src/IO/Parallel_IO.F90
+++ b/src/IO/Parallel_IO.F90
@@ -1,3 +1,22 @@
+!
+!  Copyright (C) 2018 by the authors of the RAYLEIGH code.
+!
+!  This file is part of RAYLEIGH.
+!
+!  RAYLEIGH is free software; you can redistribute it and/or modify
+!  it under the terms of the GNU General Public License as published by
+!  the Free Software Foundation; either version 3, or (at your option)
+!  any later version.
+!
+!  RAYLEIGH is distributed in the hope that it will be useful,
+!  but WITHOUT ANY WARRANTY; without even the implied warranty of
+!  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+!  GNU General Public License for more details.
+!
+!  You should have received a copy of the GNU General Public License
+!  along with RAYLEIGH; see the file LICENSE.  If not see
+!  <http://www.gnu.org/licenses/>.
+!
 Module Parallel_IO
     Use RA_MPI_Base
     Use Parallel_Framework

--- a/src/Makefile.fdeps
+++ b/src/Makefile.fdeps
@@ -1,10 +1,10 @@
 All_to_All.o : All_to_All.F90 Ra_MPI_Base.o 
 Benchmarking.o : Benchmarking.F90 Initial_Conditions.o BoundaryConditions.o Math_Constants.o PDE_Coefficients.o Legendre_Polynomials.o Fields.o Spherical_IO.o Controls.o ProblemSize.o 
-BoundaryConditions.o : BoundaryConditions.F90 PDE_Coefficients.o Generic_Input.o Load_Balance.o Fields.o ProblemSize.o Math_Constants.o 
+BoundaryConditions.o : BoundaryConditions.F90 Checkpointing.o PDE_Coefficients.o Generic_Input.o Load_Balance.o Fields.o ProblemSize.o Math_Constants.o 
 BufferedOutput.o : BufferedOutput.F90 
 Chebyshev_Polynomials.o : Chebyshev_Polynomials.F90 Structures.o 
 Chebyshev_Polynomials_Alt.o : Chebyshev_Polynomials_Alt.F90 
-Checkpointing.o : Checkpointing.F90 BufferedOutput.o Parallel_IO.o Chebyshev_Polynomials_Alt.o Ra_MPI_Base.o Controls.o ISendReceive.o SendReceive.o Linear_Solve.o Spherical_Buffer.o Parallel_Framework.o ProblemSize.o Timers.o 
+Checkpointing.o : Checkpointing.F90 BufferedOutput.o PDE_Coefficients.o MakeDir.o Parallel_IO.o Chebyshev_Polynomials_Alt.o Ra_MPI_Base.o Controls.o Linear_Solve.o Spherical_Buffer.o Parallel_Framework.o ProblemSize.o Timers.o 
 ClockInfo.o : ClockInfo.F90 Controls.o 
 Controls.o : Controls.F90 BufferedOutput.o 
 Diagnostics_ADotGradB.o : Diagnostics_ADotGradB.F90 indices.F Diagnostics_Base.o 
@@ -42,7 +42,7 @@ General_MPI.o : General_MPI.F90 Ra_MPI_Base.o
 Generic_Input.o : Generic_Input.F90 ProblemSize.o SendReceive.o Load_Balance.o Spherical_Buffer.o Parallel_Framework.o Ra_MPI_Base.o 
 ISendReceive.o : ISendReceive.F90 Ra_MPI_Base.o 
 Initial_Conditions.o : Initial_Conditions.F90 Load_Balance.o BufferedOutput.o Math_Utility.o Linear_Solve.o ClockInfo.o BoundaryConditions.o PDE_Coefficients.o General_MPI.o Timers.o Controls.o Generic_Input.o Checkpointing.o Math_Constants.o SendReceive.o Legendre_Transforms.o Fourier_Transform.o Parallel_Framework.o Fields.o ProblemSize.o 
-Input.o : Input.F90 MPI_LAYER.o Ra_MPI_Base.o Parallel_Framework.o PDE_Coefficients.o TestSuite.o Initial_Conditions.o BoundaryConditions.o Spherical_IO.o Controls.o ProblemSize.o 
+Input.o : Input.F90 MPI_LAYER.o Ra_MPI_Base.o Checkpointing.o Parallel_Framework.o PDE_Coefficients.o TestSuite.o Initial_Conditions.o BoundaryConditions.o Spherical_IO.o Controls.o ProblemSize.o 
 Legendre_Polynomials.o : Legendre_Polynomials.F90 
 Legendre_Transforms.o : Legendre_Transforms.F90 Structures.o Legendre_Polynomials.o 
 Linear_Solve.o : Linear_Solve.F90 Chebyshev_Polynomials.o Finite_Difference.o 
@@ -60,11 +60,10 @@ ProblemSize.o : ProblemSize.F90 Timers.o BufferedOutput.o Math_Constants.o Cheby
 Ra_MPI_Base.o : Ra_MPI_Base.F90 
 Ra_Precision.o : Ra_Precision.F90 
 Run_Param_Header.dbg.o : Run_Param_Header.dbg.F 
-Run_Param_Header.opt.o : Run_Param_Header.opt.F 
 Run_Parameters.o : Run_Parameters.F90 PDE_Coefficients.o TestSuite.o Initial_Conditions.o BoundaryConditions.o Spherical_IO.o ProblemSize.o Parallel_Framework.o Controls.o 
 SendReceive.o : SendReceive.F90 Ra_MPI_Base.o 
 Spectral_Derivatives.o : Spectral_Derivatives.F90 Structures.o 
-Sphere_Driver.o : Sphere_Driver.F90 Fields.o Timers.o Controls.o Checkpointing.o Spherical_IO.o Diagnostics_Interface.o Sphere_Spectral_Space.o Sphere_Physical_Space.o Sphere_Hybrid_Space.o ClockInfo.o 
+Sphere_Driver.o : Sphere_Driver.F90 Run_Parameters.o Fields.o Timers.o Controls.o Checkpointing.o Spherical_IO.o Diagnostics_Interface.o Sphere_Spectral_Space.o Sphere_Physical_Space.o Sphere_Hybrid_Space.o ClockInfo.o 
 Sphere_Hybrid_Space.o : Sphere_Hybrid_Space.F90 indices.F PDE_Coefficients.o ClockInfo.o Timers.o Fields.o Spectral_Derivatives.o Legendre_Transforms.o Legendre_Polynomials.o ProblemSize.o Controls.o Parallel_Framework.o Load_Balance.o 
 Sphere_Linear_Terms.o : Sphere_Linear_Terms.F90 Math_Constants.o PDE_Coefficients.o ClockInfo.o Timers.o BoundaryConditions.o Fields.o Linear_Solve.o ProblemSize.o Controls.o Load_Balance.o 
 Sphere_Physical_Space.o : Sphere_Physical_Space.F90 indices.F Benchmarking.o Math_Constants.o PDE_Coefficients.o ClockInfo.o Timers.o General_MPI.o Diagnostics_Interface.o Fields.o Spectral_Derivatives.o Fourier_Transform.o ProblemSize.o Controls.o Parallel_Framework.o 

--- a/src/Makefile.fdeps
+++ b/src/Makefile.fdeps
@@ -60,6 +60,7 @@ ProblemSize.o : ProblemSize.F90 Timers.o BufferedOutput.o Math_Constants.o Cheby
 Ra_MPI_Base.o : Ra_MPI_Base.F90 
 Ra_Precision.o : Ra_Precision.F90 
 Run_Param_Header.dbg.o : Run_Param_Header.dbg.F 
+Run_Param_Header.opt.o : Run_Param_Header.opt.F 
 Run_Parameters.o : Run_Parameters.F90 PDE_Coefficients.o TestSuite.o Initial_Conditions.o BoundaryConditions.o Spherical_IO.o ProblemSize.o Parallel_Framework.o Controls.o 
 SendReceive.o : SendReceive.F90 Ra_MPI_Base.o 
 Spectral_Derivatives.o : Spectral_Derivatives.F90 Structures.o 

--- a/src/Makefile.fdeps
+++ b/src/Makefile.fdeps
@@ -1,10 +1,10 @@
 All_to_All.o : All_to_All.F90 Ra_MPI_Base.o 
 Benchmarking.o : Benchmarking.F90 Initial_Conditions.o BoundaryConditions.o Math_Constants.o PDE_Coefficients.o Legendre_Polynomials.o Fields.o Spherical_IO.o Controls.o ProblemSize.o 
-BoundaryConditions.o : BoundaryConditions.F90 Checkpointing.o PDE_Coefficients.o Generic_Input.o Load_Balance.o Fields.o ProblemSize.o Math_Constants.o 
+BoundaryConditions.o : BoundaryConditions.F90 Controls.o Checkpointing.o PDE_Coefficients.o Generic_Input.o Load_Balance.o Fields.o ProblemSize.o Math_Constants.o 
 BufferedOutput.o : BufferedOutput.F90 
 Chebyshev_Polynomials.o : Chebyshev_Polynomials.F90 Structures.o 
 Chebyshev_Polynomials_Alt.o : Chebyshev_Polynomials_Alt.F90 
-Checkpointing.o : Checkpointing.F90 BufferedOutput.o PDE_Coefficients.o MakeDir.o Parallel_IO.o Chebyshev_Polynomials_Alt.o Ra_MPI_Base.o Controls.o Linear_Solve.o Spherical_Buffer.o Parallel_Framework.o ProblemSize.o Timers.o 
+Checkpointing.o : Checkpointing.F90 Load_Balance.o BufferedOutput.o PDE_Coefficients.o MakeDir.o Parallel_IO.o Chebyshev_Polynomials_Alt.o Ra_MPI_Base.o Controls.o Linear_Solve.o Spherical_Buffer.o Parallel_Framework.o ProblemSize.o Timers.o 
 ClockInfo.o : ClockInfo.F90 Controls.o 
 Controls.o : Controls.F90 BufferedOutput.o 
 Diagnostics_ADotGradB.o : Diagnostics_ADotGradB.F90 indices.F Diagnostics_Base.o 

--- a/src/Physics/BoundaryConditions.F90
+++ b/src/Physics/BoundaryConditions.F90
@@ -142,7 +142,7 @@ Contains
             ! Grab the boundary conditions from the checkpoint directory
             ! This will typically be used in full_restart mode.
             Call Load_BC_Mask(bc_values)  ! from checkpointing
-            If (my_rank .eq. 0) Write(6,*)'LOADING IN BCS!'
+
         Endif
     End Subroutine Finalize_Boundary_Conditions
 
@@ -165,7 +165,7 @@ Contains
         !Need to multiply by sqrt(4pi) for ell=0 BCs as a result.
 
         If (.not. full_restart) Then
-            Write(6,*)'Setting BC manually!'
+
             If (fix_tvar_top) Then
                 if (trim(T_top_file) .eq. '__nothing__') then
                   bc_val= T_Top*sqrt(four_pi)

--- a/src/Physics/BoundaryConditions.F90
+++ b/src/Physics/BoundaryConditions.F90
@@ -136,6 +136,16 @@ Contains
 
     End Subroutine Initialize_Boundary_Conditions
 
+    Subroutine Finalize_Boundary_Conditions()
+        Implicit None
+        If (full_restart) Then
+            ! Grab the boundary conditions from the checkpoint directory
+            ! This will typically be used in full_restart mode.
+            Call Load_BC_Mask(bc_values)  ! from checkpointing
+            If (my_rank .eq. 0) Write(6,*)'LOADING IN BCS!'
+        Endif
+    End Subroutine Finalize_Boundary_Conditions
+
     Subroutine Generate_Boundary_Mask()
         Implicit None
         Real*8 :: bc_val
@@ -154,12 +164,8 @@ Contains
         !BC's are specified in physical space, but enforced in spectral space.
         !Need to multiply by sqrt(4pi) for ell=0 BCs as a result.
 
-        If (full_restart) Then
-            ! Grab the boundary conditions from the checkpoint directory
-            ! This will typically be used in full_restart mode.
-            Call Load_BC_Mask(bc_values)  ! from checkpointing
-            If (my_rank .eq. 0) Write(6,*)'LOADING IN BCS!'
-        Else
+        If (.not. full_restart) Then
+            Write(6,*)'Setting BC manually!'
             If (fix_tvar_top) Then
                 if (trim(T_top_file) .eq. '__nothing__') then
                   bc_val= T_Top*sqrt(four_pi)

--- a/src/Physics/BoundaryConditions.F90
+++ b/src/Physics/BoundaryConditions.F90
@@ -29,6 +29,7 @@ Module BoundaryConditions
     Use Generic_Input
     Use PDE_Coefficients
     Use Checkpointing, Only : Store_BC_Mask, Load_BC_Mask
+    Use Controls, Only : full_restart
 
     Implicit None
 
@@ -153,10 +154,11 @@ Contains
         !BC's are specified in physical space, but enforced in spectral space.
         !Need to multiply by sqrt(4pi) for ell=0 BCs as a result.
 
-        If (use_checkpoint_bc_file) Then
+        If (full_restart) Then
             ! Grab the boundary conditions from the checkpoint directory
             ! This will typically be used in full_restart mode.
             Call Load_BC_Mask(bc_values)  ! from checkpointing
+            If (my_rank .eq. 0) Write(6,*)'LOADING IN BCS!'
         Else
             If (fix_tvar_top) Then
                 if (trim(T_top_file) .eq. '__nothing__') then

--- a/src/Physics/BoundaryConditions.F90
+++ b/src/Physics/BoundaryConditions.F90
@@ -28,6 +28,7 @@ Module BoundaryConditions
 
     Use Generic_Input
     Use PDE_Coefficients
+    Use Checkpointing, Only : Store_BC_Mask, Load_BC_Mask
 
     Implicit None
 
@@ -68,6 +69,7 @@ Module BoundaryConditions
     Logical :: no_slip_boundaries = .false. ! Set to true to use no-slip boundaries.  Stree-free boundaries are the default.
     Logical :: stress_free_top = .true., stress_free_bottom = .true.
     Logical :: no_slip_top = .false., no_slip_bottom = .false.
+    Logical :: use_checkpoint_bc_file = .false.
 
     Real*8, allocatable, dimension(:,:,:,:) :: bc_values  ! a 4-D array: (top/bottom, real/imag, my_num_lm, n_equations)
 
@@ -139,6 +141,7 @@ Contains
         Integer :: uind, lind
         Integer :: real_ind, imag_ind
 
+
         allocate(bc_values(2, 2, my_num_lm, n_equations))
         bc_values = zero
 
@@ -150,63 +153,69 @@ Contains
         !BC's are specified in physical space, but enforced in spectral space.
         !Need to multiply by sqrt(4pi) for ell=0 BCs as a result.
 
-        If (fix_tvar_top) Then
-            if (trim(T_top_file) .eq. '__nothing__') then
-              bc_val= T_Top*sqrt(four_pi)
-              Call Set_BC(bc_val,0,0, teq,real_ind, uind)
-            else
-              Call Set_BC_from_file(T_top_file, teq, uind)
-            end if
+        If (use_checkpoint_bc_file) Then
+            ! Grab the boundary conditions from the checkpoint directory
+            ! This will typically be used in full_restart mode.
+            Call Load_BC_Mask(bc_values)  ! from checkpointing
+        Else
+            If (fix_tvar_top) Then
+                if (trim(T_top_file) .eq. '__nothing__') then
+                  bc_val= T_Top*sqrt(four_pi)
+                  Call Set_BC(bc_val,0,0, teq,real_ind, uind)
+                else  
+                  Call Set_BC_from_file(T_top_file, teq, uind)
+                end if
+            Endif
+
+            If (fix_tvar_bottom) Then
+                if (trim(T_bottom_file) .eq. '__nothing__') then
+                  bc_val= T_bottom*sqrt(four_pi)
+                  Call Set_BC(bc_val,0,0, teq,real_ind, lind)
+                else
+                  Call Set_BC_from_file(T_bottom_file, teq, lind)
+                end if
+            Endif
+
+            If (fix_dtdr_top) Then
+                if (trim(dTdr_top_file) .eq. '__nothing__') then
+                  bc_val= dtdr_top*sqrt(four_pi)
+                  Call Set_BC(bc_val,0,0, teq,real_ind, uind)
+                else
+                  Call Set_BC_from_file(dTdr_top_file, teq, uind)
+                end if
+            Endif
+
+            If (fix_dtdr_bottom) Then
+                if (trim(dTdr_bottom_file) .eq. '__nothing__') then
+                  bc_val= dtdr_bottom*sqrt(four_pi)
+                  Call Set_BC(bc_val,0,0, teq,real_ind, lind)
+                else
+                  Call Set_BC_from_file(dTdr_bottom_file, teq, lind)
+                end if
+            Endif
+
+            If (fix_poloidalfield_top) Then
+                if (trim(C_top_file) .eq. '__nothing__') then
+                  Call Set_BC(C10_top ,1,0,ceq,real_ind,uind)
+                  Call Set_BC(C11_top ,1,1,ceq,real_ind,uind)
+                  Call Set_BC(C1m1_top,1,1,ceq,imag_ind,uind)
+                else
+                  Call Set_BC_from_file(C_top_file, ceq, uind)
+                end if
+            Endif        
+
+            If (fix_poloidalfield_bottom) Then
+                if (trim(C_bottom_file) .eq. '__nothing__') then
+                  Call Set_BC(C10_bottom ,1,0,ceq,real_ind,lind)
+                  Call Set_BC(C11_bottom ,1,1,ceq,real_ind,lind)
+                  Call Set_BC(C1m1_bottom,1,1,ceq,imag_ind,lind)
+                else
+                  Call Set_BC_from_file(C_bottom_file, ceq, lind)
+                end if
+            Endif   
+
         Endif
-
-        If (fix_tvar_bottom) Then
-            if (trim(T_bottom_file) .eq. '__nothing__') then
-              bc_val= T_bottom*sqrt(four_pi)
-              Call Set_BC(bc_val,0,0, teq,real_ind, lind)
-            else
-              Call Set_BC_from_file(T_bottom_file, teq, lind)
-            end if
-        Endif
-
-        If (fix_dtdr_top) Then
-            if (trim(dTdr_top_file) .eq. '__nothing__') then
-              bc_val= dtdr_top*sqrt(four_pi)
-              Call Set_BC(bc_val,0,0, teq,real_ind, uind)
-            else
-              Call Set_BC_from_file(dTdr_top_file, teq, uind)
-            end if
-        Endif
-
-        If (fix_dtdr_bottom) Then
-            if (trim(dTdr_bottom_file) .eq. '__nothing__') then
-              bc_val= dtdr_bottom*sqrt(four_pi)
-              Call Set_BC(bc_val,0,0, teq,real_ind, lind)
-            else
-              Call Set_BC_from_file(dTdr_bottom_file, teq, lind)
-            end if
-        Endif
-
-        If (fix_poloidalfield_top) Then
-            if (trim(C_top_file) .eq. '__nothing__') then
-              Call Set_BC(C10_top ,1,0,ceq,real_ind,uind)
-              Call Set_BC(C11_top ,1,1,ceq,real_ind,uind)
-              Call Set_BC(C1m1_top,1,1,ceq,imag_ind,uind)
-            else
-              Call Set_BC_from_file(C_top_file, ceq, uind)
-            end if
-        Endif        
-
-        If (fix_poloidalfield_bottom) Then
-            if (trim(C_bottom_file) .eq. '__nothing__') then
-              Call Set_BC(C10_bottom ,1,0,ceq,real_ind,lind)
-              Call Set_BC(C11_bottom ,1,1,ceq,real_ind,lind)
-              Call Set_BC(C1m1_bottom,1,1,ceq,imag_ind,lind)
-            else
-              Call Set_BC_from_file(C_bottom_file, ceq, lind)
-            end if
-        Endif   
-
-
+        Call Store_BC_Mask(bc_values)  ! to checkpointing
     End Subroutine Generate_Boundary_Mask
 
     Subroutine Set_BC(inval,ellval,emval,eqval,imi,bound_ind)

--- a/src/Physics/Checkpointing.F90
+++ b/src/Physics/Checkpointing.F90
@@ -604,4 +604,15 @@ Contains
         Endif
     End Subroutine
 
+    Subroutine Store_BC_Mask(bvals)
+        Implicit None
+        Real*8, Intent(In) :: bvals(:,:,:,:)
+    End Subroutine Store_BC_Mask
+
+    Subroutine Load_BC_Mask(bvals)
+        Implicit None
+        Real*8, Intent(Out) :: bvals(:,:,:,:)
+
+    End Subroutine Load_BC_Mask
+
 End Module Checkpointing

--- a/src/Physics/Checkpointing.F90
+++ b/src/Physics/Checkpointing.F90
@@ -36,6 +36,7 @@ Module Checkpointing
     Implicit None
     Type(SphericalBuffer) :: chktmp, chktmp2
     Integer, private :: numfields = 4 ! 6 for MHD
+    Integer, private :: check_err_off = 100  ! Checkpoint errors report in range 100-200.
     Integer,private,Allocatable :: mode_count(:)
     Integer,private :: checkpoint_tag = 425, read_var(1:12)
     Integer, Allocatable, Private :: lmstart(:)
@@ -269,19 +270,24 @@ Contains
                 grid_file = Trim(checkpoint_prefix)//under_slash//'grid_etc'
                 Inquire(File=grid_file, Exist=fexist)       
                 If (fexist) Then
+                    Call stdout%print(' ')
                     Call stdout%print(' ------ Legacy checkpoint format detected. ')
+                    Call stdout%print(' ')
                 Endif     
             Endif
             If (fexist) Then
                 Open(newunit=funit,file=grid_file,form='unformatted', status='old',&
                      access=access_type, iostat=ierr)
                 If (ierr .ne. 0) Then
+                    Call stdout%print(' ')
                     Call stdout%print(' ------ Error: Failed to open '//TRIM(grid_file)//'.')
                     Call stdout%print(' ')
                     ierr = 2 ! grid file could not be opened
                 Endif
             Else
-                Call stdout%print(' ------ Error: '//TRIM(grid_file)//' does not exist.')
+                Call stdout%print(' ')
+                Call stdout%print(' ------ Error: Could not find '//Trim(checkpoint_prefix)//'/grid_etc')
+                Call stdout%print(' ------        or '//TRIM(grid_file)//'.')
                 Call stdout%print(' ')
                 ierr = 1 ! grid_file did not exist
             Endif
@@ -307,6 +313,7 @@ Contains
                     Endif
                     Close(funit)
                 Else
+                    Call stdout%print(' ')
                     Call stdout%print(' ------ Error: Endian-check failed when reading '//TRIM(grid_file)//'.')
                     Call stdout%print(' ')
                     ierr = 3
@@ -369,7 +376,7 @@ Contains
                 Call stdout%print(' ------ Exiting...')
                 Call stdout%print(' ')
             Endif
-            Call pfi%exit(old_pars(7))
+            Call pfi%exit(check_err_off+old_pars(7))
         Endif
 
 

--- a/src/Physics/Checkpointing.F90
+++ b/src/Physics/Checkpointing.F90
@@ -331,8 +331,12 @@ Contains
                 endian_tag=0
                 If (.not. legacy_format) Read(funit)endian_tag
                 If (legacy_format .or. (endian_tag .eq. 314)) Then
-                    If (.not. legacy_format) Read(funit)version
-                    Read(funit)n_r_old
+                    If (.not. legacy_format) Then
+                        Read(funit)version
+                        Read(funit)n_r_old
+                    Else
+                        Read(funit)n_r_old
+                    Endif
                     Read(funit)grid_type_old
                     Read(funit)l_max_old
                     Read(funit)dt
@@ -359,6 +363,7 @@ Contains
             If (ierr .eq. 0) Then
                 ! Verify that all checkpoint files exist and  have the correct size.
                 expected_bytes = n_r_old*((l_max_old+1)**2 + l_max_old+1)*8 !TODO: Make this work for general precision
+                write(6,*)'check: ', endian_tag, version, n_r_old
                 Do i = 1, numfields*2
                     If (read_var(i) .eq. 1) Then
                         checkfile = trim(checkpoint_prefix)//under_slash//trim(checkpoint_suffix(i))

--- a/src/Physics/Checkpointing.F90
+++ b/src/Physics/Checkpointing.F90
@@ -150,7 +150,7 @@ Contains
 
             cfile = Trim(my_path)//trim(checkpoint_prefix)//'/'//'grid_etc'
 
-            open(unit=15,file=cfile,form='unformatted', status='replace')
+            open(unit=15,file=cfile,form='unformatted', status='replace', access='stream')
             Write(15)n_r
             Write(15)grid_type
             Write(15)l_max
@@ -209,7 +209,7 @@ Contains
         checkpoint_iter = iteration
         
         under_slash='/'      ! '_' underscore for legacy mode checkpoints
-        access_type='sequential' ! 'sequential' for legacy mode <--- set to stream
+        access_type='stream' ! 'sequential' for legacy mode <--- set to stream
         legacy_mode=.false.
 
         read_var(:) = 0
@@ -264,11 +264,12 @@ Contains
                 under_slash='_'
                 grid_file = Trim(checkpoint_prefix)//under_slash//'grid_etc'
                 Inquire(File=grid_file, Exist=fexist)            
+                access_type='sequential'
             Endif
             If (fexist) Then
-                Write(6,*)'Grid file used is: ', grid_file
+                Write(6,*)'Grid file used is: ', grid_file, access_type
                 Open(unit=15,file=grid_file,form='unformatted', status='old',&
-                     access=access_type, iostat=ierr)
+                     access='stream', iostat=ierr)
                 If (ierr .ne. 0) Then
                     ierr = 2 ! grid file could not be opened
                 Endif
@@ -293,9 +294,9 @@ Contains
                     old_pars(4) = Checkpoint_iter
                 Endif
                 Close(15)
-            Endif
-                old_pars(1) = -ierr
             Else
+                old_pars(1) = -ierr
+            Endif
             Write(dstring,sci_note_fmt)checkpoint_time
             Call stdout%print(' ------ Checkpoint time is: '//trim(dstring))
             old_pars(1) = n_r_old

--- a/src/Physics/Checkpointing.F90
+++ b/src/Physics/Checkpointing.F90
@@ -185,6 +185,7 @@ Contains
 
             Open(unit=15,file=cfile,form='unformatted', status='replace', access='stream')
             Write(15)endian_tag
+            Write(15)checkpoint_version
             Write(15)n_r
             Write(15)grid_type
             Write(15)l_max
@@ -225,7 +226,7 @@ Contains
         Real*8, Intent(InOut) :: fields(:,:,:,:), abterms(:,:,:,:)
         Integer :: n_r_old, l_max_old, grid_type_old, nr_read
         Integer :: i, ierr, m, p, np, mp, lb,ub, f,  r, ind
-        Integer :: old_pars(7), fcount(3,2)
+        Integer :: old_pars(7), fcount(3,2), version
         Integer :: last_iter, last_auto, endian_tag, funit
         Integer*8 :: found_bytes, expected_bytes
         Integer :: read_magnetism = 0, read_hydro = 0
@@ -330,6 +331,7 @@ Contains
                 endian_tag=0
                 If (.not. legacy_format) Read(funit)endian_tag
                 If (legacy_format .or. (endian_tag .eq. 314)) Then
+                    If (.not. legacy_format) Read(funit)version
                     Read(funit)n_r_old
                     Read(funit)grid_type_old
                     Read(funit)l_max_old
@@ -516,7 +518,6 @@ Contains
 
         If (.not. legacy_format) Then
             ! Load the boundary values array
-            If (my_rank .eq. 0) Write(6,*)'Reading Boundary Conditions File!'
 
             Call bctmp%construct('s2b')
             bctmp%config = 's2b'

--- a/src/Physics/Controls.F90
+++ b/src/Physics/Controls.F90
@@ -138,6 +138,8 @@ Module Controls
     Real*8 :: kill_signal = 0.0d0  ! Signal will be passed in Real*8 buffer, but should be integer-like
     Integer :: nglobal_msgs = 5  ! timestep, elapsed since checkpoint, kill_signal/global message, simulation time, terminate file found
 
+    Logical :: full_restart = .false.  ! Set to true if a full-restart is initiated from the command line
+
 Contains
     Subroutine Initialize_Controls()
         Implicit None

--- a/src/Physics/Input.F90
+++ b/src/Physics/Input.F90
@@ -25,7 +25,8 @@ Module Input
                              physical_controls_namelist, max_iterations, pad_alltoall, &
                              multi_run_mode, nruns, rundirs, my_path, run_cpus, &
                              io_controls_namelist, new_iteration, jobinfo_file, my_sim_id, &
-                             integer_input_digits, int_in_fmt, initialize_io_format_codes
+                             integer_input_digits, int_in_fmt, initialize_io_format_codes, &
+                             full_restart
     Use Spherical_IO, Only : output_namelist
     Use BoundaryConditions, Only : boundary_conditions_namelist, T_top_file, T_bottom_file, &
                                    dTdr_top_file, dTdr_bottom_file, C_Top_File, C_Bottom_File
@@ -58,7 +59,7 @@ Contains
         Character*120 :: input_file, iter_string, input_prefix, res_eq_file
         Character(len=:), Allocatable :: input_as_string(:)
         Type(Communicator) :: sim_comm
-        Logical :: read_complete, full_restart
+        Logical :: read_complete
         input_file = Trim(my_path)//'main_input'
 
         ! Check command line to see if this is a full restart,

--- a/src/Physics/Input.F90
+++ b/src/Physics/Input.F90
@@ -69,7 +69,7 @@ Contains
 
         full_restart=.false.
         Call Read_CMD_Line('-full_restart' , full_restart_iter)
-        If (my_rank .eq. 0) Write(6,*)'full restart: ', full_restart_iter
+
         If (full_restart_iter .ne. 0) Then
             full_restart = .true.
             If (full_restart_iter .lt. 0) Then
@@ -86,7 +86,7 @@ Contains
             Endif
             res_eq_file = TRIM(input_prefix)//'/equation_coefficients'
             input_file = TRIM(input_prefix)//'/main_input'
-            If (my_rank .eq. 0) Write(6,*)'Input file is: ', input_file
+            If (global_rank .eq. 0) Write(6,*)'Input file is: ', input_file
 
         Endif
 

--- a/src/Physics/Input.F90
+++ b/src/Physics/Input.F90
@@ -53,7 +53,7 @@ Contains
         Use RA_MPI_Base
         Use MPI_Layer
         Implicit None
-        Integer :: nlines, line_len,  ierr, pars(2), full_restart_iter
+        Integer :: nlines, line_len,  ierr, pars(2), full_restart_iter, isave
         Character*120 :: input_file, iter_string, input_prefix, res_eq_file
         Character(len=:), Allocatable :: input_as_string(:)
         Type(Communicator) :: sim_comm
@@ -76,6 +76,7 @@ Contains
                 ! We may be restarting from a checkpoint written with 
                 ! more/less than the default 8 digits.
                 Call Read_CMD_Line('-input_digits',integer_input_digits)
+                isave = integer_input_digits
                 Call Initialize_IO_Format_Codes()
                 Write(iter_string,int_in_fmt) full_restart_iter
                 input_prefix= Trim(my_path)//'Checkpoints/'//TRIM(iter_string)
@@ -140,6 +141,7 @@ Contains
             magnetic_init_type=-1
             restart_iter = full_restart_iter
             custom_reference_file = res_eq_file
+            integer_input_digits = isave
             Write(6,*)'custom ref file is: ', custom_reference_file
         Endif
 

--- a/src/Physics/Input.F90
+++ b/src/Physics/Input.F90
@@ -86,7 +86,7 @@ Contains
             Endif
             res_eq_file = TRIM(input_prefix)//'/equation_coefficients'
             input_file = TRIM(input_prefix)//'/main_input'
-            If (global_rank .eq. 0) Write(6,*)'Input file is: ', input_file
+            
 
         Endif
 
@@ -148,8 +148,9 @@ Contains
             custom_reference_file = res_eq_file
             integer_input_digits = isave
             If (global_rank .eq. 0) Then
-                Write(6,*)'Full_restart is true.  Custom reference file is: ', &
-                       custom_reference_file
+                Write(6,*)'Initializing in full-restart mode.'
+                Write(6,*)'Input file: ', input_file
+                Write(6,*)'Equation coefficients file: ' , custom_reference_file
             Endif
         Endif
 

--- a/src/Physics/Input.F90
+++ b/src/Physics/Input.F90
@@ -20,11 +20,12 @@
 
 Module Input
     Use ProblemSize,  Only : problemsize_namelist, nprow, npcol, n_r,n_theta, npout, global_rank, &
-                             & ncpu_global, aspect_ratio, l_max
+                             ncpu_global, aspect_ratio, l_max
     Use Controls,     Only : temporal_controls_namelist, numerical_controls_namelist, &
-                            & physical_controls_namelist, max_iterations, pad_alltoall, &
-                            & multi_run_mode, nruns, rundirs, my_path, run_cpus, &
-                            & io_controls_namelist, new_iteration, jobinfo_file, my_sim_id
+                             physical_controls_namelist, max_iterations, pad_alltoall, &
+                             multi_run_mode, nruns, rundirs, my_path, run_cpus, &
+                             io_controls_namelist, new_iteration, jobinfo_file, my_sim_id, &
+                             integer_input_digits, int_in_fmt, initialize_io_format_codes
     Use Spherical_IO, Only : output_namelist
     Use BoundaryConditions, Only : boundary_conditions_namelist
     Use Initial_Conditions, Only : initial_conditions_namelist, alt_check, init_type, &
@@ -53,7 +54,7 @@ Contains
         Use MPI_Layer
         Implicit None
         Integer :: nlines, line_len,  ierr, pars(2), full_restart_iter
-        Character*120 :: input_file, auto_string, input_prefix, res_eq_file
+        Character*120 :: input_file, iter_string, input_prefix, res_eq_file
         Character(len=:), Allocatable :: input_as_string(:)
         Type(Communicator) :: sim_comm
         Logical :: read_complete, full_restart
@@ -62,15 +63,22 @@ Contains
         ! Check command line to see if this is a full restart,
         ! in which case all input comes from checkpoint directory.    
         restart_iter = 0
+
         full_restart=.false.
         Call Read_CMD_Line('-full_restart' , full_restart_iter)
         Write(6,*)'full restart: ', full_restart_iter
         If (full_restart_iter .ne. 0) Then
             full_restart = .true.
             If (full_restart_iter .lt. 0) Then
-                Write(auto_string,auto_fmt) -full_restart_iter
-                input_prefix= Trim(my_path)//'Checkpoints/quicksave_'//TRIM(auto_string)
-
+                Write(iter_string,auto_fmt) -full_restart_iter
+                input_prefix= Trim(my_path)//'Checkpoints/quicksave_'//TRIM(iter_string)
+            Else
+                ! We may be restarting from a checkpoint written with 
+                ! more/less than the default 8 digits.
+                Call Read_CMD_Line('-input_digits',integer_input_digits)
+                Call Initialize_IO_Format_Codes()
+                Write(iter_string,int_in_fmt) full_restart_iter
+                input_prefix= Trim(my_path)//'Checkpoints/'//TRIM(iter_string)
             Endif
             res_eq_file = TRIM(input_prefix)//'/equation_coefficients'
             input_file = TRIM(input_prefix)//'/main_input'

--- a/src/Physics/Input.F90
+++ b/src/Physics/Input.F90
@@ -55,11 +55,12 @@ Contains
         Use RA_MPI_Base
         Use MPI_Layer
         Implicit None
-        Integer :: nlines, line_len,  ierr, pars(2), full_restart_iter, isave
+        Integer :: nlines, line_len,  ierr, pars(2), isave
         Character*120 :: input_file, iter_string, input_prefix, res_eq_file
         Character(len=:), Allocatable :: input_as_string(:)
         Type(Communicator) :: sim_comm
         Logical :: read_complete
+        Integer :: full_restart_iter=0
         input_file = Trim(my_path)//'main_input'
 
         ! Check command line to see if this is a full restart,

--- a/src/Physics/Input.F90
+++ b/src/Physics/Input.F90
@@ -69,7 +69,7 @@ Contains
 
         full_restart=.false.
         Call Read_CMD_Line('-full_restart' , full_restart_iter)
-        Write(6,*)'full restart: ', full_restart_iter
+        If (my_rank .eq. 0) Write(6,*)'full restart: ', full_restart_iter
         If (full_restart_iter .ne. 0) Then
             full_restart = .true.
             If (full_restart_iter .lt. 0) Then
@@ -86,7 +86,7 @@ Contains
             Endif
             res_eq_file = TRIM(input_prefix)//'/equation_coefficients'
             input_file = TRIM(input_prefix)//'/main_input'
-            Write(6,*)'Input file is: ', input_file
+            If (my_rank .eq. 0) Write(6,*)'Input file is: ', input_file
 
         Endif
 
@@ -147,7 +147,8 @@ Contains
             restart_iter = full_restart_iter
             custom_reference_file = res_eq_file
             integer_input_digits = isave
-            Write(6,*)'custom ref file is: ', custom_reference_file
+            Write(6,*)'Full_restart is true.  Custom reference file is: ', &
+                       custom_reference_file
 
         Endif
 

--- a/src/Physics/Input.F90
+++ b/src/Physics/Input.F90
@@ -87,6 +87,7 @@ Contains
             res_eq_file = TRIM(input_prefix)//'/equation_coefficients'
             input_file = TRIM(input_prefix)//'/main_input'
             Write(6,*)'Input file is: ', input_file
+
         Endif
 
         ! For multi-run mode, we need a unique communicator for each run before the read/broadcast.
@@ -147,24 +148,6 @@ Contains
             custom_reference_file = res_eq_file
             integer_input_digits = isave
             Write(6,*)'custom ref file is: ', custom_reference_file
-
-            If (trim(T_top_file) .ne. '__nothing__') &
-                T_top_file=TRIM(input_prefix)//'/T_top_BC'
-
-            If (trim(T_bottom_file) .ne. '__nothing__') &
-                T_top_file=TRIM(input_prefix)//'/T_bottom_BC'
-
-            If (trim(dTdr_top_file) .ne. '__nothing__') &
-                T_top_file=TRIM(input_prefix)//'/dTdr_top_BC'
-
-            If (trim(dTdr_bottom_file) .ne. '__nothing__') &
-                T_top_file=TRIM(input_prefix)//'/dTdr_bottom_BC'
-
-            If (trim(C_top_file) .ne. '__nothing__') &
-                T_top_file=TRIM(input_prefix)//'/C_top_BC'
-
-            If (trim(C_bottom_file) .ne. '__nothing__') &
-                T_top_file=TRIM(input_prefix)//'/C_bottom_BC'
 
         Endif
 

--- a/src/Physics/Input.F90
+++ b/src/Physics/Input.F90
@@ -27,7 +27,8 @@ Module Input
                              io_controls_namelist, new_iteration, jobinfo_file, my_sim_id, &
                              integer_input_digits, int_in_fmt, initialize_io_format_codes
     Use Spherical_IO, Only : output_namelist
-    Use BoundaryConditions, Only : boundary_conditions_namelist
+    Use BoundaryConditions, Only : boundary_conditions_namelist, T_top_file, T_bottom_file, &
+                                   dTdr_top_file, dTdr_bottom_file, C_Top_File, C_Bottom_File
     Use Initial_Conditions, Only : initial_conditions_namelist, alt_check, init_type, &
                                    magnetic_init_type, restart_iter
     Use TestSuite, Only : test_namelist
@@ -136,6 +137,7 @@ Contains
 
         ! Finally, if this is a full restart, make sure we actually restart 
         ! using only data from the desired checkpoint directory.
+        ! This entails repointing a few file names and input_flags.
         If (full_restart) Then
             init_type=-1
             magnetic_init_type=-1
@@ -143,6 +145,25 @@ Contains
             custom_reference_file = res_eq_file
             integer_input_digits = isave
             Write(6,*)'custom ref file is: ', custom_reference_file
+
+            If (trim(T_top_file) .ne. '__nothing__') &
+                T_top_file=TRIM(input_prefix)//'/T_top_BC'
+
+            If (trim(T_bottom_file) .ne. '__nothing__') &
+                T_top_file=TRIM(input_prefix)//'/T_bottom_BC'
+
+            If (trim(dTdr_top_file) .ne. '__nothing__') &
+                T_top_file=TRIM(input_prefix)//'/dTdr_top_BC'
+
+            If (trim(dTdr_bottom_file) .ne. '__nothing__') &
+                T_top_file=TRIM(input_prefix)//'/dTdr_bottom_BC'
+
+            If (trim(C_top_file) .ne. '__nothing__') &
+                T_top_file=TRIM(input_prefix)//'/C_top_BC'
+
+            If (trim(C_bottom_file) .ne. '__nothing__') &
+                T_top_file=TRIM(input_prefix)//'/C_bottom_BC'
+
         Endif
 
         DeAllocate(input_as_string)

--- a/src/Physics/Input.F90
+++ b/src/Physics/Input.F90
@@ -147,9 +147,10 @@ Contains
             restart_iter = full_restart_iter
             custom_reference_file = res_eq_file
             integer_input_digits = isave
-            Write(6,*)'Full_restart is true.  Custom reference file is: ', &
+            If (global_rank .eq. 0) Then
+                Write(6,*)'Full_restart is true.  Custom reference file is: ', &
                        custom_reference_file
-
+            Endif
         Endif
 
         DeAllocate(input_as_string)

--- a/src/Physics/Main.F90
+++ b/src/Physics/Main.F90
@@ -96,6 +96,9 @@ Contains
         Call Linear_Init()
 
         Call Initialize_Fields()
+       
+        Call Finalize_Boundary_Conditions()
+
         Call StopWatch(init_time)%increment() ! started in Init_Problemsize just after MPI is started up
 
         If (my_rank .eq. 0) Then

--- a/src/Physics/Main.F90
+++ b/src/Physics/Main.F90
@@ -83,7 +83,7 @@ Contains
         Call Initialize_Reference()
 
         Call Initialize_Field_Structure()
-
+        Call Initialize_Checkpointing()
         Call Initialize_Boundary_Conditions()
         Call Initialize_Transport_Coefficients()
 
@@ -94,7 +94,7 @@ Contains
         Call Full_Barrier()
 
         Call Linear_Init()
-        Call Initialize_Checkpointing()
+
         Call Initialize_Fields()
         Call StopWatch(init_time)%increment() ! started in Init_Problemsize just after MPI is started up
 

--- a/src/Physics/PDE_Coefficients.F90
+++ b/src/Physics/PDE_Coefficients.F90
@@ -901,7 +901,7 @@ Contains
                        ref_arr_old(1:n_r,1:n_ra_functions)
 
                 If (my_rank .eq. 0) Then
-                    call stdout%print("WARNING:  nr = nr_old.  Assuming grids are the same.")
+                    call stdout%print(" WARNING:  nr = nr_old.  Assuming grids are the same.")
                 Endif
             Endif
             DeAllocate(ref_arr_old,old_radius)

--- a/src/Physics/Run_Parameters.F90
+++ b/src/Physics/Run_Parameters.F90
@@ -29,7 +29,7 @@ Module Run_Parameters
 
 Contains
 
-    Subroutine Write_Run_Parameters()
+    Subroutine Write_Run_Parameters(checkpoint_input_file)
 
         Use Controls, Only : my_path, magnetism, jobinfo_file
         Use Controls, Only : numerical_controls_namelist, physical_controls_namelist, &
@@ -53,8 +53,11 @@ Contains
         Character(len=16 ) :: date, time, zone_in
         Integer :: values(8)
         Integer :: io, ierr, i
-        Logical :: file_exist
+        Logical :: file_exist, write_header
         Integer :: ntrim = 4
+        Character*256, Intent(In), Optional :: checkpoint_input_file
+
+        write_header = .true.
 
         Call Date_and_Time(date, time, zone_in, values) ! get current date/time
 
@@ -67,119 +70,129 @@ Contains
         1005 Format (a,ES11.4)
 
         If (my_rank .eq. 0) Then
-            Inquire(file=Trim(my_path)//Trim(jobinfo_file), exist=file_exist)
-            Open(unit=io, file=Trim(my_path)//Trim(jobinfo_file), form='formatted', &
-               action='write', access='sequential', status='unknown', iostat=ierr)
-            If (ierr .eq. 0) Then
-                Write(io,*)
-                Write(io,999)
-                Write(io,*) "Job Information"
-                Write(io,999)
-                Write(io,1003) "Date = ", values(1), values(2), values(3)
-                Write(io,1004) "Time = ", values(5), values(6), values(7)
-                Write(io,1001) "Path = ", Trim(my_path)
-                Write(io,*)
-                Write(io,999)
-                Write(io,*) "Compiler Information"
-                Write(io,999)
 
-                ! the string slicing is to remove the beginning "---short_name---"
-                ! as well as the trailing "---Char(0)"
-                Write(io,1001) "Compiler Location = ", &
-                             Trim(FC_location(18:Len_Trim(FC_location)-ntrim))
-                Write(io,1001) "Compiler Version  = ", &
-                             Trim(FC_version(17:Len_Trim(FC_version)-ntrim))
-                Write(io,*)
-                Write(io,1001) "Compiler Flags    = ", &
-                             Trim(build_fflags(19:Len_Trim(build_fflags)-ntrim))
-                Write(io,1001) "Compiler Library  = ", &
-                             Trim(build_lib(16:Len_Trim(build_lib)-ntrim))
-                Write(io,*)
-                Write(io,999)
-                Write(io,*) "Build Information"
-                Write(io,999)
-                Write(io,1001) "Build Date       = ", &
-                             Trim(build_date(17:Len_trim(build_date)-ntrim))
-                Write(io,1001) "Build Machine    = ", &
-                             Trim(build_machine(20:Len_trim(build_machine)-ntrim))
-                Write(io,1001) "Build Directory  = ", &
-                             Trim(build_dir(16:Len_trim(build_dir)-ntrim))
-                Write(io,1001) "Custom Directory = ", &
-                             Trim(build_custom_dir(17:Len_trim(build_custom_dir)-ntrim))
-                Write(io,*)
-                Write(io,1001) "Build Version = ", &
-                             Trim(build_version(20:Len_trim(build_version)-ntrim))
-                Write(io,1001) "Git Hash = ", &
-                             Trim(build_git_commit(15:Len_trim(build_git_commit)-ntrim))
-                Write(io,1001) "Git URL = ", &
-                             Trim(build_git_url(14:Len_trim(build_git_url)-ntrim))
-                Write(io,1001) "Git Branch = ", &
-                             Trim(build_git_branch(17:Len_trim(build_git_branch)-ntrim))
-                Write(io,*)
+            If (.not. present(checkpoint_input_file)) Then
+                Inquire(file=Trim(my_path)//Trim(jobinfo_file), exist=file_exist)
+                Open(unit=io, file=Trim(my_path)//Trim(jobinfo_file), form='formatted', &
+                   action='write', access='sequential', status='unknown', iostat=ierr)
+            Else
+                Open(unit=io, file=checkpoint_input_file, form='formatted', &
+                   action='write', access='sequential', status='unknown', iostat=ierr)
+                write_header = .false.
+            Endif
 
-                Write(io,999)
-                Write(io,*) "Preamble Information"
-                Write(io,999)
-                Write(io,*) "MPI"
-                Write(io,1002) "    NCPU  : ", pfi%wcomm%np
-                Write(io,1002) "    NPROW : ", nprow
-                Write(io,1002) "    NPCOL : ", npcol
-                Write(io,*)
-                Write(io,*) "Grid"
-                Write(io,1002) "    N_R                : ", n_r
-                Write(io,1002) "    N_THETA            : ", n_theta
-                Write(io,1002) "    Ell_MAX            : ", l_max
-                Write(io,1005) "    R_MIN              : ", rmin
-                Write(io,1005) "    R_MAX              : ", rmax
-                Write(io,1002) "    Chebyshev Domains  : ", ndomains
-                Write(io,*)
-                Do i=1,ndomains
-                    Write(io,1002) "      Domain ", i
-                    Write(io,1002) "        Grid points           : ", ncheby(i)
-                    If (dealias_by(i) .eq. -1) Then
-                        Write(io,1002) "        Dealiased Polynomials : ", (ncheby(i)*2)/3
-                    Else
-                        Write(io,1002) "        Dealiased Polynomials : ", ncheby(i)-dealias_by(i)
+            If ( ierr .eq. 0 ) Then
+                If (write_header) Then
+                    Write(io,*)
+                    Write(io,999)
+                    Write(io,*) "Job Information"
+                    Write(io,999)
+                    Write(io,1003) "Date = ", values(1), values(2), values(3)
+                    Write(io,1004) "Time = ", values(5), values(6), values(7)
+                    Write(io,1001) "Path = ", Trim(my_path)
+                    Write(io,*)
+                    Write(io,999)
+                    Write(io,*) "Compiler Information"
+                    Write(io,999)
+
+                    ! the string slicing is to remove the beginning "---short_name---"
+                    ! as well as the trailing "---Char(0)"
+                    Write(io,1001) "Compiler Location = ", &
+                                 Trim(FC_location(18:Len_Trim(FC_location)-ntrim))
+                    Write(io,1001) "Compiler Version  = ", &
+                                 Trim(FC_version(17:Len_Trim(FC_version)-ntrim))
+                    Write(io,*)
+                    Write(io,1001) "Compiler Flags    = ", &
+                                 Trim(build_fflags(19:Len_Trim(build_fflags)-ntrim))
+                    Write(io,1001) "Compiler Library  = ", &
+                                 Trim(build_lib(16:Len_Trim(build_lib)-ntrim))
+                    Write(io,*)
+                    Write(io,999)
+                    Write(io,*) "Build Information"
+                    Write(io,999)
+                    Write(io,1001) "Build Date       = ", &
+                                 Trim(build_date(17:Len_trim(build_date)-ntrim))
+                    Write(io,1001) "Build Machine    = ", &
+                                 Trim(build_machine(20:Len_trim(build_machine)-ntrim))
+                    Write(io,1001) "Build Directory  = ", &
+                                 Trim(build_dir(16:Len_trim(build_dir)-ntrim))
+                    Write(io,1001) "Custom Directory = ", &
+                                 Trim(build_custom_dir(17:Len_trim(build_custom_dir)-ntrim))
+                    Write(io,*)
+                    Write(io,1001) "Build Version = ", &
+                                 Trim(build_version(20:Len_trim(build_version)-ntrim))
+                    Write(io,1001) "Git Hash = ", &
+                                 Trim(build_git_commit(15:Len_trim(build_git_commit)-ntrim))
+                    Write(io,1001) "Git URL = ", &
+                                 Trim(build_git_url(14:Len_trim(build_git_url)-ntrim))
+                    Write(io,1001) "Git Branch = ", &
+                                 Trim(build_git_branch(17:Len_trim(build_git_branch)-ntrim))
+                    Write(io,*)
+
+                    Write(io,999)
+                    Write(io,*) "Preamble Information"
+                    Write(io,999)
+                    Write(io,*) "MPI"
+                    Write(io,1002) "    NCPU  : ", pfi%wcomm%np
+                    Write(io,1002) "    NPROW : ", nprow
+                    Write(io,1002) "    NPCOL : ", npcol
+                    Write(io,*)
+                    Write(io,*) "Grid"
+                    Write(io,1002) "    N_R                : ", n_r
+                    Write(io,1002) "    N_THETA            : ", n_theta
+                    Write(io,1002) "    Ell_MAX            : ", l_max
+                    Write(io,1005) "    R_MIN              : ", rmin
+                    Write(io,1005) "    R_MAX              : ", rmax
+                    Write(io,1002) "    Chebyshev Domains  : ", ndomains
+                    Write(io,*)
+                    Do i=1,ndomains
+                        Write(io,1002) "      Domain ", i
+                        Write(io,1002) "        Grid points           : ", ncheby(i)
+                        If (dealias_by(i) .eq. -1) Then
+                            Write(io,1002) "        Dealiased Polynomials : ", (ncheby(i)*2)/3
+                        Else
+                            Write(io,1002) "        Dealiased Polynomials : ", ncheby(i)-dealias_by(i)
+                        Endif
+                        Write(io,1005) "        Domain Lower Bound    : ", domain_bounds(i)
+                        Write(io,1005) "        Domain Upper Bound    : ", domain_bounds(i+1)
+                    Enddo
+                    Write(io,*)
+                    Write(io,*) "Reference State"
+                    If (reference_type .eq. 1) Then
+                        Write(io,1001) "    Reference type          : ", "Boussinesq (Non-dimensional)"
+                        Write(io,1005) "    Rayleigh Number         : ", Rayleigh_Number
+                        Write(io,1005) "    Ekman Number            : ", Ekman_Number
+                        Write(io,1005) "    Prandtl Number          : ", Prandtl_Number
+                        If (magnetism) Then
+                            Write(io,1005) "    Magnetic Prandtl Number : ", Magnetic_Prandtl_Number
+                        Endif
+                    Else If (reference_type .eq. 2) Then
+                        Write(io,1001) "    Reference type           : ", "Polytrope (Non-dimensional)"
+                        Write(io,1005) "    Modified Rayleigh Number : ", Rayleigh_Number
+                        Write(io,1005) "    Ekman Number             : ", Ekman_Number
+                        Write(io,1005) "    Prandtl Number           : ", Prandtl_Number
+                        If (magnetism) Then
+                            Write(io,1005) "    Magnetic Prandtl Number  : ", Magnetic_Prandtl_Number
+                        Endif
+                        Write(io,1005) "    Polytropic Index         : ", poly_n
+                        Write(io,1005) "    Density Scaleheights     : ", poly_nrho
+                    Else If (reference_type .eq. 3) Then
+                        Write(io,1001) "    Reference type                : ", "Polytrope (Dimensional)"
+                        Write(io,1005) "    Angular Velocity (rad/s)      : ", Angular_Velocity
+                        Write(io,1005) "    Inner-Radius Density (g/cm^3) : ", poly_rho_i
+                        Write(io,1005) "    Interior Mass (g)             : ", poly_mass
+                        Write(io,1005) "    Polytropic Index              : ", poly_n
+                        Write(io,1005) "    Density Scaleheights          : ", poly_nrho
+                        Write(io,1005) "    CP (erg g^-1 cm^-3 K^-1)      : ", pressure_specific_heat
+                    Else If (reference_type .eq. 4) Then
+                        Write(io,1001) "    Reference type                : ", "Custom"
                     Endif
-                    Write(io,1005) "        Domain Lower Bound    : ", domain_bounds(i)
-                    Write(io,1005) "        Domain Upper Bound    : ", domain_bounds(i+1)
-                Enddo
-                Write(io,*)
-                Write(io,*) "Reference State"
-                If (reference_type .eq. 1) Then
-                    Write(io,1001) "    Reference type          : ", "Boussinesq (Non-dimensional)"
-                    Write(io,1005) "    Rayleigh Number         : ", Rayleigh_Number
-                    Write(io,1005) "    Ekman Number            : ", Ekman_Number
-                    Write(io,1005) "    Prandtl Number          : ", Prandtl_Number
-                    If (magnetism) Then
-                        Write(io,1005) "    Magnetic Prandtl Number : ", Magnetic_Prandtl_Number
-                    Endif
-                Else If (reference_type .eq. 2) Then
-                    Write(io,1001) "    Reference type           : ", "Polytrope (Non-dimensional)"
-                    Write(io,1005) "    Modified Rayleigh Number : ", Rayleigh_Number
-                    Write(io,1005) "    Ekman Number             : ", Ekman_Number
-                    Write(io,1005) "    Prandtl Number           : ", Prandtl_Number
-                    If (magnetism) Then
-                        Write(io,1005) "    Magnetic Prandtl Number  : ", Magnetic_Prandtl_Number
-                    Endif
-                    Write(io,1005) "    Polytropic Index         : ", poly_n
-                    Write(io,1005) "    Density Scaleheights     : ", poly_nrho
-                Else If (reference_type .eq. 3) Then
-                    Write(io,1001) "    Reference type                : ", "Polytrope (Dimensional)"
-                    Write(io,1005) "    Angular Velocity (rad/s)      : ", Angular_Velocity
-                    Write(io,1005) "    Inner-Radius Density (g/cm^3) : ", poly_rho_i
-                    Write(io,1005) "    Interior Mass (g)             : ", poly_mass
-                    Write(io,1005) "    Polytropic Index              : ", poly_n
-                    Write(io,1005) "    Density Scaleheights          : ", poly_nrho
-                    Write(io,1005) "    CP (erg g^-1 cm^-3 K^-1)      : ", pressure_specific_heat
-                Else If (reference_type .eq. 4) Then
-                    Write(io,1001) "    Reference type                : ", "Custom"
+                    Write(io,*)
+
+                    Write(io,999)
+                    Write(io,*) "Namelist Information"
+                    Write(io,999)
                 Endif
-                Write(io,*)
-
-                Write(io,999)
-                Write(io,*) "Namelist Information"
-                Write(io,999)
                 Write(io,nml=problemsize_namelist)
                 Write(io,nml=numerical_controls_namelist)
                 Write(io,nml=physical_controls_namelist)

--- a/src/Physics/Run_Parameters.F90
+++ b/src/Physics/Run_Parameters.F90
@@ -52,7 +52,7 @@ Contains
 
         Character(len=16 ) :: date, time, zone_in
         Integer :: values(8)
-        Integer :: io, ierr, i
+        Integer :: io, ierr, i, nprow_save, npcol_save
         Logical :: file_exist, write_header
         Integer :: ntrim = 4
         Character*256, Intent(In), Optional :: checkpoint_input_file
@@ -79,6 +79,12 @@ Contains
                 Open(unit=io, file=checkpoint_input_file, form='formatted', &
                    action='write', access='sequential', status='unknown', iostat=ierr)
                 write_header = .false.
+                ! Set nprow and npcol to -1 for checkpoints' main_input files.
+                ! (allows easy restarts from any process count)
+                nprow_save = nprow
+                npcol_save = npcol
+                nprow = -1
+                npcol = -1
             Endif
 
             If ( ierr .eq. 0 ) Then
@@ -208,7 +214,8 @@ Contains
             Endif
 
             Close(unit=io)
-
+            nprow = nprow_save
+            npcol = npcol_save
         Endif
 
     End Subroutine Write_Run_Parameters

--- a/src/Physics/Sphere_Driver.F90
+++ b/src/Physics/Sphere_Driver.F90
@@ -29,6 +29,7 @@ Module Sphere_Driver
     Use Controls
     Use Timers
     Use Fields
+    Use Run_Parameters, Only : write_run_parameters
 
     !sigterm...
 #ifdef INTEL_COMPILER 
@@ -75,12 +76,9 @@ Contains
         Real*8  :: captured_time, max_time_seconds
         Logical :: terminate_file_exists
         Character*14 :: tmstr
-        Character*120 :: dtstr
-        Character*120 :: wtmstr
-        Character*120 :: istr
-        !Character(len=*), parameter :: dtfmt ='(ES11.4)', wtmfmt='(ES9.3E1)', &
+        Character*120 :: dtstr, wtmstr, istr
         Character(len=*), parameter ::   fmtstr = '(F14.4)'
-        
+        Character*256 :: checkpoint_input_file
 
         ! Register handle_sig as the signal-handling 
         ! function for SIGTERM (15) signals.
@@ -255,7 +253,8 @@ Contains
             Call IsItTimeForACheckpoint(iteration)
             If (ItIsTimeForACheckpoint) Then
                 Call StopWatch(cwrite_time)%StartClock()
-                Call Write_Checkpoint(wsp%p1b,iteration, deltat,new_deltat,simulation_time)
+                Call Write_Checkpoint(wsp%p1b,iteration, deltat,new_deltat,simulation_time, checkpoint_input_file)
+                Call Write_Run_Parameters(checkpoint_input_file)
                 Call StopWatch(cwrite_time)%Increment()
             Endif
 

--- a/src/object_list
+++ b/src/object_list
@@ -6,8 +6,8 @@ MOBJ  = Math_Constants.o Timing.o Finite_Difference.o Chebyshev_Polynomials.o \
         Math_Utility.o Fourier_Transform.o Spectral_Derivatives.o
 IOOBJ = Spherical_IO.o  
 POBJ  = Controls.o ClockInfo.o Timers.o ProblemSize.o PDE_Coefficients.o Fields.o \
-        Generic_Input.o BoundaryConditions.o \
-        Checkpointing.o Initial_Conditions.o \
+        Generic_Input.o Checkpointing.o \
+        BoundaryConditions.o Initial_Conditions.o \
         Diagnostics_Base.o \
         Diagnostics_Second_Derivatives.o \
         Diagnostics_Velocity_Diffusion.o \


### PR DESCRIPTION
This PR changes the checkpoint format used by Rayleigh.  It's one of the last major changes I would like to push through before a 1.0 version release (we're at 0.95 now).   These modifications are fully compatible with old checkpoint files -- nothing new needs to be done to restart from the old format.    Rayleigh checks for the new format first when reading a checkpoint.  If that's not found, it drops back to the old format.

When new checkpoints are written their format differs as follows.

1.) Each checkpoint now gets a dedicated directory into which all checkpoint files are stored.  This directory contains all information needed to restart a model.

2.) In addition to the old files (e.g., W, PAB, etc.) a main_input file, an equation coefficients file, and a boundary conditions file are written.

Since the checkpoints now have everything needed to restart a model, you can just move the relevant directory around and not worry about the main_input file, or any custom reference-state/boundary-conditions files.

In addition to the normal method of restarting, you can also restart in 'full restart' mode from the command-line using the -full_restart flag.  For example:
mpiexec -np 16 ./rayleigh.opt -full_restart 20  (to restart from iteration 20)
mpiexec -np 16 ./rayleigh.opt -full_restart -2  (to restart from quicksave 2)
mpiexec -np 16 ./rayleigh.opt -full_restart 20 -input_digits 10 (to restart from a checkpoint written with 10 digits instead of the default 8)

Main_input, etc. doesn't need to be copied to the run directory when running with full_restart.  Rayleigh gets it directly from the Checkpoint directory in this mode.  If the main_input indicates that a custom reference state or custom boundary conditions were used, those are retrieved from the relevant checkpoint files.

-Nick