### PR TITLE
Fixed issue in Compile_GlobalAverages.

### DIFF
--- a/post_processing/YT_volrender_tutorial1.ipynb
+++ b/post_processing/YT_volrender_tutorial1.ipynb
@@ -267,7 +267,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.3"
+   "version": "3.7.3"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
The Compile_GlobalAverages routine used the old GlobalAvgs object name, instead of G_Avgs.  The routine was broken as a result.  This is a quick, name-change edit, and so I will merge without review.