### PR TITLE
Allow more quantity codes in the Namelist

### DIFF
--- a/src/Physics/Input.F90
+++ b/src/Physics/Input.F90
@@ -215,7 +215,7 @@ Contains
         Character(len=:), Allocatable, Intent(out) :: lines(:)
         Integer, Intent(Out) :: nlines, max_len
         Integer :: iunit,istat
-        Character(512):: line, line2
+        Character(2048):: line, line2
         Integer :: com_check, line_len, i
 
         ! This routine reads filename into the output character array 'lines.'


### PR DESCRIPTION
Each line in the namelist was assumed to be less than 512 characters. This means if you have more than about 120 quantity codes, then Rayleigh will truncate the line and it will not add the requested codes (and not tell you that it happened). I increased the limit from 512 to 2048, which would allow something on the order of 400 quantity codes.

In theory, Rayleigh will accept 4000 quantity codes, which would require the line length to be something like 18000, but you would probably hit a memory error well before that limit.