### PR TITLE
Install the interp3d executable to the same location as Rayleigh

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,11 +51,13 @@ endif
 
 interp3d.gnu:
 	@$(MAKE) --no-print-directory --directory=$(INTERP) interp3d.gnu
-	@cp $(INTERP)/interp3d bin/.
+	@mkdir -p $(PREFIX)/bin
+	@cp $(INTERP)/interp3d $(PREFIX)/bin/.
 
 interp3d.intel:
 	@$(MAKE) --no-print-directory --directory=$(INTERP) interp3d.intel
-	@cp $(INTERP)/interp3d bin/.
+	@mkdir -p $(PREFIX)/bin
+	@cp $(INTERP)/interp3d $(PREFIX)/bin/.
 
 
 clean:


### PR DESCRIPTION
Before, the interp3d executables were moved to bin/ which may or may not have previously existed and is not necessarily the same location that the Rayleigh executables were installed.

I added the PREFIX location to the copy command: "cp $(INTERP)/interp3d $(PREFIX)/bin/."