### PR TITLE
Bug Fix:  Adjust Reference Heating

### DIFF
--- a/src/Physics/Main.F90
+++ b/src/Physics/Main.F90
@@ -84,8 +84,9 @@ Contains
 
         Call Initialize_Field_Structure()
         Call Initialize_Checkpointing()
-        Call Initialize_Boundary_Conditions()
         Call Initialize_Transport_Coefficients()
+        Call Initialize_Boundary_Conditions()
+
 
         Call Write_Equation_Coefficients_File()
 


### PR DESCRIPTION
This small change to Main.F90 calls Initialize_Transport_Coefficients before (instead of after) Initialize_Boundary_Conditions.   Otherwise, the subroutine 'Transport_Dependencies' will cause a crash if adjust_reference_heating is true and fix_dtdr_top or fix_dtdr_bottom are also true.  In practice, this only affects reference_type = 3 (the Jupiter model).  This bug was introduced when we combined reference-state and diffusion-related quantities together into the PDE_Coefficients module.   Since this is critical to one user's workflow, I am merging without review.