### PR TITLE
Made luminosity or heating_integral specified in main_input override …

### DIFF
--- a/src/Physics/PDE_Coefficients.F90
+++ b/src/Physics/PDE_Coefficients.F90
@@ -717,6 +717,14 @@ Contains
         ref%temperature(:) = ra_functions(:,4)
         ref%dlnT(:) = ra_functions(:,10)
 
+        If (abs(Luminosity) .gt. heating_eps) Then
+            ra_constants(10) = Luminosity
+        Endif
+
+        If (abs(Heating_Integral) .gt. heating_eps) Then
+            ra_constants(10) = Heating_Integral
+        Endif
+
         ref%heating(:) = ra_functions(:,6)/(ref%density*ref%temperature)*ra_constants(10)
         
         ref%Coriolis_Coeff = ra_constants(1)


### PR DESCRIPTION
…c_10 within custom_reference framework. This shouldn't change any of the existing custom reference interface, it will just allow luminosity and heating_integral to be observed in main_input, rather than

override_constant(10) = .true.
ra_constants(10) = [luminosity]

Or else setting c_10 in the custom reference file. 