### PR TITLE
Removed duplicate error messages for transport coefficients functions/constants

### DIFF
--- a/src/Physics/PDE_Coefficients.F90
+++ b/src/Physics/PDE_Coefficients.F90
@@ -708,7 +708,7 @@ Contains
             If (ra_function_set(fi) .eq. 0) Then
                 If (my_rank .eq. 0) Then
                     Write(ind, '(I2)') fi
-                    Call stdout%print('ERROR: function f_'//Trim(Adjustl(ind))//' must be set in the custom reference file')
+                    Call stdout%print('ERROR: function f_'//Adjustl(ind)//' must be set in the custom reference file')
                 Endif
             Endif
         Enddo
@@ -788,6 +788,9 @@ Contains
         Real*8  :: input_constants(1:n_ra_constants)
         Real*8, Allocatable :: ref_arr_old(:,:), rtmp(:), rtmp2(:)
         Real*8, Allocatable :: old_radius(:)
+        Character*12 :: dstring
+        Character*8 :: dofmt = '(ES12.5)'
+        Character(len=2) :: ind
 
         cset(:) = 0
         input_constants(:) = 0.0d0
@@ -848,7 +851,10 @@ Contains
             ! Print the values of the constants
             Do k = 1, n_ra_constants
                 If (my_rank .eq. 0) Then
-                    Write(6,*)'c: ', k, ra_constants(k)
+                    Write(ind, '(I2)') k
+                    Write(dstring,dofmt) ra_constants(k)
+                    Call stdout%print('c_'//Adjustl(ind)//' = '//Trim(dstring))
+                    !Write(6,*)'c: ', k, ra_constants(k)
                 Endif
             Enddo
 
@@ -1196,7 +1202,7 @@ Contains
                 Else
                     If (my_rank .eq. 0) Then
                         Write(ind, '(I2)') fi
-                        Call stdout%print('ERROR: function f_'//Trim(Adjustl(ind))//' must be set in the custom reference file')
+                        Call stdout%print('ERROR: function f_'//Adjustl(ind)//' must be set in the custom reference file')
                     EndIf
                 EndIf
 

--- a/src/Physics/PDE_Coefficients.F90
+++ b/src/Physics/PDE_Coefficients.F90
@@ -694,7 +694,7 @@ Contains
         Implicit None
         Integer :: i, fi
         Character(len=2) :: ind
-        Integer :: fi_to_check(5) = (/1, 2, 4, 6, 14/)
+        Integer :: fi_to_check(4) = (/1, 2, 4, 6/)
 
         If (my_rank .eq. 0) Then
             Write(6,*)'Custom reference state specified.'
@@ -703,7 +703,7 @@ Contains
 
         Call Read_Custom_Reference_File(custom_reference_file)
 
-        Do i=1,5
+        Do i=1,4
             fi = fi_to_check(i)
             If (ra_function_set(fi) .eq. 0) Then
                 If (my_rank .eq. 0) Then

--- a/src/Physics/PDE_Coefficients.F90
+++ b/src/Physics/PDE_Coefficients.F90
@@ -692,8 +692,9 @@ Contains
 
     Subroutine Get_Custom_Reference()
         Implicit None
-        Integer :: i
+        Integer :: i, fi
         Character(len=2) :: ind
+        Integer :: fi_to_check(5) = (/1, 2, 4, 6, 14/)
 
         If (my_rank .eq. 0) Then
             Write(6,*)'Custom reference state specified.'
@@ -702,10 +703,11 @@ Contains
 
         Call Read_Custom_Reference_File(custom_reference_file)
 
-        Do i=1,7
-            If (ra_function_set(i) .eq. 0) Then
+        Do i=1,5
+            fi = fi_to_check(i)
+            If (ra_function_set(fi) .eq. 0) Then
                 If (my_rank .eq. 0) Then
-                    Write(ind, '(I2)') i
+                    Write(ind, '(I2)') fi
                     Call stdout%print('ERROR: function f_'//Trim(Adjustl(ind))//' must be set in the custom reference file')
                 Endif
             Endif

--- a/src/Physics/PDE_Coefficients.F90
+++ b/src/Physics/PDE_Coefficients.F90
@@ -717,6 +717,14 @@ Contains
         ref%temperature(:) = ra_functions(:,4)
         ref%dlnT(:) = ra_functions(:,10)
 
+        If (abs(Luminosity) .gt. heating_eps) Then
+            ra_constants(10) = Luminosity
+        Endif
+
+        If (abs(Heating_Integral) .gt. heating_eps) Then
+            ra_constants(10) = Heating_Integral
+        Endif
+
         ref%heating(:) = ra_functions(:,6)/(ref%density*ref%temperature)*ra_constants(10)
         
         ref%Coriolis_Coeff = ra_constants(1)

--- a/src/Physics/PDE_Coefficients.F90
+++ b/src/Physics/PDE_Coefficients.F90
@@ -693,6 +693,7 @@ Contains
     Subroutine Get_Custom_Reference()
         Implicit None
         Integer :: i
+        Character(len=2) :: ind
 
         If (my_rank .eq. 0) Then
             Write(6,*)'Custom reference state specified.'
@@ -704,7 +705,8 @@ Contains
         Do i=1,7
             If (ra_function_set(i) .eq. 0) Then
                 If (my_rank .eq. 0) Then
-                    Write(6,*) "ERROR: function f_i must be set in the custom reference file",i
+                    Write(ind, '(I2)') i
+                    Call stdout%print('ERROR: function f_'//Trim(Adjustl(ind))//' must be set in the custom reference file')
                 Endif
             Endif
         Enddo
@@ -1157,8 +1159,8 @@ Contains
             If (xtop .le. 0) Then
                 If (ra_constant_set(ci) .eq. 0) Then
                     If (my_rank .eq. 0) Then
-                        write(ind, '(I2)') ci
-                        Call stdout%print('Error: c_'//Trim(ind)//' not specified')
+                        Write(ind, '(I2)') ci
+                        Call stdout%print('ERROR: constant c_'//Trim(Adjustl(ind))//' must be set in the custom reference file')
                     Endif
                 Else
                     xtop = ra_constants(ci)
@@ -1191,8 +1193,8 @@ Contains
                     xtop = x(1)
                 Else
                     If (my_rank .eq. 0) Then
-                        write(ind, '(I2)') fi
-                        Call stdout%print('Error: Need to specify f_'//Trim(ind))
+                        Write(ind, '(I2)') fi
+                        Call stdout%print('ERROR: function f_'//Trim(Adjustl(ind))//' must be set in the custom reference file')
                     EndIf
                 EndIf
 


### PR DESCRIPTION
These were always thrown when reference_type = 4 regardless of the diffusion_types. I also standardized the formatting of the error messages. This branch is based off the luminosity_flag branch. 