### PR TITLE
Fix sign error v r times vforce r

### DIFF
--- a/src/Diagnostics/Diagnostics_Linear_Forces.F90
+++ b/src/Diagnostics/Diagnostics_Linear_Forces.F90
@@ -227,7 +227,7 @@ Contains
 
 
                 ! Finally, add the piece due to the gradient of mu
-        !        estress = buffer(PSI,dvrdr)-One_Third*buffer(PSI,vr)*ref%dlnrho(r)
+        !        estress = buffer(PSI,dvrdr)+One_Third*buffer(PSI,vr)*ref%dlnrho(r)
 
         !        qty(PSI) = 2.0d0*dmudr(r)*estress + mu_visc(r)*del2u
 

--- a/src/Diagnostics/Diagnostics_Mean_Correction.F90
+++ b/src/Diagnostics/Diagnostics_Mean_Correction.F90
@@ -386,7 +386,7 @@ Contains
 
 
                 ! Finally, add the piece due to the gradient of mu
-                estress = buffer(PSI,dvrdr)-One_Third*buffer(PSI,vr)*ref%dlnrho(r)
+                estress = buffer(PSI,dvrdr)+One_Third*buffer(PSI,vr)*ref%dlnrho(r)
 
                 mean_3dbuffer(PSI,vforce_r) = 2.0d0*dmudr(r)*estress + mu_visc(r)*del2u
 


### PR DESCRIPTION
First in a series of four (4) small bug fixes to the diagnostics. In this one, there was a sign error in the "estress" term appearing in radial viscous force and derivative quantities.