### PR TITLE
Fix vm grad vm terms

### DIFF
--- a/src/Diagnostics/Diagnostics_Linear_Forces.F90
+++ b/src/Diagnostics/Diagnostics_Linear_Forces.F90
@@ -227,7 +227,7 @@ Contains
 
 
                 ! Finally, add the piece due to the gradient of mu
-        !        estress = buffer(PSI,dvrdr)-One_Third*buffer(PSI,vr)*ref%dlnrho(r)
+        !        estress = buffer(PSI,dvrdr)+One_Third*buffer(PSI,vr)*ref%dlnrho(r)
 
         !        qty(PSI) = 2.0d0*dmudr(r)*estress + mu_visc(r)*del2u
 

--- a/src/Diagnostics/Diagnostics_Mean_Correction.F90
+++ b/src/Diagnostics/Diagnostics_Mean_Correction.F90
@@ -386,7 +386,7 @@ Contains
 
 
                 ! Finally, add the piece due to the gradient of mu
-                estress = buffer(PSI,dvrdr)-One_Third*buffer(PSI,vr)*ref%dlnrho(r)
+                estress = buffer(PSI,dvrdr)+One_Third*buffer(PSI,vr)*ref%dlnrho(r)
 
                 mean_3dbuffer(PSI,vforce_r) = 2.0d0*dmudr(r)*estress + mu_visc(r)*del2u
 

--- a/src/Diagnostics/Diagnostics_Mean_Correction.F90
+++ b/src/Diagnostics/Diagnostics_Mean_Correction.F90
@@ -319,6 +319,7 @@ Contains
 
         If (compute_mean_mean .or. compute_quantity(advec_work_mmm)) Then
 
+            Call ADotGradB(m0_values,m0_values,cbuffer,aindices=vindex,bindices=vindex)
 
             If (compute_quantity(vm_grad_vm_r) .or. compute_quantity(advec_work_mmm)) Then
                 DO_PSI


### PR DESCRIPTION
Two out of four. Missing call to AdotGradB that prevented vm_dot_grad_vm_r from being computed properly in Diagnostics_Mean_Correction.