### PR TITLE
Fix mag work mpp

### DIFF
--- a/src/Diagnostics/Diagnostics_Linear_Forces.F90
+++ b/src/Diagnostics/Diagnostics_Linear_Forces.F90
@@ -227,7 +227,7 @@ Contains
 
 
                 ! Finally, add the piece due to the gradient of mu
-        !        estress = buffer(PSI,dvrdr)-One_Third*buffer(PSI,vr)*ref%dlnrho(r)
+        !        estress = buffer(PSI,dvrdr)+One_Third*buffer(PSI,vr)*ref%dlnrho(r)
 
         !        qty(PSI) = 2.0d0*dmudr(r)*estress + mu_visc(r)*del2u
 

--- a/src/Diagnostics/Diagnostics_Lorentz_Forces.F90
+++ b/src/Diagnostics/Diagnostics_Lorentz_Forces.F90
@@ -173,7 +173,7 @@ Contains
         Endif
 
         If (compute_quantity(jp_cross_bp_phi) .or. compute_quantity(samom_lorentz_pp) &
-            .or. compute_quantity(mag_work_ppp) .or. compute_quantity(mag_work_mmm)) Then
+            .or. compute_quantity(mag_work_ppp) .or. compute_quantity(mag_work_mpp)) Then
             DO_PSI
                 qty(PSI) = ( fbuffer(PSI,curlbr)*fbuffer(PSI,btheta)- &
                            & fbuffer(PSI,br)*fbuffer(PSI,curlbtheta) )*ref%Lorentz_Coeff

--- a/src/Diagnostics/Diagnostics_Mean_Correction.F90
+++ b/src/Diagnostics/Diagnostics_Mean_Correction.F90
@@ -386,7 +386,7 @@ Contains
 
 
                 ! Finally, add the piece due to the gradient of mu
-                estress = buffer(PSI,dvrdr)-One_Third*buffer(PSI,vr)*ref%dlnrho(r)
+                estress = buffer(PSI,dvrdr)+One_Third*buffer(PSI,vr)*ref%dlnrho(r)
 
                 mean_3dbuffer(PSI,vforce_r) = 2.0d0*dmudr(r)*estress + mu_visc(r)*del2u
 

--- a/src/Diagnostics/Diagnostics_Mean_Correction.F90
+++ b/src/Diagnostics/Diagnostics_Mean_Correction.F90
@@ -319,6 +319,7 @@ Contains
 
         If (compute_mean_mean .or. compute_quantity(advec_work_mmm)) Then
 
+            Call ADotGradB(m0_values,m0_values,cbuffer,aindices=vindex,bindices=vindex)
 
             If (compute_quantity(vm_grad_vm_r) .or. compute_quantity(advec_work_mmm)) Then
                 DO_PSI


### PR DESCRIPTION
Three out of four. Typo in Diagnostics_Lorentz_Forces, line 176, meant that mag_work_mpp (1919) would never be added.