### PR TITLE
Shell Spectra Once Again Satisfy Parseval's Theorem

### DIFF
--- a/post_processing/rayleigh_diagnostics.py
+++ b/post_processing/rayleigh_diagnostics.py
@@ -1289,7 +1289,7 @@ class Shell_Spectra:
             self.time[i] = swapread(fd,dtype='float64',count=1,swap=bs)
             self.iters[i] = swapread(fd,dtype='int32',count=1,swap=bs)
 
-        if (self.version < 4):
+        if (self.version != 4):
             # The m>0 --power-- is too high by a factor of 2
             # We divide the --complex amplitude-- by sqrt(2)
             self.vals[:,1:,:,:,:] /= np.sqrt(2.0)

--- a/src/IO/Parallel_IO.F90
+++ b/src/IO/Parallel_IO.F90
@@ -157,6 +157,7 @@ Module Parallel_IO
         Procedure :: DeAllocate_Receive_Buffers
         Procedure :: write_data
         Procedure :: Spectral_Prep
+        Procedure :: Reset_Cache_Index
 
         Procedure :: gather_data
         Procedure :: cascade
@@ -965,6 +966,12 @@ Contains
             self%cache_index = MOD(self%cache_index, self%ncache)+1
         Endif
     End Subroutine Cache_Data
+
+    Subroutine Reset_Cache_Index(self)
+        Implicit None
+        Class(io_buffer) :: self
+        self%cache_index = 1
+    End Subroutine Reset_Cache_Index
 
     Subroutine Spectral_Prep(self)
         Implicit None

--- a/src/IO/Spherical_IO.F90
+++ b/src/IO/Spherical_IO.F90
@@ -761,7 +761,7 @@ Contains
                 !If (responsible) Write(6,*)'check disp: ', self%buffer%qdisp, self%buffer%ncache, self%buffer%spectral
 
                 Call self%buffer%write_data(disp=new_disp,file_unit=funit)
-            
+                Call self%buffer%reset_cache_index()
                 If (output_rank) Call self%closefile_par()
 
             Endif            
@@ -940,12 +940,15 @@ Contains
             self%values(:) = values(:) 
             
             Do i = 1, nqmax
-                if(self%values(i) .gt. 0) Then 
-                    self%nq = self%nq+1
+                If(self%values(i) .gt. 0) Then 
                     ind = self%values(i)
-                    self%compute(ind) = 1
-                    computes(ind) = 1
-                endif 
+                    ! Guard against duplicate inputs                    
+                    If (self%compute(ind) .ne. 1) Then
+                        self%nq = self%nq+1
+                        self%compute(ind) = 1
+                        computes(ind) = 1
+                    Endif
+                Endif 
             Enddo
         Endif
 


### PR DESCRIPTION
This partially fixes a bug related to the power spectra normalization.  Generally, shell_spectra power should satisfy Parsevals's theorem, such that the integrated power (e.g., v* v) over ell and m is equal to the integral of v^2 over the shell in physical space.  For some reason, the m!=0 power is too high again by a factor of 2.  This was fixed in shell_spectra version 4, but seems to have crept back in in version 5.  

I will look into the Rayleigh source later to see where/why this happened again, but for the time being, this quick fix in rayleigh_diagnostics.py will correct the problem for all versions except for version 4.
