### PR TITLE
Critical Bug Fix: Duplicate/Non-existent quantity codes no longer garble output

### DIFF
--- a/src/IO/Parallel_IO.F90
+++ b/src/IO/Parallel_IO.F90
@@ -157,6 +157,7 @@ Module Parallel_IO
         Procedure :: DeAllocate_Receive_Buffers
         Procedure :: write_data
         Procedure :: Spectral_Prep
+        Procedure :: Reset_Cache_Index
 
         Procedure :: gather_data
         Procedure :: cascade
@@ -965,6 +966,12 @@ Contains
             self%cache_index = MOD(self%cache_index, self%ncache)+1
         Endif
     End Subroutine Cache_Data
+
+    Subroutine Reset_Cache_Index(self)
+        Implicit None
+        Class(io_buffer) :: self
+        self%cache_index = 1
+    End Subroutine Reset_Cache_Index
 
     Subroutine Spectral_Prep(self)
         Implicit None

--- a/src/IO/Spherical_IO.F90
+++ b/src/IO/Spherical_IO.F90
@@ -761,7 +761,7 @@ Contains
                 !If (responsible) Write(6,*)'check disp: ', self%buffer%qdisp, self%buffer%ncache, self%buffer%spectral
 
                 Call self%buffer%write_data(disp=new_disp,file_unit=funit)
-            
+                Call self%buffer%reset_cache_index()
                 If (output_rank) Call self%closefile_par()
 
             Endif            
@@ -940,12 +940,15 @@ Contains
             self%values(:) = values(:) 
             
             Do i = 1, nqmax
-                if(self%values(i) .gt. 0) Then 
-                    self%nq = self%nq+1
+                If(self%values(i) .gt. 0) Then 
                     ind = self%values(i)
-                    self%compute(ind) = 1
-                    computes(ind) = 1
-                endif 
+                    ! Guard against duplicate inputs                    
+                    If (self%compute(ind) .ne. 1) Then
+                        self%nq = self%nq+1
+                        self%compute(ind) = 1
+                        computes(ind) = 1
+                    Endif
+                Endif 
             Enddo
         Endif
 


### PR DESCRIPTION
This update allows Rayleigh to deal gracefully with an easy source of user error.   When the new I/O interface was written, the indexing logic for output data was changed slightly.  If duplicate and/or non-existent quantity codes were specified via main_input, an indexing variable was improperly incremented, leading to corrupted output.   This is a pretty easily-expected source of user error, and so Rayleigh should guard against this.  This update fixes the logical issue, and the output is no longer corrupted.  The new behavior is as follows:

1) If a valid quantity code is specified multiple times, it only appears once in the output file.  The file appears exactly as though no duplicates were specified in main_input.

2) If an invalid quantity code is specified, it does not appear in the output, but there is 'blank' space (i.e., zeros) in the file where this value would otherwise appear.  The quantity code is recorded as 4100 (maximum allowsed quantity-code value; currently unused).

3) If a magnetic quantity code is specified for a hydro run, the behavior is identical to (2).

We can certainly improve on this later if people have opinions.  The point of this update is to stop the output corruption.
-Nick