### PR TITLE
Updated configure file for mac: lstdc++ to lc++

### DIFF
--- a/configure
+++ b/configure
@@ -761,8 +761,8 @@ then
             if [[ $MACMKL == "TRUE" ]]
             then
                 MKL_LIB="-L${RAMKLROOT}/lib -Wl,-rpath,${MKLROOT}/lib -lmkl_intel_lp64 -lmkl_sequential -lmkl_core -lpthread -lm -ldl"
-                LIB_FLAGS="\$(MKL_LIB) -lstdc++"
-                FULL_LIB="-L${RAMKLROOT}/lib -Wl,-rpath,${MKLROOT}/lib -lmkl_intel_lp64 -lmkl_sequential -lmkl_core -lpthread -lm -ldl -lstdc++"
+                LIB_FLAGS="\$(MKL_LIB) -lc++"
+                FULL_LIB="-L${RAMKLROOT}/lib -Wl,-rpath,${MKLROOT}/lib -lmkl_intel_lp64 -lmkl_sequential -lmkl_core -lpthread -lm -ldl -lc++"
             else
                 MKL_LIB="-L${RAMKLROOT}/lib -Wl,--no-as-needed -lmkl_gf_lp64 -lmkl_sequential -lmkl_core -lpthread -lm -ldl"
                 LIB_FLAGS="\$(MKL_LIB) -lstdc++"


### PR DESCRIPTION
To correct the following error when compiling using a Mac:
ld: library not found for -lstdc++
