### PR TITLE
remove echo after call to make

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -43,8 +43,7 @@ default:
 
 all: 
 	@for i in $(VERSIONS) ; do \
-		$(MAKE) $$i VERSION=$$i PREFIX=$(PREFIX); \
-		echo ' ' ; \
+		$(MAKE) $$i VERSION=$$i PREFIX=$(PREFIX) && echo ' ' ; \
 	done
 
 rayleigh_exec: $(OBJ)


### PR DESCRIPTION
The `echo` prevents `make` from returning a nonzero exit code on failure.
Removing it makes it exit on error.

Fixes #15.

@feathern was there a specific reason to include the `echo`?