### PR TITLE
Improve test action

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -37,9 +37,9 @@ jobs:
 
         mpirun -np 4 $RAYLEIGH_TEST_MPI_PARAMS ../../bin/rayleigh.dbg
 
-        // Generic input test
+        # Generic input test
         cd "$GITHUB_WORKSPACE"
-        source tests/generic_input/run_test.sh
+        sh ./tests/generic_input/run_test.sh
 
         git diff > changes.diff
         git diff --exit-code --name-only

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -39,7 +39,7 @@ jobs:
 
         // Generic input test
         cd "$GITHUB_WORKSPACE"
-        sh './tests/generic_input/run_test.sh'
+        source tests/generic_input/run_test.sh
 
         git diff > changes.diff
         git diff --exit-code --name-only

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -29,16 +29,18 @@ jobs:
         make install
     - name: Test
       run: |
-        # Set some environment variables necessary for OpenMPI
-        # to run as root
-        export OMPI_ALLOW_RUN_AS_ROOT=1
-        export OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
+        # Set some environment variables necessary for OpenMPI to run as root
+        # and on more MPI ranks than available cores
+        export RAYLEIGH_TEST_MPI_PARAMS="--oversubscribe --allow-run-as-root"
 
         cd "$GITHUB_WORKSPACE"/tests/c2001_case0
 
-        mpirun -np 4 --oversubscribe --allow-run-as-root ../../bin/rayleigh.dbg
+        mpirun -np 4 $RAYLEIGH_TEST_MPI_PARAMS ../../bin/rayleigh.dbg
 
-        cd ..
+        // Generic input test
+        cd "$GITHUB_WORKSPACE"
+        sh './tests/generic_input/run_test.sh'
+
         git diff > changes.diff
         git diff --exit-code --name-only
 

--- a/tests/generic_input/run_test.sh
+++ b/tests/generic_input/run_test.sh
@@ -5,7 +5,7 @@ cd tests/generic_input
 # first we run the "base" case, this just sets up and runs Rayleigh for one time-step with hard-coded initial conditions 
 # for the Christensen et al., 2001 benchmark case 1
 cd base
-mpirun -np 4 ../../../bin/rayleigh.dbg
+mpirun -np 4 $RAYLEIGH_TEST_MPI_PARAMS ../../../bin/rayleigh.dbg
 ../../../post_processing/convert_full3d_to_vtu.py
 cd ..
 
@@ -18,14 +18,14 @@ cd script
 # then we use a custom python script using rayleigh_spectral_input.py as a module to write the magnetic initial conditions
 PYTHONPATH=../../../pre_processing:$PYTHONPATH python generate_magnetic_input.py
 # finally we run Rayleigh
-mpirun -np 4 ../../../bin/rayleigh.dbg
+mpirun -np 4 $RAYLEIGH_TEST_MPI_PARAMS ../../../bin/rayleigh.dbg
 ../../../post_processing/convert_full3d_to_vtu.py
 cd ..
 
 # onto testing bcs... again, first the base case using hard-coded Rayleigh options
 cd bcs_base
 ../../../pre_processing/rayleigh_spectral_input.py -m 0 0 0 0.0+0.j -o zero_init_vol
-mpirun -np 4 ../../../bin/rayleigh.dbg
+mpirun -np 4 $RAYLEIGH_TEST_MPI_PARAMS ../../../bin/rayleigh.dbg
 cd ..
 
 # then again onto the same thing but using generic input files to set the boundary conditions
@@ -35,7 +35,7 @@ cd bcs_script
 ../../../pre_processing/rayleigh_spectral_input.py -m 1 0 15.778615862127371 -m 1 1 3.9346188846598249+0.j -o cbottom_init_bc
 ../../../pre_processing/rayleigh_spectral_input.py -e '5.0' -o five_init_bc
 ../../../pre_processing/rayleigh_spectral_input.py -e '-5.0' -o mfive_init_bc
-mpirun -np 4 ../../../bin/rayleigh.dbg
+mpirun -np 4 $RAYLEIGH_TEST_MPI_PARAMS ../../../bin/rayleigh.dbg
 cd ..
 
 # after both versions have run, we test the output for errors


### PR DESCRIPTION
I added an environment variable to add OpenMPI specific options into the generic_input test run script. This should avoid conflicts with running the script under different  MPI implementations.

With these changes the new github test action now runs all of the tests that the old Jenkinsfile has. In principle the Jenkins tester is now not longer needed (but we can run it in parallel for a while, before removing the Jenkinsfile).

