### PR TITLE
Allow building a particular version of Rayleigh (dbg, opt, etc.)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,9 +9,12 @@ export LC_COLLATE=C
 # make the CUSTOMROOT variable available to sub-make processes
 export CUSTOMROOT
 
+# running "make target=dbg" will only compile the specified target
+target=all
+
 rayleigh: prepare_directory
 	@$(MAKE) --no-print-directory --directory=$(BUILD) clean_exec
-	@$(MAKE) --no-print-directory --directory=$(BUILD) all
+	@$(MAKE) --no-print-directory --directory=$(BUILD) $(target)
 	@echo ""
 	@echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
 	@echo "Compilation is complete."


### PR DESCRIPTION
The default behavior when typing "make" is to build the debug version as well as the optimized version. This PR allows you to specify a particular version of Rayleigh to build by typing "make target=opt" or "make target=dbg". The default behavior is to build everything, just as before.