### PR TITLE
Fix for Issue #144: internally used preprocessor flags are no longer overwritten by custom flags

### DIFF
--- a/configure
+++ b/configure
@@ -32,12 +32,12 @@ function opt_flags {
   #$1 --version
   if [[ $1 == "INTEL" ]]
   then
-    echo '-FR -fpp -r8 -O3 -shared-intel -DINTEL_COMPILER'
+    echo '-FR -fpp -r8 -O3 -shared-intel'
   fi
 
   if [[ $1 == "GNU" ]]
   then
-    echo '-O3 -ffixed-line-length-132 -DGNU_COMPILER'
+    echo '-O3 -ffixed-line-length-132'
   fi
 }
 
@@ -45,11 +45,11 @@ function dbg_flags {
   #$1 --version
   if [[ $1 == "INTEL" ]]
   then
-    echo '-FR -fpp -r8 -O0 -g -CB -traceback -shared-intel -DINTEL_COMPILER'
+    echo '-FR -fpp -r8 -O0 -g -CB -traceback -shared-intel'
   fi
   if [[ $1 == "GNU" ]]
   then
-    echo '-O0 -g -fbounds-check -ffpe-trap=invalid,zero,overflow -fbacktrace -ffixed-line-length-132 -DGNU_COMPILER'
+    echo '-O0 -g -fbounds-check -ffpe-trap=invalid,zero,overflow -fbacktrace -ffixed-line-length-132'
   fi
 }
 
@@ -495,12 +495,6 @@ else
   OPT_FLAGS=$(opt_flags $FVERSION)
   DBG_FLAGS=$(dbg_flags $FVERSION)
 
-  if [ "$USEMPIF77" == "TRUE" ]
-  then
-          OPT_FLAGS="$OPT_FLAGS -DUSE_MPI_F77_BINDINGS"
-          DBG_FLAGS="$DBG_FLAGS -DUSE_MPI_F77_BINDINGS"
-  fi
-
   if [ "$CUSTOMOPT" == "TRUE" ]
   then
     echo "  Overriding optimization flags."
@@ -518,6 +512,25 @@ else
     echo "  Overriding all flags..,"
     OPT_FLAGS=$RAFFLAGS
     DBG_FLAGS=$RAFFLAGS
+  fi
+
+  # internally used preprocessor flags should appear after custom flags are set
+  if [ "$USEMPIF77" == "TRUE" ]
+  then
+          OPT_FLAGS="$OPT_FLAGS -DUSE_MPI_F77_BINDINGS"
+          DBG_FLAGS="$DBG_FLAGS -DUSE_MPI_F77_BINDINGS"
+  fi
+
+  if [ $FVERSION == "INTEL" ]
+  then
+      OPT_FLAGS="$OPT_FLAGS -DINTEL_COMPILER"
+      DBG_FLAGS="$DBG_FLAGS -DINTEL_COMPILER"
+  fi
+
+  if [ $FVERSION == "GNU" ]
+  then
+      OPT_FLAGS="$OPT_FLAGS -DGNU_COMPILER"
+      DBG_FLAGS="$DBG_FLAGS -DGNU_COMPILER"
   fi
 
   echo ' '


### PR DESCRIPTION
When running ./configure a compiler-dependent preprocessor flag is included such as "-DINTEL_COMPILER" or "-DGNU_COMPILER". When specifying custom flags such as "./configure --FFLAGS='-O3' ..." the preprocessor flags were overwritten and lost, even when using Intel and GCC compilers. This PR adds all preprocessor flags after the custom flags have been applied, i.e., fix for Issue #144