### PR TITLE
Update AUTHORS file

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,7 +1,9 @@
-Rayleigh 
-Version 0.9.0
-Developed by Nicholas Featherstone
+Rayleigh was originally developed by Nicholas Featherstone.
 
+Since then many more people have contributed and Rayleigh has grown into a
+project with many authors. A complete and growing list can be found at:
+https://github.com/geodynamics/Rayleigh/graphs/contributors.
 
-Special thanks to Michael Calkins, Moritz Heimpel, Bradley Hindman, Wei Jiang, and Ryan Orvedahl, 
-Krista Soderlund, and Rakesh Yadav for their intensive beta testing of the code. 
+Special thanks to Michael Calkins, Moritz Heimpel, Bradley Hindman, Wei Jiang,
+and Ryan Orvedahl, Krista Soderlund, and Rakesh Yadav for their intensive beta
+testing of the code.

--- a/AUTHORS
+++ b/AUTHORS
@@ -5,5 +5,5 @@ project with many authors. A complete and growing list can be found at:
 https://github.com/geodynamics/Rayleigh/graphs/contributors.
 
 Special thanks to Michael Calkins, Moritz Heimpel, Bradley Hindman, Wei Jiang,
-and Ryan Orvedahl, Krista Soderlund, and Rakesh Yadav for their intensive beta
+Ryan Orvedahl, Krista Soderlund, and Rakesh Yadav for their intensive beta
 testing of the code.


### PR DESCRIPTION
This removes the version number from the AUTHORS file (which would be a pain to update for every release). It also updates the text to better reflect Rayleigh's current development model. @feathern should take a look at this before merging.