### PR TITLE
Reduce duplication in doc and devel environments

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -13,8 +13,5 @@ sphinx:
 formats:
   - pdf
 
-# Optionally set the version of Python and requirements required to build your docs
-python:
-  version: 3.7
-  install:
-    - requirements: doc/requirements.txt
+conda:
+  environment: environment_doc.yml

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,8 +1,0 @@
-sphinxcontrib-bibtex
-recommonmark
-ipykernel
-nbsphinx
-pandoc
-numpy
-scipy
-matplotlib

--- a/environment.yml
+++ b/environment.yml
@@ -1,3 +1,9 @@
+# Rayleigh development environment.
+#
+# If you change this file with a package relevant for
+# building the documentation make sure to also update
+# environment_doc.yml.
+
 name: radev
 channels:
   - conda-forge

--- a/environment_doc.yml
+++ b/environment_doc.yml
@@ -1,0 +1,15 @@
+name: radoc
+channels:
+  - conda-forge
+dependencies:
+  - python=3.7
+  - matplotlib=3.4
+  - jupyter=1.0
+  - scipy=1.6
+  - sphinx=4.0
+  - sphinxcontrib-bibtex=2.2
+  - nbsphinx=0.8
+  - pandoc=2.13
+  - recommonmark=0.7
+  - funcsigs=1.0
+  - vtk=9.0

--- a/environment_doc.yml
+++ b/environment_doc.yml
@@ -1,8 +1,13 @@
+# Rayleigh documentation environment.
+#
+# If you change this file make sure to also update
+# environment.yml.
+
 name: radoc
 channels:
   - conda-forge
 dependencies:
-  - python=3.7
+  - python=3.9
   - matplotlib=3.4
   - jupyter=1.0
   - scipy=1.6


### PR DESCRIPTION
Our development environment and the environment that builds the documentation should ideally be the same environment to make sure things look and work the same online and locally. But the development environment also needs a lot of stuff that the doc environment does not need (we dont need mkl on readthedocs to build the documentation). This change includes the doc/requirements.txt file into the environment.yml to make sure they always use the same packages.

The documenation should be unchanged. Let's see what the conda tester says.