### PR TITLE
Fixing some uninitialized variables found by the intel compiler.

### DIFF
--- a/src/IO/Spherical_IO.F90
+++ b/src/IO/Spherical_IO.F90
@@ -975,9 +975,13 @@ Contains
                 Enddo
                 indices(1,5) = rcount
                 indices(1:rcount,1) = self%r_inds(1:rcount)
+            Else
+                Allocate(self%r_vals(1:0))
+                Allocate(self%r_inds(1:0))
             Endif
 
         Else
+            rcount = 1
             Allocate(self%r_inds(1:1))
             Allocate(self%r_vals(1:1))
             self%r_inds(1) = -1
@@ -1003,9 +1007,13 @@ Contains
                 Enddo
                 indices(2,5) = tcount
                 indices(1:tcount,2) = self%theta_inds(1:tcount)
+            Else
+                Allocate(self%theta_inds(1:0))
+                Allocate(self%theta_vals(1:0))
             Endif
 
         Else
+            tcount = 1
             Allocate(self%theta_inds(1:1))
             Allocate(self%theta_vals(1:1))
             self%theta_inds(1) = -1
@@ -1030,8 +1038,12 @@ Contains
                 Enddo
                 indices(3,5) = pcount
                 indices(1:pcount,3) = self%phi_inds(1:pcount)
+            Else
+                Allocate(self%phi_inds(1:0))
+                Allocate(self%phi_vals(1:0))
             Endif
         Else
+            pcount = 1
             Allocate(self%phi_inds(1:1))
             Allocate(self%phi_vals(1:1))
             self%phi_inds(1) = -1
@@ -1055,8 +1067,11 @@ Contains
                 self%nell = lcount
                 indices(1:self%nell,4) = lvals(1:lcount)
                 indices(4,5) = self%nell
+            Else
+                Allocate(self%l_values(1:0))
             Endif
         Else
+            lcount = 1
             Allocate(self%l_values(1:1))
             self%l_values(1) = -1
         Endif

--- a/src/Physics/Benchmarking.F90
+++ b/src/Physics/Benchmarking.F90
@@ -70,6 +70,7 @@ Contains
         Character*120 :: file_remember
         ! This routine re-initializes input values to their benchmark values
 
+        ref_remember = 1
         If (benchmark_mode .gt. 0) Then
 
             mode_remember = benchmark_mode  ! Keep track of a few things before restoring defaults

--- a/src/Physics/Input.F90
+++ b/src/Physics/Input.F90
@@ -98,8 +98,10 @@ Contains
         my_sim_rank = sim_comm%rank
 
         ! Rank zero read the file and broadcasts the file size to all other ranks.
-        If (my_sim_rank .eq. 0)  Call File_to_String(input_file,input_as_string,nlines,line_len)
-        pars(1:2) = (/ nlines, line_len /)
+        If (my_sim_rank .eq. 0)  Then 
+          Call File_to_String(input_file,input_as_string,nlines,line_len)
+          pars(1:2) = (/ nlines, line_len /)
+        Endif
         Call MPI_Bcast(pars, 2, MPI_INTEGER, 0, sim_comm%comm,ierr)
 
         nlines = pars(1)

--- a/src/Physics/Run_Parameters.F90
+++ b/src/Physics/Run_Parameters.F90
@@ -71,6 +71,8 @@ Contains
 
         If (my_rank .eq. 0) Then
 
+            nprow_save = nprow
+            npcol_save = npcol
             If (.not. present(checkpoint_input_file)) Then
                 Inquire(file=Trim(my_path)//Trim(jobinfo_file), exist=file_exist)
                 Open(unit=io, file=Trim(my_path)//Trim(jobinfo_file), form='formatted', &
@@ -81,8 +83,6 @@ Contains
                 write_header = .false.
                 ! Set nprow and npcol to -1 for checkpoints' main_input files.
                 ! (allows easy restarts from any process count)
-                nprow_save = nprow
-                npcol_save = npcol
                 nprow = -1
                 npcol = -1
             Endif


### PR DESCRIPTION
Compiling using intel with '-check all' stops at runtime on uninitialized variables. This pr fixes some found running a Boussinesq hydro benchmark.  There are likely more.

It would be good if someone else could check my initialization of some of these.  In particular `ref_remember`.