### PR TITLE
Conda environment file for mac

### DIFF
--- a/environment_mac.yml
+++ b/environment_mac.yml
@@ -1,0 +1,21 @@
+name: radev_mac
+channels:
+  - conda-forge
+dependencies:
+  - basemap
+  - make
+  - git
+  - matplotlib
+  - jupyter
+  - scipy
+  - sphinx
+  - sphinxcontrib-bibtex
+  - nbsphinx
+  - pandoc
+  - recommonmark
+  - sphinx
+  - clang_osx-64
+  - gfortran_osx-64
+  - mkl
+  - fftw
+  - mpich


### PR DESCRIPTION
Mac, conda environment: the code would compile, but got the following error when trying to run it:
mpiexec -np 8 ./rayleigh.opt -nprow 4 -npcol 2
Fortran runtime error: Integer overflow when calculating the amount of memory to allocate

This is intended to fix this bug.