### PR TITLE
Activate compiler warnings and remove unused variables

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -23,7 +23,8 @@ jobs:
     - name: Build Rayleigh
       # First make sure notebooks do not contain output, then build doc
       run: |
-        ./configure --with-blas='/usr' --with-fftw='/usr' --with-lapack='/usr'
+        ./configure --with-blas='/usr' --with-fftw='/usr' --with-lapack='/usr' --FFLAGS_DBG='-O0 -g -fbounds-check -ffpe-trap=invalid,zero,overflow -fbacktrace -ffixed-line-length-132 -Wall'
+
         make fdeps && git diff --exit-code
         make -j
         make install
@@ -68,6 +69,6 @@ jobs:
       run: |
         cd "$GITHUB_WORKSPACE"
         export MKLROOT=$CONDA_PREFIX
-        ./configure -conda-mkl --FC=mpifort
+        ./configure -conda-mkl --FC=mpifort --FFLAGS_DBG='-O0 -g -fbounds-check -ffpe-trap=invalid,zero,overflow -fbacktrace -ffixed-line-length-132 -Wall'
         make -j
         make install

--- a/configure
+++ b/configure
@@ -49,7 +49,7 @@ function dbg_flags {
   fi
   if [[ $1 == "GNU" ]]
   then
-    echo '-O0 -g -fbounds-check -ffpe-trap=invalid,zero,overflow -fbacktrace -ffixed-line-length-132 -Wall -pedantic'
+    echo '-O0 -g -fbounds-check -ffpe-trap=invalid,zero,overflow -fbacktrace -ffixed-line-length-132'
   fi
 }
 

--- a/configure
+++ b/configure
@@ -49,7 +49,7 @@ function dbg_flags {
   fi
   if [[ $1 == "GNU" ]]
   then
-    echo '-O0 -g -fbounds-check -ffpe-trap=invalid,zero,overflow -fbacktrace -ffixed-line-length-132'
+    echo '-O0 -g -fbounds-check -ffpe-trap=invalid,zero,overflow -fbacktrace -ffixed-line-length-132 -Wall -pedantic'
   fi
 }
 

--- a/src/Diagnostics/Diagnostics_ADotGradB.F90
+++ b/src/Diagnostics/Diagnostics_ADotGradB.F90
@@ -449,7 +449,7 @@ Contains
         Real*8, Intent(InOut) :: cbuff(1:,my_r%min:,my_theta%min:,1:)
         Integer, Intent(In), Optional :: aindices(1:), bindices(1:), cindices(1:)
 
-        Integer :: r,k, t   !indices for iteration
+        Integer :: r, t   !indices for iteration
 
         Integer :: iar    , iatheta , iaphi    ! Abuff indices for a_r, a_theta, and a_phi
         Integer :: ibr    , ibtheta , ibphi    ! Bbuff indices for b_r, b_theta, and b_phi

--- a/src/Diagnostics/Diagnostics_Angular_Momentum.F90
+++ b/src/Diagnostics/Diagnostics_Angular_Momentum.F90
@@ -145,7 +145,6 @@ Contains
     Subroutine Compute_Angular_Momentum_Sources(buffer)
         Implicit None
         Real*8, Intent(InOut) :: buffer(1:,my_r%min:,my_theta%min:,1:)
-        Integer :: r,k, t
 
     End Subroutine Compute_Angular_Momentum_Sources
 

--- a/src/Diagnostics/Diagnostics_Axial_Field.F90
+++ b/src/Diagnostics/Diagnostics_Axial_Field.F90
@@ -47,7 +47,7 @@ Contains
                 qty = tmp1*qty
                 Call Add_Quantity(qty)
             Endif
-        Endif	
+        Endif
 
         If (compute_quantity(vm_z) .or. compute_quantity(vortm_z) .or. compute_quantity(kin_helicity_z_mm) .or.&
             compute_quantity(kin_helicity_z_mp) .or. compute_quantity(kin_helicity_z_pm)) Then
@@ -101,7 +101,7 @@ Contains
                 qty = tmp3*tmp4
                 Call Add_Quantity(qty)
             Endif
-        Endif	
+        Endif
 
         !/////////////////////////////////////////////////
         ! 2. The term involving dvzdz
@@ -111,7 +111,7 @@ Contains
                 (buffer(PSI,dvrdt)-buffer(PSI,vtheta))+one_over_r(r)*(buffer(PSI,vr)+buffer(PSI,dvtdt)) !dvzdz
             END_DO
             Call Add_Quantity(qty)
-        Endif	
+        Endif
 
         If (compute_quantity(dvzdz_m)) Then
             DO_PSI
@@ -120,14 +120,14 @@ Contains
                 m0_values(PSI2,dvtdt)) !dvzdz_m
             END_DO
             Call Add_Quantity(qty)
-        Endif	
+        Endif
         If (compute_quantity(dvzdz_p)) Then
             DO_PSI
                 qty(PSI)=fbuffer(PSI,dvrdr)-fbuffer(PSI,dvtdr)*tantheta(t)-cottheta(t)*one_over_r(r)*&
                 (fbuffer(PSI,dvrdt)-fbuffer(PSI,vtheta))+one_over_r(r)*(fbuffer(PSI,vr)+fbuffer(PSI,dvtdt)) !dvzdz_p
             END_DO
             Call Add_Quantity(qty)
-        Endif	
+        Endif
         !///////////////////////////////////////////
         ! 3. terms involving B_z/J_z/dTvardz/dPdz/
      

--- a/src/Diagnostics/Diagnostics_Custom.F90
+++ b/src/Diagnostics/Diagnostics_Custom.F90
@@ -105,7 +105,7 @@ Contains
 
         !=============================================
         ! Edit Below This Line (you may define your own variables below)
-        Real*8 :: mtmp1, mtmp2, mtmp3   ! temporary variables for use as needed
+        ! Real*8 :: mtmp1, mtmp2, mtmp3   ! temporary variables for use as needed
 
 
         ! TUTORIAL EXAMPLE 1:
@@ -190,7 +190,7 @@ Contains
         Integer :: r,k, t
         !=============================================
         ! Edit Below This Line (you may define your own variables below)
-        Real*8 :: htmp1, htmp2, htmp3   ! temporary variables for use if needed
+        ! Real*8 :: htmp1, htmp2, htmp3   ! temporary variables for use if needed
 
         ! Tutorial Exercise 2:
         !   Uncomment and modify the code below to assign

--- a/src/Diagnostics/Diagnostics_Interface.F90
+++ b/src/Diagnostics/Diagnostics_Interface.F90
@@ -152,9 +152,9 @@ Contains
         Integer, Intent(In) :: iteration
         Real*8, Intent(InOut) :: buffer(1:,my_r%min:,my_theta%min:,1:)
         Real*8, Intent(In) :: current_time
-        Real*8 :: over_n_phi, tmp, tmp2, tmp3
+        Real*8 :: over_n_phi
 
-        Integer :: p,t,r, nfields, bdims(1:4), pass_num, k
+        Integer :: nfields, bdims(1:4), pass_num
 
 
         If (time_to_output(iteration)) Then
@@ -271,7 +271,7 @@ Contains
 
     Subroutine Initialize_Diagnostics()
         Implicit None
-        Integer :: i, isize, n_phi, sig_pi = 314
+        Integer :: i, n_phi, sig_pi = 314
         Real*8 :: delr
         Character*120 :: grid_file
 

--- a/src/Diagnostics/Diagnostics_KE_Flux.F90
+++ b/src/Diagnostics/Diagnostics_KE_Flux.F90
@@ -34,8 +34,7 @@ Contains
         Real*8 :: htmp1, htmp2, htmp3             ! temporary variables for use if needed
         Real*8 :: one_over_rsin, ctn_over_r        ! spherical trig
         Real*8 :: Err,Ett,Epp, Ert,Erp,Etp        ! variables to store the components of the rate of strain
-        Real*8 :: Lap_r, Lap_t, Lap_p            ! variables to store Laplacians
-        Real*8 :: mu, dmudr                ! the dynamic viscosity and its radial derivativ
+        
         ! First, we compute the flux of total KE in each direction
         If (compute_quantity(ke_flux_radial) .or. compute_quantity(ke_flux_theta) &
             .or. compute_quantity(ke_flux_phi)) Then

--- a/src/Diagnostics/Diagnostics_Linear_Forces.F90
+++ b/src/Diagnostics/Diagnostics_Linear_Forces.F90
@@ -188,7 +188,7 @@ Contains
         Implicit None
         Real*8, Intent(InOut) :: buffer(1:,my_r%min:,my_theta%min:,1:)
         Integer :: r,k, t
-        Real*8 :: mypi, amp,del2u, estress
+        Real*8 :: del2u, estress
         Real*8, Allocatable :: mu_visc(:), dmudr(:), ovstheta(:), ovs2theta(:)
 
         Allocate(ovstheta(1:N_theta), ovs2theta(1:N_theta)) ! 1/sin; 1/sin^2

--- a/src/Diagnostics/Diagnostics_Mean_Correction.F90
+++ b/src/Diagnostics/Diagnostics_Mean_Correction.F90
@@ -206,7 +206,7 @@ Contains
         Logical :: compute_fluct_fluct = .false.
         Logical :: compute_mean_mean = .false.
         logical :: compute_mean_correct =.false.
-        Real*8 :: amp,del2u, estress
+        Real*8 :: del2u, estress
         Real*8, Allocatable :: mu_visc(:), dmudr(:), ovstheta(:), ovs2theta(:)
 
         compute_mean_correct = .false.

--- a/src/Diagnostics/Diagnostics_Thermal_Equation.F90
+++ b/src/Diagnostics/Diagnostics_Thermal_Equation.F90
@@ -28,7 +28,6 @@ Contains
     Subroutine Compute_Thermal_Equation_Terms(buffer)
         Implicit None
         Real*8, Intent(InOut) :: buffer(1:,my_r%min:,my_theta%min:,1:)
-        Integer :: r,k, t
         Call Compute_Thermal_Advective_Terms(buffer)
         Call Compute_Thermal_Diffusion_Terms(buffer)
         Call Compute_Thermal_HeatSource(buffer)
@@ -768,7 +767,6 @@ Contains
     Subroutine Compute_Ohmic_Heating_Diag(buffer)
         Implicit None
         Real*8, Intent(InOut) :: buffer(1:,my_r%min:,my_theta%min:,1:)
-        Real*8 :: dt_by_ds, dt_by_dp
         Integer :: r,k, t
         ! The "Diag" in the name refers to "diagnostics," and not "diagonal"
 
@@ -899,7 +897,6 @@ Contains
     Subroutine Compute_Thermal_HeatSource(buffer)
         Implicit None
         Real*8, Intent(InOut) :: buffer(1:,my_r%min:,my_theta%min:,1:)
-        Real*8, Allocatable :: rhot(:)
         Real*8 :: mean_rho, mean_t, mean_r2, mean_q, mean_dr
         Real*8 :: qadd, fpr2dr
         Integer :: r,k, t

--- a/src/Diagnostics/Diagnostics_Velocity_Diffusion.F90
+++ b/src/Diagnostics/Diagnostics_Velocity_Diffusion.F90
@@ -34,7 +34,7 @@ Contains
         Implicit None
         Real*8, Intent(InOut) :: buffer(1:,my_r%min:,my_theta%min:,1:)
         Integer :: r,k, t
-        Real*8 :: mypi, amp,del2u, estress
+        Real*8 :: del2u, estress
         Real*8, Allocatable :: mu_visc(:), dmudr(:), ovstheta(:), ovs2theta(:)
 
         Allocate(ovstheta(1:N_theta), ovs2theta(1:N_theta)) ! 1/sin; 1/sin^2

--- a/src/IO/General_IO.F90
+++ b/src/IO/General_IO.F90
@@ -102,7 +102,6 @@ Contains
     Subroutine Write_Rayleigh_Array(arr,filename)
         Implicit None
         Character*120, Optional, Intent(In) :: filename
-        Character*120 :: ref_file
         Integer :: i,j,nq,sig = 314, nx
         Real*8, Intent(In) :: arr(1:,1:)
         nx = size(arr,1)

--- a/src/IO/Spherical_IO.F90
+++ b/src/IO/Spherical_IO.F90
@@ -343,7 +343,7 @@ Contains
 
         ! First, initialize Spherical_3D.   It uses a separate buffer due to I/O semantics.
         fdir = 'Spherical_3D/'  ! Note: Full 3D only uses frequency, not nrec
-        Call Outputs(Spherical_3D)%Init(compute_q,myid, 54, fdir, &
+        Call Outputs(Spherical_3D)%Init(compute_q, 54, fdir, &
                           full3d_version, 1, full3d_frequency, &
                           values = full3d_values, nobuffer=.true.) 
 
@@ -352,38 +352,38 @@ Contains
 
         ! Now, initialize those outputs that use the new I/O for caching and parallel output.
         fdir = 'G_Avgs/'
-        Call Outputs(G_Avgs)%Init(compute_q,myid, 55, fdir, &
+        Call Outputs(G_Avgs)%Init(compute_q, 55, fdir, &
                           globalavg_version, globalavg_nrec, globalavg_frequency, &
                           values = globalavg_values, average_in_phi = .true. , &
                           average_in_theta = .true., average_in_radius = .true., &
                           cache_size = globalavg_cache_size, full_cache=.true.)
 
         fdir = 'Shell_Avgs/'
-        Call Outputs(Shell_Avgs)%Init(compute_q,myid, 156, fdir, &
+        Call Outputs(Shell_Avgs)%Init(compute_q, 156, fdir, &
                           shellavg_version, shellavg_nrec, shellavg_frequency, &
                           values = shellavg_values, average_in_phi = .true. , &
                           average_in_theta = .true., moments=4, &
                           cache_size = shellavg_cache_size, full_cache=.true.)
 
         fdir = 'Point_Probes/'
-        Call Outputs(Point_Probes)%Init(compute_q,myid, 63, fdir, &
+        Call Outputs(Point_Probes)%Init(compute_q, 63, fdir, &
                           probe_version, point_probe_nrec, point_probe_frequency, &
                           values = point_probe_values, cache_size = point_probe_cache_size, &
                           rinds = point_probe_r, tinds = point_probe_theta, & 
                           pinds = point_probe_phi)
 
         fdir = 'Meridional_Slices/'
-        Call Outputs(Meridional_Slices)%Init(compute_q,myid, 61, fdir, &
+        Call Outputs(Meridional_Slices)%Init(compute_q, 61, fdir, &
                           meridslice_version, meridional_nrec, meridional_frequency, &
                           values = meridional_values, pinds = meridional_indices)
 
         fdir = 'AZ_Avgs/'
-        Call Outputs(AZ_Avgs)%Init(compute_q,myid, 56, fdir, &
+        Call Outputs(AZ_Avgs)%Init(compute_q, 56, fdir, &
                           azavg_version, azavg_nrec, azavg_frequency, &
                           values = azavg_values, average_in_phi = .true. )
 
         fdir = 'Equatorial_Slices/'
-        Call Outputs(Equatorial_Slices)%Init(compute_q,myid, 60, fdir, &
+        Call Outputs(Equatorial_Slices)%Init(compute_q, 60, fdir, &
                           equslice_version, equatorial_nrec, equatorial_frequency, &
                           values = equatorial_values, tinds=(/ ntheta/2, ntheta/2+1 /), &
                           tweights = (/ 0.5d0, 0.5d0 /) ) 
@@ -394,26 +394,26 @@ Contains
         wmode = 1
         if (mem_friendly) wmode = 2
         fdir = 'Shell_Slices/'
-        Call Outputs(Shell_Slices)%Init(compute_q,myid, 58, fdir, &
+        Call Outputs(Shell_Slices)%Init(compute_q, 58, fdir, &
                           shellslice_version, shellslice_nrec, shellslice_frequency, &
                           values = shellslice_values, rinds = shellslice_levels, &
                           write_mode = wmode)
 
         fdir = 'Shell_Spectra/'
-        Call Outputs(Shell_Spectra)%Init(compute_q,myid, 59, fdir, &
+        Call Outputs(Shell_Spectra)%Init(compute_q, 59, fdir, &
                           shellspectra_version, shellspectra_nrec, shellspectra_frequency, &
                           values = shellspectra_values, rinds=shellspectra_levels, &
                           is_spectral = .true. , write_mode = wmode) 
 
         fdir = 'SPH_Modes/'
-        Call Outputs(SPH_Modes)%Init(compute_q,myid, 62, fdir, &
+        Call Outputs(SPH_Modes)%Init(compute_q, 62, fdir, &
                           sphmode_version, sph_mode_nrec, sph_mode_frequency, &
                           values = sph_mode_values, rinds=sph_mode_levels, &
                           is_spectral = .true. , write_mode = wmode, lvals=sph_mode_ell) 
 
         If (Test_IO) Then
             fdir = 'Temp_IO/'
-            Call Outputs(Temp_IO)%Init(compute_q,myid, 156, fdir, &
+            Call Outputs(Temp_IO)%Init(compute_q, 156, fdir, &
                               globalavg_version, globalavg_nrec, globalavg_frequency, &
                               values = globalavg_values, average_in_phi = .true. , &
                               average_in_theta = .true., average_in_radius = .true.)
@@ -726,9 +726,9 @@ Contains
         Real*8, Intent(in) :: simtime
         Integer, Intent(in) :: this_iter
         Class(DiagnosticInfo) :: self
-        INTEGER(kind=MPI_OFFSET_KIND) :: disp, hdisp, my_pdisp, new_disp, qdisp, full_disp, tdisp
+        INTEGER(kind=MPI_OFFSET_KIND) :: new_disp, full_disp
         Logical :: responsible, output_rank
-        Integer :: orank, funit, error, ncache, omode
+        Integer :: orank, funit, error, ncache
 
         If ((self%nq > 0) .and. (Mod(this_iter,self%frequency) .eq. 0 )) Then
 
@@ -803,21 +803,19 @@ Contains
         self%hdisp = self%hdisp+8*n
     End Subroutine Add_DHeader
 
-    Subroutine Initialize_Diagnostic_Info(self,computes,pid,mpi_tag, &
+    Subroutine Initialize_Diagnostic_Info(self,computes,mpi_tag, &
                  dir, version, nrec, frequency, values, &
-                 levels, phi_inds, cache_size, rinds, tinds, pinds, write_mode, &
+                 cache_size, rinds, tinds, pinds, write_mode, &
                  tweights, is_spectral, lvals, nobuffer, &
                  average_in_phi, average_in_radius, average_in_theta, moments, &
                  full_cache)
         Implicit None
         Integer :: i,ind, nmom
-        Integer, Intent(In) :: pid, mpi_tag, version, nrec, frequency
+        Integer, Intent(In) :: mpi_tag, version, nrec, frequency
         Integer, Intent(In), Optional :: cache_size, write_mode
         Character*120, Intent(In) :: dir
         Integer, Optional, Intent(In) :: moments
         Integer, Optional, Intent(In) :: values(1:)
-        Integer, Optional, Intent(In) :: levels(1:)
-        Integer, Optional, Intent(In) :: phi_inds(1:)
         Integer, Intent(InOut) :: computes(1:)
         Integer, Intent(In), Optional :: rinds(1:), tinds(1:), pinds(1:), lvals(1:)
 
@@ -827,7 +825,7 @@ Contains
         Logical, Intent(In), Optional :: nobuffer, average_in_phi, average_in_theta, average_in_radius
         !Real*8, Allocatable th_weights(:)
         Integer :: rcount, tcount, pcount, lcount, modcheck, nmax
-        Logical ::  spectral_io, spectral_buffer, nonstandard
+        Logical ::  spectral_io, nonstandard
         Integer :: avg_axes(1:3), ecode
         Integer, Allocatable :: indices(:,:)
         Real*8, Allocatable :: avg_weights(:,:)
@@ -1135,7 +1133,7 @@ Contains
         Integer, Intent(InOut) :: ierr
         Character*120 :: iterstring
         Character*120 :: filename
-        Integer :: modcheck, imod, file_iter, next_iter, ibelong, icomp
+        Integer :: modcheck, imod, ibelong, icomp
         Integer :: buffsize, funit
         Integer :: mstatus(MPI_STATUS_SIZE)
         integer(kind=MPI_OFFSET_KIND) :: disp
@@ -1348,7 +1346,7 @@ Contains
         Real*8, Intent(InOut) :: outbuff(my_rmin:,1:)
         Real*8, Allocatable :: tmp_buffer(:,:)
         Integer :: bdims(1:3)
-        Integer :: q,nq,r,t,p
+        Integer :: q,nq,r,t
         !Averages over theta and phi to get the spherically symmetric mean of all
         ! fields in inbuff at each radii
         ! inbuff is expected to be dimensioned as (my_r%min:my_r%max,my_theta%min:my_theta%max,1:nfields)
@@ -1390,7 +1388,7 @@ Contains
         Real*8, Intent(InOut) :: outbuff(1:)
         Real*8, Allocatable :: tmp_buffer(:)
         Integer :: bdims(1:2)
-        Integer :: q,nq,r,t,p
+        Integer :: q,nq,r
         !Averages over radius for all fields contained in inbuff
         ! fields in inbuff at each radii
         ! inbuff is expected to be dimensioned as (1:nphi,my_r%min:my_r%max,my_theta%min:my_theta%max,1:nfields)
@@ -1423,7 +1421,7 @@ Contains
 
     Subroutine IOComputeM0(qty)
         Real*8, Intent(In) :: qty(1:,my_rmin:,my_theta_min:)
-        Integer :: q,nq,r,t,p, ind
+        Integer :: r,t,p, ind
         !Averages over phi to get the azimuthally symmetric mean of all
         ! fields in inbuff at each radii and theta value.
         ! inbuff is expected to be dimensioned as (1:nphi,my_r%min:my_r%max,my_theta%min:my_theta%max,1:nfields)
@@ -1576,7 +1574,7 @@ Contains
         INTEGER, ALLOCATABLE :: ind_copy(:)
         LOGICAL, INTENT(In), Optional :: rev_inds
         INTEGER :: nnorm_coord, nbase_coord, numi
-        INTEGER :: i,j,k, ind, last_index
+        INTEGER :: i,j, last_index
         REAL*8 :: cdel, del1,del2, ccheck
         REAL*8 :: nrmc, cmin, tolchk = 2.0d0
 

--- a/src/Math_Layer/Chebyshev_Polynomials.F90
+++ b/src/Math_Layer/Chebyshev_Polynomials.F90
@@ -24,7 +24,6 @@ Module Chebyshev_Polynomials
     Implicit None
     Integer :: cp_nthreads
     Real*8, private ::    Pi  = 3.1415926535897932384626433832795028841972d+0
-    Real*8, private :: pi_over_N
     Logical :: DeAlias = .true.
     Logical :: Parity = .true.
     Logical :: initialized = .false.
@@ -75,7 +74,7 @@ Contains
 
         Real*8 :: domain_delta, scaling, upperb, lowerb, xmin,xmax
         Real*8 :: gmax, gmin, xx,int_scale
-        Integer :: r, i,n, domain_count
+        Integer :: i, n, domain_count
         Integer :: ind, ind2, n_max, dmx, gindex, db,scheck
         Logical :: custom_dealiasing = .false.
         Logical :: report
@@ -382,7 +381,7 @@ Contains
         Real*8 :: alpha, beta
         Real*8, Allocatable :: f_even(:,:,:,:), f_odd(:,:,:,:), c_temp(:,:,:,:)
         Integer :: i, j, k, kk, n2, n3, n4, dims(4),nsub,nglobal, hoff, hh
-        Integer :: istart, iend, n_even, n_odd, n_max, n_x
+        Integer :: n_even, n_odd, n_max, n_x
 
 
         beta = 0.0d0
@@ -569,7 +568,7 @@ Contains
         Integer, Intent(In)    :: ind, dind, dorder
         Real*8, Allocatable :: dbuffer(:,:,:)
         Integer :: dims(4), n,n2,n3, i,j,k, order
-        Integer :: kstart, kend, nthr,trank
+        Integer :: kstart, kend, trank
         Integer :: nglobal, nsub, hoff, hh
         dims = shape(buffer)
         nglobal = dims(1)

--- a/src/Math_Layer/Chebyshev_Polynomials_Alt.F90
+++ b/src/Math_Layer/Chebyshev_Polynomials_Alt.F90
@@ -240,13 +240,14 @@ Contains
         Real*8 :: alpha, beta
         Real*8, Allocatable :: f_even(:), f_odd(:), c_temp(:)
         Integer :: i, N_x, n_even, n_odd, n_max
-        alpha = 2.0d0/n_max
-        beta = 0.0d0
 
         n_x = self%n_x
         n_even = self%n_even
         n_odd = self%n_odd
         n_max = self%n_max
+
+        alpha = 2.0d0/n_max
+        beta = 0.0d0
 
         If (self%parity) Then
             Allocate(c_temp(1:n_even ))

--- a/src/Math_Layer/Fourier_Transform.F90
+++ b/src/Math_Layer/Fourier_Transform.F90
@@ -38,7 +38,7 @@ Contains
         Use Parallel_Framework, Only : pfi
         Implicit None
         ! Really just here for openmp init
-        integer :: iret, nthread
+        integer :: nthread
 
         nthread = pfi%nthreads
 #ifdef useomp

--- a/src/Math_Layer/Legendre_Transforms.F90
+++ b/src/Math_Layer/Legendre_Transforms.F90
@@ -148,10 +148,6 @@ Subroutine Test_Legendre
         Enddo
     Enddo
 
-
-
-103 format(d11.2)
-
     DeAllocate(theta)
     DeAllocate(ylm)
     DeAllocate(tmp)
@@ -977,9 +973,9 @@ Subroutine StP_4d_dgp2(data_in, data_out)
     Type(rmcontainer4d), Intent(In) :: data_in(:)
     Real*8, Intent(InOut) :: data_out(:,:,:)
     Real*8 :: alpha, beta
-    Real*8, Allocatable :: temp(:,:),temp2(:,:), temp3(:,:,:,:)
-    Integer :: m,nl,nt1,i,j,l, nt2, ddims(3), nrhs, jstart, jend,r,lstart
-    Integer :: nfield, rmn, rmx, oddims(4),imi,f,iend,istart
+    Real*8, Allocatable :: temp(:,:), temp3(:,:,:,:)
+    Integer :: m,nl,nt1,i,j,l, nt2, ddims(3), nrhs, jend,r
+    Integer :: nfield, rmn, rmx, oddims(4),imi,f
 
     ddims = shape(data_out)
     n_m = ddims(3)
@@ -1087,7 +1083,7 @@ Subroutine PtS_4d_dgpv3(data_in, data_out)
     Real*8, Allocatable :: temp(:,:,:,:),fodd(:,:,:), feven(:,:,:)
     Integer :: m,nl,nt1,i,j,l, nt2,ddims(3),k
     Integer :: oddims(4), nfield
-    Integer :: rmn, rmx, f, imi, istart, iend, jend,r
+    Integer :: rmn, rmx, f, imi, jend, r
 
     oddims = shape(data_out(1)%data)
     nfield = oddims(4)

--- a/src/Math_Layer/Linear_Solve.F90
+++ b/src/Math_Layer/Linear_Solve.F90
@@ -31,7 +31,7 @@ Module Linear_Solve
     Integer, Save, Private :: n_modes_total
     Integer, Save, Private, Allocatable :: nsub_modes(:)
 
-    Integer, Save, Private :: ndim1, ndim2, n_links, maximum_deriv_order        ! Variable used to keep track of linked equations (i.e. WPS)
+    Integer, Save, Private :: ndim1, ndim2, maximum_deriv_order        ! Variable used to keep track of linked equations (i.e. WPS)
 
     real*8, Save, Private :: LHS_time_factor, RHS_time_factor    ! Forward and Backward time-weighting of the implicit scheme.
     real*8, Allocatable :: dfield(:,:,:,:)
@@ -836,7 +836,7 @@ Module Linear_Solve
 
     Subroutine print_column(mode,col,eqind)
         Integer, Intent(In) :: mode, col, eqind
-        Integer :: rowblock,i
+        Integer :: i
         real*8, Pointer, Dimension(:,:) :: mpointer
         mpointer => equation_set(mode,eqind)%mpointer
         Do i = 1, ndim1*3
@@ -896,8 +896,8 @@ Module Linear_Solve
         Implicit None
         Class(Equation) :: self
 
-        Integer :: error, mtype, phase, mxfct, mnum, nrows
-        Integer :: msglvl, nrhs
+        Integer :: error, phase
+        Integer :: msglvl
         Real*8, Allocatable :: faux_rhs(:,:), faux_x(:,:)
         self%mtype = 11
         phase  = 33      ! only solve
@@ -940,8 +940,8 @@ Module Linear_Solve
         Implicit None
         Class(Equation) :: self
 
-        Integer :: error, mtype, solver,phase, mxfct, mnum, nrows
-        Integer :: msglvl, nrhs
+        Integer :: error, solver, phase
+        Integer :: msglvl
         self%nrows = self%nlinks*ndim1
         self%nrhs = size(self%rhs_pointer)/self%nrows
 

--- a/src/Parallel_Framework/ISendReceive.F90
+++ b/src/Parallel_Framework/ISendReceive.F90
@@ -255,7 +255,7 @@ Contains
         Real*8, Intent(Out)  :: x(1:,1:,1:,1:)
         Integer, Intent(In), Optional :: source, n_elements, tag,indstart(1:4)
         Type(communicator), Intent(In), Optional :: grp
-        Integer :: p, n, comm2, tag2, status(MPI_STATUS_SIZE)
+        Integer :: p, n, comm2, tag2
         Integer, Intent(Out) :: irq
         Integer :: istart,jstart,kstart,lstart
 
@@ -352,7 +352,7 @@ Contains
         Integer, Intent(In), Optional :: source, n_elements, tag,indstart(1:5)
         Type(communicator), Intent(In), Optional :: grp
         Integer, Intent(Out) :: irq
-        Integer :: p, n, comm2, tag2, status(MPI_STATUS_SIZE)
+        Integer :: p, n, comm2, tag2
         Integer :: istart,jstart,kstart,lstart,mstart
 
         If (Present(n_elements)) Then
@@ -608,7 +608,7 @@ Contains
         Integer, Intent(In), Optional :: source, n_elements, tag, istart
         Type(communicator), Intent(In), Optional :: grp
         Integer, Intent(Out) :: irq
-        Integer :: p, n, comm2, tag2, status(MPI_STATUS_SIZE), ione
+        Integer :: p, n, comm2, tag2, ione
 
         If (Present(n_elements)) Then
             n = n_elements
@@ -650,7 +650,7 @@ Contains
         Integer, Intent(In), Optional :: source, n_elements, tag, istart
         Type(communicator), Intent(In), Optional :: grp
         Integer, Intent(Out) :: irq
-        Integer :: p, n, comm2, tag2, status(MPI_STATUS_SIZE), ione
+        Integer :: p, n, comm2, tag2, ione
 
         If (Present(n_elements)) Then
            n = n_elements
@@ -692,7 +692,7 @@ Contains
         Integer, Intent(In), Optional :: source, n_elements, tag, indstart(1:2)
         Type(communicator),  Optional :: grp
         Integer, Intent(Out) :: irq
-        Integer :: p, n, comm2, tag2, status(MPI_STATUS_SIZE), ione, jone
+        Integer :: p, n, comm2, tag2, ione, jone
 
         If (Present(n_elements)) Then
             n = n_elements
@@ -736,7 +736,7 @@ Contains
         Integer, Intent(In), Optional :: source, n_elements, tag,indstart(1:3)
         Type(communicator), Intent(In), Optional :: grp
         Integer, Intent(Out) :: irq
-        Integer :: p, n, comm2, tag2, status(MPI_STATUS_SIZE)
+        Integer :: p, n, comm2, tag2
         Integer :: istart,jstart,kstart
 
         If (Present(n_elements)) Then
@@ -784,7 +784,7 @@ Contains
         Integer, Intent(In), Optional :: source, n_elements, tag, indstart(1:2)
         Type(communicator), Intent(In), Optional :: grp
         Integer, Intent(Out) :: irq
-        Integer :: p, n, comm2, tag2, status(MPI_STATUS_SIZE), istart, jstart
+        Integer :: p, n, comm2, tag2, istart, jstart
 
         If (Present(n_elements)) Then
            n = n_elements
@@ -827,7 +827,7 @@ Contains
         Integer, Intent(In), Optional :: source, n_elements, tag,indstart(1:3)
         Type(communicator), Intent(In), Optional :: grp
         Integer, Intent(Out) :: irq
-        Integer :: p, n, comm2, tag2, status(MPI_STATUS_SIZE)
+        Integer :: p, n, comm2, tag2
         Integer :: istart, jstart, kstart
 
         If (Present(n_elements)) Then

--- a/src/Parallel_Framework/Parallel_Framework.F90
+++ b/src/Parallel_Framework/Parallel_Framework.F90
@@ -39,7 +39,6 @@ Module Parallel_Framework
     Integer, Parameter, Public :: Cartesian = 1, Cylindrical = 2, Spherical = 3
     Integer, Parameter, Public :: p1 =1 ,s1 = 2, p2 = 3,s2a =4, p3a=5,p3b=6
     Public :: Load_Config, Full_Barrier, Main_MPI_Init
-    Character*6 :: ifmt = '(i4.4)' ! Integer format for indicating processor tag numbers in output
     Type, Public :: Parallel_Interface
         Type(Load_Config) :: my_1p, my_2p, my_3p    !  like my_r, my_theta in ASH
         Type(Load_Config) :: my_1s, my_2s, my_3s    !     like my_mp, my_n etc.
@@ -121,7 +120,6 @@ Contains
         Integer, Intent(In) ::  pars(1:)
         Integer, Intent(In) :: ncpus(1:)
         Integer :: pcheck, error
-        Integer :: ierr
         Character*6 :: istr
         Logical, Intent(In) :: init_only
         Class(Parallel_Interface) :: self
@@ -255,7 +253,7 @@ Contains
 #endif
 
         Class(Parallel_Interface) :: self
-        Integer :: my_mpi_rank,my_thread
+        Integer :: my_mpi_rank
         my_mpi_rank = pfi%gcomm%rank
 #ifdef useomp
         self%nthreads = omp_get_max_threads()

--- a/src/Parallel_Framework/Spherical_Buffer.F90
+++ b/src/Parallel_Framework/Spherical_Buffer.F90
@@ -443,11 +443,11 @@ Contains
         ! share a common set of ell-m values).
         Implicit None
 
-        Integer :: r,l, mp, lp, indx, r_min, r_max, dr,  cnt,i, imi, rind
-        Integer :: n1, n, nfields, offset, delta_r, rmin, rmax, np,p
+        Integer :: r, l, mp, lp, indx, r_min, r_max, dr,  cnt, i, imi
+        Integer :: n1, n, nfields, np, p
 
         Real*8, Allocatable :: send_buff(:),recv_buff(:)
-        Integer :: tnr, send_offset
+        Integer :: send_offset
 
         ! cargo information
         Integer :: inext, pcurrent
@@ -573,9 +573,9 @@ Contains
         ! Go from implicit configuration (1 physical) to configuration 2 (spectral)
         Implicit None
 
-        Integer :: r,l, mp, lp, indx, r_min, r_max, dr, cnt,i
-        Integer :: n, nfields, offset, delta_r, rmin, rmax, np,p,rind
-        Integer :: recv_offset, tnr
+        Integer :: r, l, mp, lp, indx, r_min, r_max, dr, cnt,i
+        Integer :: n, nfields, np, p
+        Integer :: recv_offset
         Integer :: imi, numalloc
         Integer, Intent(In), Optional :: extra_recv
         Real*8, Allocatable :: send_buff(:),recv_buff(:)

--- a/src/Physics/Benchmarking.F90
+++ b/src/Physics/Benchmarking.F90
@@ -594,7 +594,7 @@ Contains
         Integer, Intent(In) :: iteration
         Real*8, Intent(InOut) :: buffer(1:,my_r%min:,my_theta%min:,:)
         Real*8, Intent(In) :: current_time
-        Real*8 :: tmp, tmp2, tmp3, time_passed, over_n_phi
+        Real*8 :: tmp, tmp2, over_n_phi
         Real*8 :: rel_diff, mean_value, sdev_value
 
         Integer :: i,p,t,r, funit, iter_start, iter_end

--- a/src/Physics/BoundaryConditions.F90
+++ b/src/Physics/BoundaryConditions.F90
@@ -87,7 +87,6 @@ Contains
     Subroutine Initialize_Boundary_Conditions()
         Implicit None
         Real*8 :: tilt_angle_radians,a,b
-        Real*8 :: fsun
 
         fix_tvar_top = .not. fix_dtdr_top
         fix_tvar_bottom = .not. fix_dtdr_bottom
@@ -276,7 +275,7 @@ Contains
 
     Subroutine Transport_Dependencies()
         Implicit None
-        Real*8 :: fsun, lum_top, lum_bottom
+        Real*8 :: lum_top, lum_bottom
 
         ! Odd reference state quantities that somehow depend on 
         ! boundary conditions can be set here.

--- a/src/Physics/Checkpointing.F90
+++ b/src/Physics/Checkpointing.F90
@@ -40,9 +40,7 @@ Module Checkpointing
     Integer, private :: numfields = 4 ! 6 for MHD
     Integer, private :: check_err_off = 100  ! Checkpoint errors report in range 100-200.
     Integer, private :: checkpoint_version = 2
-    Integer,private,Allocatable :: mode_count(:)
     Integer,private :: checkpoint_tag = 425, read_var(1:12)
-    Integer, Allocatable, Private :: lmstart(:)
     Character*3 :: wchar = 'W', pchar = 'P', tchar = 'T', zchar = 'Z', achar = 'A', cchar = 'C'
     Character*120 :: checkpoint_prefix ='nothing'
     Character*6 :: auto_fmt = '(i2.2)'  ! Format code for quicksaves
@@ -73,7 +71,6 @@ Contains
     Subroutine Initialize_Checkpointing()
         Implicit None
         Integer :: nfs(6)
-        Integer :: p, np, nl, m, mp, rextra
         Integer, Allocatable :: gpars(:,:)
 
         checkpoint_t0 = stopwatch(walltime)%elapsed
@@ -121,7 +118,7 @@ Contains
         Implicit None
         Real*8, Intent(In) :: abterms(:,:,:,:), dt, new_dt, elapsed_time
         Integer, Intent(In) :: iteration
-        Integer :: mp, m, i, ecode,endian_tag
+        Integer :: i, ecode, endian_tag
         Character*120 :: autostring, iterstring, cfile, checkfile
         Character*256, Intent(Out) :: input_file 
         Character*120 :: coeff_file
@@ -224,8 +221,8 @@ Contains
         Implicit None
         Integer, Intent(In) :: iteration, read_pars(1:2)
         Real*8, Intent(InOut) :: fields(:,:,:,:), abterms(:,:,:,:)
-        Integer :: n_r_old, l_max_old, grid_type_old, nr_read
-        Integer :: i, ierr, m, p, np, mp, lb,ub, f,  r, ind
+        Integer :: n_r_old, l_max_old, grid_type_old
+        Integer :: i, ierr, mp, lb,ub
         Integer :: old_pars(7), fcount(3,2), version
         Integer :: last_iter, last_auto, endian_tag, funit
         Integer*8 :: found_bytes, expected_bytes, n_r_old_big, l_max_old_big
@@ -234,7 +231,7 @@ Contains
         Real*8 :: dt_pars(3),dt,new_dt
         Real*8, Allocatable :: old_radius(:), radius_old(:)
         Real*8, Allocatable :: tempfield1(:,:,:,:), tempfield2(:,:,:,:)
-        Character*120 :: autostring, cfile,  dstring, iterstring, access_type
+        Character*120 :: autostring, dstring, iterstring, access_type
         Character*256 :: grid_file, checkfile
         Character*1 :: under_slash 
         Character*13 :: szstr

--- a/src/Physics/Generic_Input.F90
+++ b/src/Physics/Generic_Input.F90
@@ -44,7 +44,7 @@ contains
     type(SphericalBuffer), intent(inout) :: field
     
     integer :: l_endian_tag, version, fmode, n_lmn, l_l_max, l_n_max, k_lm_owner, l_max_n
-    integer :: i, j, k, l, m, n, lm, mp, j1, jc, jf, jn, jo, ji, p, col_np, col_mp_min
+    integer :: i, j, k, l, m, n, lm, mp, j1, jc, jn, jo, ji, p, col_np, col_mp_min
     integer :: start_count, end_count, my_lmn_count, total_lmn_count, col_lmn_n, col_lmn_i, l_lm_count
     integer :: offset, ierr, funit
     integer(kind=MPI_ADDRESS_KIND) :: lb, int_size, real_size

--- a/src/Physics/Initial_Conditions.F90
+++ b/src/Physics/Initial_Conditions.F90
@@ -320,7 +320,7 @@ Contains
     Subroutine Generate_Random_Field(rand_amp, field_ind, infield,rprofile, &
                 & ell0_profile)
         Implicit None
-        Integer :: ncombinations, i, m, r, seed(1), mp,n, l, ind1, ind2
+        Integer :: ncombinations, i, m, r, seed(1), mp, l, ind1, ind2
         Integer :: mode_count, my_mode_start, my_mode_end, fcount(3,2)
         Integer, Intent(In) :: field_ind
         Real*8, Intent(In) :: rand_amp
@@ -880,7 +880,7 @@ Contains
         Implicit None
 
 
-        Integer :: r, l, m, mp
+        Integer :: r, m, mp
         Integer :: fcount(3,2)
         type(SphericalBuffer) :: tempfield
         fcount(:,:) = 1
@@ -1051,9 +1051,7 @@ Contains
 
     Subroutine Calculate_Conductive_Profile
         Implicit None
-        Integer :: i, r, old_code
-        Real*8 :: amp, grav_r_ref, dr, vhint, qadd2, ftest
-        Real*8 :: lum_top, lum_bottom, sfactor, diff, r2dr, qadd, dsdr_mean
+        Real*8 :: amp, ftest
         Real*8, Allocatable :: tmp1d(:), tmp1d2(:), tmp1d3(:)
         Allocate(tmp1d(1:N_R),tmp1d2(1:N_R))
         tmp1d(:) =0.0d0

--- a/src/Physics/Input.F90
+++ b/src/Physics/Input.F90
@@ -215,7 +215,7 @@ Contains
         Character(len=:), Allocatable, Intent(out) :: lines(:)
         Integer, Intent(Out) :: nlines, max_len
         Integer :: iunit,istat
-        Character(2048):: line, line2
+        Character(2048):: line
         Integer :: com_check, line_len, i
 
         ! This routine reads filename into the output character array 'lines.'
@@ -274,7 +274,7 @@ Contains
         ! Checks the command line for multiple run flag
         Implicit None
         Character*10 :: arg, arg2
-        Integer :: i, itemp
+        Integer :: i
         Logical :: eof_err
         Character*120 :: aline, ifile
         Integer :: errcheck,  rcount, cpu_count, cmin, mx_rank, mn_rank
@@ -383,8 +383,6 @@ Contains
             ! Checks the command line for acceptable arguments.
             ! Specified values overwrite namelist inputs.
             Implicit None
-            Character*120 :: arg, arg2
-            Integer :: i, itemp
 
             Call Read_CMD_Line('-new_iter' , new_iteration)
             Call Read_CMD_Line('-nprow'    , nprow)

--- a/src/Physics/PDE_Coefficients.F90
+++ b/src/Physics/PDE_Coefficients.F90
@@ -412,7 +412,7 @@ Contains
         ra_constants(4) = ref%Lorentz_Coeff
         ra_constants(8) = Ekman_Number*Dissipation_Number/Modified_Rayleigh_Number
         If (magnetism) Then
-        	ra_constants(9) = Ekman_Number**2*Dissipation_Number/(Magnetic_Prandtl_Number**2*Modified_Rayleigh_Number)
+            ra_constants(9) = Ekman_Number**2*Dissipation_Number/(Magnetic_Prandtl_Number**2*Modified_Rayleigh_Number)
         Endif ! if not magnetism, ra_constants(9) was initialized to zero
         DeAllocate(dtmparr, gravity)
     End Subroutine Polytropic_ReferenceND

--- a/src/Physics/ProblemSize.F90
+++ b/src/Physics/ProblemSize.F90
@@ -174,13 +174,13 @@ Contains
 
     Subroutine Auto_Assign_Domain_Decomp()
         Implicit None
-        Integer :: f1, f2, imax, i, j, npairs, sind, i3, i4, ii, jj
-        Integer :: fcount, nfact_ok
+        Integer :: f1, f2, imax, i, j, npairs, i3, i4, ii, jj
+        Integer :: fcount
         Integer :: nprow_max, npcol_max, jinds(1:3), iinds(1:4)
-        Integer, Allocatable, Dimension(:,:) :: factors_of_ncpu, factor_diff
+        Integer, Allocatable, Dimension(:,:) :: factors_of_ncpu
         Integer, Allocatable :: factor_type(:), suitable_factors(:,:,:)
         Logical, Allocatable :: factor_balanced(:), have_pair(:,:)
-        Real*8 :: ncpu_sqrt,r, rval, min_ratio, rdiff, rtol
+        Real*8 :: ncpu_sqrt, rval, min_ratio, rdiff, rtol
         Real*8, Allocatable :: ratio_measure(:,:)
         Logical :: fewer_npcol, hbal, rbal, need_pair
         ncpu_sqrt = sqrt(dble(ncpu))
@@ -315,7 +315,7 @@ Contains
 
     Subroutine Establish_Grid_Parameters()
         Implicit None
-        Integer :: cheby_count, bounds_count, i,r
+        Integer :: cheby_count, bounds_count, i
         Real*8 :: rdelta
         !Initialize everything related to grid resolution and domain bounds.
 
@@ -600,10 +600,8 @@ Contains
 
     Subroutine Halt_On_Error()
 
-        Integer :: esize, i,j,tmp, ecode
+        Integer :: i,j,tmp, ecode
         Character*6 :: istr, istr2
-        Character*12 :: dstring
-        Character*8 :: dofmt = '(ES12.5)'
         If (maxval(perr) .gt. 0) Then
             ecode = maxval(perr)
             If (my_rank .eq. 0) Then

--- a/src/Physics/Sphere_Driver.F90
+++ b/src/Physics/Sphere_Driver.F90
@@ -71,7 +71,7 @@ Contains
 
     Subroutine Main_Loop_Sphere()
         Implicit None
-        Integer ::  last_iteration, first_iteration,i,iret, sigflag
+        Integer ::  last_iteration, first_iteration, i, iret
         Integer :: io=15, ierr
         Real*8  :: captured_time, max_time_seconds
         Logical :: terminate_file_exists

--- a/src/Physics/Sphere_Hybrid_Space.F90
+++ b/src/Physics/Sphere_Hybrid_Space.F90
@@ -57,7 +57,7 @@ Contains
 
     Subroutine rlm_spacea()
         Implicit None
-        Integer :: mp,r,imi,m,l, ind_top
+        Integer :: mp
         Call StopWatch(rlma_time)%startclock()
 
         ! Zero out l_max mode
@@ -211,7 +211,7 @@ Contains
 
     Subroutine Hydro_Output_Derivatives()
         Implicit None
-        Integer :: r, l, m, mp, imi
+        Integer :: r, m, mp, imi
         ! Compute sin(theta) dP/dtheta and
         ! place it in the cobuffer
         Call d_by_dtheta(wsp%s2a,pvar,ftemp1)
@@ -260,7 +260,7 @@ Contains
 
     Subroutine Velocity_Derivatives()
         Implicit None
-        Integer :: r, l, m, mp, imi
+        Integer :: r, m, mp, imi
         !/////////////////////////////////
         ! sintheta dv theta dr
         Call d_by_dtheta(wsp%s2a,d2wdr2,ftemp1)    ! Store sintheta dwdtheta there for now.  We're going to use it a bit anyway.
@@ -415,7 +415,7 @@ Contains
 
     Subroutine Bfield_Derivatives()
         Implicit None
-        Integer :: r, l, m, mp, imi
+        Integer :: r, m, mp, imi
 
         ! These terms are only needed if we want to output
         ! inductions terms in the diagnostics
@@ -483,7 +483,7 @@ Contains
 
     Subroutine Hybrid_Output_Initial()
         Implicit None
-        Integer :: r, l, m, mp, imi
+        Integer :: r, m, mp, imi
         If (magnetism) Then
             Call Allocate_rlm_Field(ftemp3)
             Call Allocate_rlm_Field(ftemp4)
@@ -513,7 +513,7 @@ Contains
 
     Subroutine Hybrid_Output_Final()
         Implicit None
-        Integer :: r, l, m, mp, imi
+        Integer :: mp
         Do mp = my_mp%min, my_mp%max
             ASBUFFA(l_max,:,:,:) = 0.0d0
         Enddo

--- a/src/Physics/Sphere_Linear_Terms.F90
+++ b/src/Physics/Sphere_Linear_Terms.F90
@@ -35,7 +35,7 @@ Module Sphere_Linear_Terms
 Contains
     Subroutine Linear_Init()
         Implicit None
-        Real*8 :: amp, T,arg
+        Real*8 :: T
         Integer :: n, r, m, nm
         !Depending on process layout, some ranks may not participate in the solve
         If (my_num_lm .gt. 0) Then 
@@ -663,9 +663,6 @@ Contains
 
     Subroutine Enforce_Boundary_Conditions
         Implicit None
-        Real*8 :: bc_val
-        Integer :: uind, lind
-        Integer :: real_ind, imag_ind
 
         Call Apply_Boundary_Mask(bc_values)
         Call Domain_Continuity()
@@ -674,7 +671,7 @@ Contains
 
     Subroutine Domain_Continuity()
         Implicit None
-        Integer :: l, indx, ii,lp, j, k,n
+        Integer :: l, indx, ii, lp, j, n
         ! start applying the boundary and continuity conditions by setting
         ! the appropriate right hand sides.
 

--- a/src/Physics/Sphere_Physical_Space.F90
+++ b/src/Physics/Sphere_Physical_Space.F90
@@ -40,7 +40,7 @@ Module Sphere_Physical_Space
 Contains
     Subroutine physical_space()
         Implicit None
-        Integer :: t, r,k
+
         ! We aren't quite in physical space yet.
         ! 1st, get the phi derivatives
         Call StopWatch(dphi_time)%startclock()
@@ -587,8 +587,6 @@ Contains
     End Subroutine Momentum_Advection_Phi
     Subroutine Phi_Derivatives()
         Implicit None
-        Integer :: r,t,k
-
 
         Call d_by_dphi(wsp%p3a,vr,dvrdp)
         Call d_by_dphi(wsp%p3a,vtheta,dvtdp)
@@ -657,7 +655,6 @@ Contains
 
     Subroutine Diagnostics_Copy_and_Derivs()
         Implicit None
-        Integer :: t,r,k
         !Copy everything from out auxiliary output buffer into the main buffer
 
         wsp%p3a(:,:,:,dpdr) = cobuffer%p3a(:,:,:,dpdr_cb)

--- a/src/Physics/Sphere_Spectral_Space.F90
+++ b/src/Physics/Sphere_Spectral_Space.F90
@@ -269,7 +269,7 @@ Contains
     End Subroutine AdvanceTime
     Subroutine Finalize_EMF()
         Implicit None
-        Integer m, i,j,jstart,jend
+        Integer m, i
         ! we need to take one last radial derivative and combine terms
 
         If (chebyshev) Then


### PR DESCRIPTION
This PR activates gfortran warnings ('-Wall') during compilation in debug mode for the automatic tester. There are dozens of active warnings and this PR fixes all that I could easily identify and fix, mostly '-Wunused-parameter' and I think this can be safely merged if the tester passes. 

However, someone in a follow-up PR should go through the remaining warnings and see which ones can be addressed: https://github.com/gassmoeller/Rayleigh/runs/2697219115?check_suite_focus=true