### PR TITLE
Fix the versions in the conda environment to ones that are currently known to work

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -2,19 +2,21 @@ name: radev
 channels:
   - conda-forge
 dependencies:
-  - make
-  - git
-  - matplotlib
-  - jupyter
-  - scipy
-  - sphinx
-  - sphinxcontrib-bibtex
-  - nbsphinx
-  - pandoc
-  - recommonmark
-  - sphinx
-  - gcc_linux-64
-  - gfortran_linux-64
-  - mkl
-  - fftw
-  - mpich
+  - python=3.9
+  - make=4.3
+  - git=2.30
+  - matplotlib=3.4
+  - jupyter=1.0
+  - scipy=1.6
+  - sphinx=4.0
+  - sphinxcontrib-bibtex=2.2
+  - nbsphinx=0.8
+  - pandoc=2.13
+  - recommonmark=0.7
+  - gcc_linux-64=9.3
+  - gfortran_linux-64=9.3
+  - mkl=2020.4
+  - fftw=3.3
+  - mpich=3.4
+  - funcsigs=1.0
+  - vtk=9.0

--- a/environment_mac.yml
+++ b/environment_mac.yml
@@ -3,7 +3,6 @@ channels:
   - conda-forge
 dependencies:
   - python=3.9
-  - basemap=1.2
   - make=4.3
   - git=2.30
   - matplotlib=3.4

--- a/environment_mac.yml
+++ b/environment_mac.yml
@@ -2,19 +2,22 @@ name: radev
 channels:
   - conda-forge
 dependencies:
-  - make
-  - git
-  - matplotlib
-  - jupyter
-  - scipy
-  - sphinx
-  - sphinxcontrib-bibtex
-  - nbsphinx
-  - pandoc
-  - recommonmark
-  - sphinx
-  - clang_osx-64
-  - gfortran_osx-64
-  - mkl
-  - fftw
-  - mpich
+  - python=3.9
+  - basemap=1.2
+  - make=4.3
+  - git=2.30
+  - matplotlib=3.4
+  - jupyter=1.0
+  - scipy=1.6
+  - sphinx=4.0
+  - sphinxcontrib-bibtex=2.2
+  - nbsphinx=0.8
+  - pandoc=2.13
+  - recommonmark=0.7
+  - clang_osx-64=11.1
+  - gfortran_osx-64=9.3
+  - mkl=2020.4
+  - fftw=3.3
+  - mpich=3.4
+  - funcsigs=1.0
+  - vtk=9.0


### PR DESCRIPTION
Only mac so far, will give linux a quick whirl now.

Removed duplicate dependency on sphinx, added in vtk and funcsigs to allow generic input tests to run.