### PR TITLE
Unify acknowledgments and make citation more visible

### DIFF
--- a/ACKNOWLEDGE
+++ b/ACKNOWLEDGE
@@ -1,23 +1,9 @@
-For any work that uses Rayleigh, or work that uses software which incorporates Rayleigh source code, please acknowledge the authors and funding agencies as: 
-Rayleigh has been developed by Nicholas Featherstone with support by the National Science
-Foundation through the Computational Infrastructure for Geodynamics (CIG).  This
-effort was supported by NSF grants NSF-0949446 and NSF-1550901.
+For any work that uses Rayleigh, or work that uses software which incorporates
+Rayleigh source code, please acknowledge the authors and funding agencies as
+indicated in our online documentation:
 
+https://rayleigh-documentation.readthedocs.io/en/latest/doc/source/User_Guide/overview.html#referencing
 
-A paper describing the parallelization of Rayleigh and the accuracy of its algorithms is now in preparation. For this version
-of the code ONLY (version 0.9.x), please cite BOTH of the following references:
+If you have no access to the online documentation, please refer to the following file in the Rayleigh repository:
 
-(i) 
-Featherstone, N.A. & Hindman, B.W., 2016, “The spectral amplitude of stellar convec-
-tion and its scaling in the high-Rayleigh-number regime,” Astrophys. J., 818, 32
-{presents anelastic benchmarking results for Rayleigh}
-DOI:  10.3847/0004-637X/818/1/32
-
-
-(ii) 
-Matsui, H. et al., including Featherstone, N.A., 2016, “Performance benchmarks for
-a next generation numerical dynamo model,” Geochem., Geophys., Geosys., 17,1586
-{presents initial performance data from Rayleigh as measured on Intel Sandybridge processors}
-DOI:  10.1002/2015GC006159
-
-
+doc/source/User_Guide/overview.rst

--- a/doc/source/User_Guide/overview.rst
+++ b/doc/source/User_Guide/overview.rst
@@ -83,7 +83,7 @@ Please also cite the following references:
   }
 
 Rayleigh's development is supported by the
-National-Science-Foundation through the Geodynamo Working Group of the
+National Science Foundation through the Geodynamo Working Group of the
 Computational Infrastructure for Geodynamics (CIG,
 https://geodynamics.org/cig/working-groups/geodynamo/).
 
@@ -105,10 +105,9 @@ parallel design would not have been possible without earlier work by
 Gary Glatzmaier and Thomas Clune described in: :cite:`GLATZMAIER1984461`,
 :cite:`Glatzmaier1999`
 
-  Glatzmaier, G.A., 1984,Numerical simulations of stellar convective dynamos. I. the model and method,
+  Glatzmaier, G.A., 1984, Numerical simulations of stellar convective dynamos. I. the model and method,
   *J. Comp. Phys.*, 55(3), 461-484. ISSN 0021-9991, doi:10.1016/0021-9991(84)90033-0.
 
   Clune, T.C., Elliott, J.R., Miesch, M.S.,Toomre, J., and Glatzmaier, G.A., 1999,
   Computational aspects of a code to study rotating turbulent convection in
   spherical shells, Parallel Comp., 25, 361-380.
-  

--- a/doc/source/User_Guide/overview.rst
+++ b/doc/source/User_Guide/overview.rst
@@ -21,20 +21,7 @@ Rayleigh's diagnostics package is discussed in the companion document :ref:`DVal
 
 Referencing
 -----------
-Rayleigh's implementation of the pseudo-spectral algorithm and its
-parallel design would not have been possible without earlier work by
-Gary Glatzmaier and Thomas Clune described in: :cite:`GLATZMAIER1984461`,
-:cite:`Glatzmaier1999`
 
-  Glatzmaier, G.A., 1984,Numerical simulations of stellar convective dynamos. I. the model and method,
-  *J. Comp. Phys.*, 55(3), 461-484. ISSN 0021-9991, doi:10.1016/0021-9991(84)90033-0.
-
-  Clune, T.C., Elliott, J.R., Miesch, M.S.,Toomre, J., and Glatzmaier, G.A., 1999,
-  Computational aspects of a code to study rotating turbulent convection in
-  spherical shells, Parallel Comp., 25, 361-380.
-
-
-Rayleigh has been written by Nicholas Featherstone with contributions by others.
 We ask that you cite the appropriate references if you publish results that were obtained in some
 part using Rayleigh.  To cite other versions of the code, please see: https://geodynamics.org/cig/abc
 
@@ -95,18 +82,33 @@ Please also cite the following references:
   opturl="http://doi.wiley.com/10.1002/2015GC006159"
   }
 
-
-Acknowledging
--------------
-Rayleigh is written by Nicholas Featherstone and all Rayleigh contributors with
-National-Science-Foundation support through the Geodynamo Working Group of the
+Rayleigh's development is supported by the
+National-Science-Foundation through the Geodynamo Working Group of the
 Computational Infrastructure for Geodynamics (CIG,
 https://geodynamics.org/cig/working-groups/geodynamo/).
 
-Please acknowledge CIG as follows:
+Please acknowledge CIG support in your work as follows:
 
-.. note::
+  .. note::
 
-  Rayleigh is hosted and receives support from the Computational
-  Infrastructure for Geodynamics (CIG) which is supported by the
-  National Science Foundation awards NSF-0949446 and NSF-1550901.
+    Rayleigh is hosted and receives support from the Computational
+    Infrastructure for Geodynamics (CIG) which is supported by the
+    National Science Foundation awards NSF-0949446 and NSF-1550901.
+
+Acknowledging
+-------------
+
+.. include:: ../../../AUTHORS
+
+Rayleigh's implementation of the pseudo-spectral algorithm and its
+parallel design would not have been possible without earlier work by
+Gary Glatzmaier and Thomas Clune described in: :cite:`GLATZMAIER1984461`,
+:cite:`Glatzmaier1999`
+
+  Glatzmaier, G.A., 1984,Numerical simulations of stellar convective dynamos. I. the model and method,
+  *J. Comp. Phys.*, 55(3), 461-484. ISSN 0021-9991, doi:10.1016/0021-9991(84)90033-0.
+
+  Clune, T.C., Elliott, J.R., Miesch, M.S.,Toomre, J., and Glatzmaier, G.A., 1999,
+  Computational aspects of a code to study rotating turbulent convection in
+  spherical shells, Parallel Comp., 25, 361-380.
+  

--- a/doc/source/User_Guide/overview.rst
+++ b/doc/source/User_Guide/overview.rst
@@ -98,14 +98,10 @@ Please also cite the following references:
 
 Acknowledging
 -------------
-Rayleigh is written by Nicholas Featherstone with
-National-Science-Foundation support through the Geodynamo Working Group
-of the Computational Infrastructure for Geodynamics (CIG, geodynamics.org).
-
-The CIG Geodynamo Working Group Members are:
-Jonathon Aurnou, Benjamin Brown, Bruce Buffett, Nicholas Featherstone,
-Gary Glatzmaier, Eric Heien, Moritz Heimpel, Lorraine Hwang, Louise Kellogg,
-Hiroaki Matsui, Peter Olson, Krista Soderlund, Sabine Stanley, Rakesh Yadav.
+Rayleigh is written by Nicholas Featherstone and all Rayleigh contributors with
+National-Science-Foundation support through the Geodynamo Working Group of the
+Computational Infrastructure for Geodynamics (CIG,
+https://geodynamics.org/cig/working-groups/geodynamo/).
 
 Please acknowledge CIG as follows:
 

--- a/src/Physics/Main.F90
+++ b/src/Physics/Main.F90
@@ -106,6 +106,11 @@ Contains
             Call stdout%print(" Initialization Complete.")
             Call stdout%print(" //////////////////////////////////////")
             Call stdout%print(" ")
+            Call stdout%print(" Remember to cite Rayleigh in your publications:")
+            Call stdout%print(" Check the ACKNOWLEDGE file for more information.")
+            Call stdout%print(" ")
+            Call stdout%print(" //////////////////////////////////////")
+            Call stdout%print(" ")
         Endif
     End Subroutine Main_Initialization
 


### PR DESCRIPTION
Currently we explain how to cite and acknowledge Rayleigh in different location. This PR unifies this handling by letting the ACKNOWLEDGE file refer to the web documentation (or the local one for everyone without internet connection).

Also make clear with every Rayleigh run, where to look for citation information. The output now looks like the following:

```
-- Initializing Fields...
 ---- Specified parameters:
 ---- Hydro Init Type    : Benchmark (Christensen et al. 2001)
 -- Fields initialized.

 Initialization Complete.
 //////////////////////////////////////

 Remember to cite Rayleigh in your publications:
 Check the ACKNOWLEDGE file for more information.

 //////////////////////////////////////

 Timestep has changed from  0.00000E+00 to  1.00000E-04.
 Iteration:  00000001   DeltaT:  1.000E-04   Iter/sec:  0.000E+00
 Iteration:  00000002   DeltaT:  1.000E-04   Iter/sec:  1.186E+01
```

This is the last change I wanted to have for the release, so I appreciate comments to get the process started.