### PR TITLE
Build mac env

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -50,7 +50,12 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        
+        include:
+          - os: ubuntu-latest
+            environment: environment.yml
+          - os: macos-latest
+            environment: environment_mac.yml
+
     runs-on: ${{ matrix.os }}
 
     # Needs to be here to properly detect changes to conda
@@ -62,15 +67,9 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - uses: conda-incubator/setup-miniconda@v2
-      if: runner.os == Linux
       with:
         activate-environment: radev
-        environment-file: environment.yml
-    - uses: conda-incubator/setup-miniconda@v2
-      if: runner.os == macOS
-      with:
-        activate-environment: radev
-        environment-file: environment_mac.yml
+        environment-file: ${{ matrix.environment }}
     - name: Build documentation
       continue-on-error: true
       run: |

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -53,8 +53,10 @@ jobs:
         include:
           - os: ubuntu-latest
             environment: environment.yml
+            extra_configure_flag:
           - os: macos-latest
             environment: environment_mac.yml
+            extra_configure_flag: -mac-mkl
 
     runs-on: ${{ matrix.os }}
 
@@ -79,6 +81,6 @@ jobs:
       run: |
         cd "$GITHUB_WORKSPACE"
         export MKLROOT=$CONDA_PREFIX
-        ./configure -conda-mkl --FC=mpifort --FFLAGS_DBG='-O0 -g -fbounds-check -ffpe-trap=invalid,zero,overflow -fbacktrace -ffixed-line-length-132 -Wall'
+        ./configure ${{ matrix.extra_configure_flag }} -conda-mkl --FC=mpifort --FFLAGS_DBG='-O0 -g -fbounds-check -ffpe-trap=invalid,zero,overflow -fbacktrace -ffixed-line-length-132 -Wall'
         make -j
         make install

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -47,7 +47,12 @@ jobs:
 
   conda:
     name: conda-build
-    runs-on: [ubuntu-latest]
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+        
+    runs-on: ${{ matrix.os }}
+
     # Needs to be here to properly detect changes to conda
     # see https://github.com/conda-incubator/setup-miniconda#IMPORTANT
     defaults:
@@ -57,9 +62,15 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - uses: conda-incubator/setup-miniconda@v2
+      if: runner.os == Linux
       with:
         activate-environment: radev
         environment-file: environment.yml
+    - uses: conda-incubator/setup-miniconda@v2
+      if: runner.os == macOS
+      with:
+        activate-environment: radev
+        environment-file: environment_mac.yml
     - name: Build documentation
       continue-on-error: true
       run: |


### PR DESCRIPTION
This adds an automatic MacOS tester that builds the Rayleigh conda environment for Mac.

It seems the tester fails, because Mac's default `ld` does not recognize the `--no-as-needed` option. Will investigate further later.