### PR TITLE
do not install sphinx via apt

### DIFF
--- a/docker/rayleigh-buildenv-focal/Dockerfile
+++ b/docker/rayleigh-buildenv-focal/Dockerfile
@@ -15,7 +15,6 @@ RUN apt update && \
     nano \
     wget \
     python3-pip \
-    sphinx-common \
     texlive-base \
     texlive-latex-base \
     texlive-latex-recommended \


### PR DESCRIPTION
This breaks the documentation build because the pip version conflicts with the
one from apt. The Ubuntu focal container ends up having an incompatible version
of pygments. The current pip install command pulls in sphinx as a dependency so
there is no need for installing it also via apt.

I am not sure if this fixes the documentation build issues producing all italics because I couldn't reproduce the issue on my system.