### PR TITLE
Read only some parts of file

### DIFF
--- a/post_processing/rayleigh_diagnostics.py
+++ b/post_processing/rayleigh_diagnostics.py
@@ -1320,6 +1320,8 @@ class Shell_Spectra:
         self.time = self.time[iitervals]
         self.iters = self.iters[iitervals]
         self.qv = qv[iqvals]
+        self.radius = radius[irvals]
+        self.inds = irvals
 
         self.niter = len(iitervals)
         self.nq = len(iqvals)

--- a/post_processing/rayleigh_diagnostics.py
+++ b/post_processing/rayleigh_diagnostics.py
@@ -1045,7 +1045,7 @@ class Shell_Slices:
         # now read only the records/slices we want
         self.iters = np.zeros(nrec,dtype='int32')
         self.time  = np.zeros(nrec,dtype='float64')
-        self.vals  = np.zeros((nphi, ntheta, len(irvals), len(iqvals), len(iitervals)),dtype='complex128')
+        self.vals  = np.zeros((nphi, ntheta, len(irvals), len(iqvals), len(iitervals)))
 
         # loop over everything, in Fortran/Rayleigh order
         offset = 0

--- a/post_processing/rayleigh_diagnostics.py
+++ b/post_processing/rayleigh_diagnostics.py
@@ -977,7 +977,7 @@ class Shell_Slices:
            rec0       : Set to true to read the first timestep's data only.
            irvals     : read only radial levels denoted by irvals (0-based indexing)
            qvals      : read only quantity codes denoted by qvals
-           iitervalsi : read only records denoted by iitervals (0-based indexing)
+           iitervals  : read only records denoted by iitervals (0-based indexing)
            NOTE: irvals, qvals, iitervals can be non-contiguous; they trump the earlier slice_spec and rec0; scalars are interpreted as rank-1 arrays
            rec0=True is equivalent to iitervals=0
            slice_spec = [time index, quantity code, radial index] = [iiterval, qval, irval]
@@ -1217,6 +1217,11 @@ class Shell_Spectra:
         """
            filename  : The reference state file to read.
            path      : The directory where the file is located (if full path not in filename)
+           irvals     : read only radial levels denoted by irvals (0-based indexing)
+           qvals      : read only quantity codes denoted by qvals
+           iitervals  : read only records denoted by iitervals (0-based indexing)
+           NOTE: irvals, qvals, iitervals can be non-contiguous; scalars are interpreted as rank-1 arrays
+
         """
         if (filename == 'none'):
             the_file = path+'00000001'
@@ -1263,13 +1268,15 @@ class Shell_Spectra:
                 iqvals[j] = np.argmin(np.abs(qv - qval))
 
         # now read only the records/slices we want
+        # we'll read each iter and time value at first, then keep 
+        # only the ones for slices we read
         self.iters = np.zeros(nrec,dtype='int32')
         self.time  = np.zeros(nrec,dtype='float64')
         self.vals  = np.zeros((nell, nm, len(irvals), len(iqvals), len(iitervals)),dtype='complex128')
 
         # loop over everything, in Fortran/Rayleigh order
         offset = 0
-        for iiter in range(nrec):
+        for iiter in range(len(iitervals)):
             tmp_real = []
             tmp_imag = []
             for icomplex in range(2):


### PR DESCRIPTION
This changes the Shell_Spectra class to have the ability to read one radial level, one record, and/or one quantity, without reading the whole binary file (uses the offset keyword arg in numpy.fromfile). Interface is unchanged except Shell_Spectra now takes the keyword args (default None)

iitervals
qvals
irvals

For example, Shell_Spectra(fname, path, iitervals=1, qvals=801, irvals=[2,4]).

returns the spectrum of the 2nd record, for the radial magnetic field only, at the 3rd and 5th radial levels. Dimensionality of the vals/lpower arrays will be unchanged. In this case shape (vals) = (nell, nm, 2, 1, 1)

If no new keyword args are specified, behavior is the same as before. 

@tukss and @feathern, I know the new memory-mapping framework may make this obsolete, but in the meantime I think this is a quick way to start reading sections of files quickly. 

I have run some tests and it seems to work as intended, with reading shorter parts of file going much faster than reading the whole file. If other people want to try it out too (and it works for them as well!) it should be straightforward to extend this to the other classes.