### PR TITLE
Allow changing the executable name at the "make install" step

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,9 +72,21 @@ clear_ipynb:
 
 .PHONY: install
 install:
+ifeq ($(target), "all")
 	@echo "Installing executables into: " $(PREFIX)"/bin"
 	@mkdir -p $(PREFIX)/bin
 	@cp $(BUILD)/compiled/rayleigh.* $(PREFIX)/bin/.
+else
+ifdef output
+	@echo "Installing rayleigh.$(target) into: " $(PREFIX)"/bin/$(output)"
+	@mkdir -p $(PREFIX)/bin
+	@cp $(BUILD)/compiled/rayleigh.$(target) $(PREFIX)/bin/$(output)
+else
+	@echo "Installing executables into: " $(PREFIX)"/bin"
+	@mkdir -p $(PREFIX)/bin
+	@cp $(BUILD)/compiled/rayleigh.* $(PREFIX)/bin/.
+endif
+endif
 
 .PHONY: doc
 doc:

--- a/doc/source/User_Guide/installation.rst
+++ b/doc/source/User_Guide/installation.rst
@@ -56,8 +56,9 @@ these commands:
 
 #. **make install** – This places the Rayleigh executables in
    Rayleigh/bin. If you would like to place them in (say)
-   /home/my_rayleigh, run configure as: **./configure
-   –prefix=/home/my_rayleigh**.
+   /home/my_rayleigh/bin, run configure as: **./configure
+   –prefix=/home/my_rayleigh**, i.e., the executables will be placed in the
+   **$(prefix)/bin** directory.
 
 For most builds, two executables will be created: rayleigh.opt and
 rayleigh.dbg. Use them as follows:
@@ -77,6 +78,42 @@ etc. will be placed in Rayleigh/bin. This is useful if running on a
 machine with heterogeneous node architectures (e.g., Pleiades). If you
 are not running on such a machine, pick the appropriate vectorization
 level, and rayleigh.opt will be compiled using that vectorization level.
+
+The default behavior of the **make** command is to build both the
+optimized, **rayleigh.opt**, and the debug versions, **rayleigh.dbg**. As
+described above, if Intel is used and *all* is selected, every version will
+be compiled. To build only a single version, the **target=<target>** option
+may be used at the **make** stage, for example:
+
+#. **make target=opt** - build only the optimzed version, **rayleigh.opt**
+
+#. **make target=dbg** - build only the debug version, **rayleigh.dbg**
+
+#. **make target=avx** - build only the AVX version, **rayleigh.avx**
+
+When building a single target, the final name of the executable can be changed
+with the **output=<output>** option during the **make install** command. For example,
+to build the optimized version and name the executable **a.out**:
+
+#. **make target=opt** - only build the optimized version
+
+#. **make target=opt output=a.out install** - install the optimized version as **a.out**
+
+Inspection of the **$(prefix)/bin** directory (specified at configure time with the -prefix
+option) will show a new file named **a.out**.
+
+If both the optimized version and the debug version have already been built, they
+can be renamed at install time as:
+
+#. **make** - build both optimized and debug verion (or all versions)
+
+#. **make target=opt output=a.out.opt install** - install and rename the optimzed version
+
+#. **make target=dbg output=a.out.dbg install** - install and rename the debug version
+
+The **output** option is only respected when a particular **target** is specified. Running
+**make output=a.out install** will install all **rayleigh.*** executables, they will not
+be renamed.
 
 Verifying Your Installation
 ---------------------------


### PR DESCRIPTION
The default behavior when you do "make target=opt" is to build only the optimized executable and it will be named "rayleigh.opt". Similarly, "make target=dbg" will build the debug version "rayleigh.dbg". The executables are then placed into the bin directory with "make install", but the filenames are always rayleigh.opt or rayleigh.dbg.

When actively developing multiple branches, it can be a little hard to keep track of what executable came from what branch. This PR allows you to change the name of the executable when doing "make install", but only if you requested a particular target.

To build the optimized version and call the executable "branch1.opt", the following would be used:
`make target=opt`
`make target=opt output=branch1.opt install
The resulting executable will be placed into the PREFIX directory, just as before. The added "output=" argument is only used if there is a target specified.

I would view this more of a tool for developers who compile multiple optimized/debug versions at once. The user might find this useful as well, but it grew out of an annoyance while developing multiple branches.