### PR TITLE
Fix issue with calculating the resolution in spectral_utils.py module

### DIFF
--- a/post_processing/spectral_utils.py
+++ b/post_processing/spectral_utils.py
@@ -346,10 +346,10 @@ def grid_size(N, spectral, dealias=1.0):
     """
     if (spectral):
         Npoly_max = N
-        Ngrid = int(dealias*(Npoly_max+1))
+        Ngrid = int(np.floor(dealias*(Npoly_max+1)))
     else:
         Ngrid = N
-        Npoly_max = int(Ngrid/dealias - 1)
+        Npoly_max = int(np.ceil(Ngrid/dealias - 1))
     return Ngrid, Npoly_max
 
 class Fourier:


### PR DESCRIPTION
The resolutions were previously computed by converting a float into an integer, ignoring any decimal contribution. Now the code rounds in the appropriate direction, similarly to what Rayleigh does.

Thanks to @illorenzo7 for finding this bug and suggesting the fix.