### PR TITLE
fix attribute access in reference_tools

### DIFF
--- a/post_processing/reference_tools.py
+++ b/post_processing/reference_tools.py
@@ -39,7 +39,7 @@ class equation_coefficients:
         if name in self.f_dict:
             self.set_function(value, name)
         elif name in self.c_dict:
-            self.set_constant[name]
+            self.set_constant(value, name)
         else:
             super().__setattr__(name, value)
 


### PR DESCRIPTION
This interface never worked before. With the fix you can do things like `r.diff_fact = 1.0` and it will call the appropriate setter for constants. It already worked for functions.git push --set-upstream origin fix-set-constant