### PR TITLE
Remove dimensional flag

### DIFF
--- a/input_examples/c2001_case1_input
+++ b/input_examples/c2001_case1_input
@@ -58,7 +58,6 @@ Magnetic_Prandtl_Number = 5.0d0
 reference_type = 1
 heating_type = 0
 gravity_power = 1.0d0
-dimensional = .false.
 /
 &Transport_Namelist
 /

--- a/input_examples/j2011_steady_hydro_input
+++ b/input_examples/j2011_steady_hydro_input
@@ -51,7 +51,6 @@ poly_Nrho = 5.0d0
 poly_mass = 1.9D30
 poly_rho_i = 1.1d0
 pressure_specific_heat = 1.0509d8
-dimensional = .true.
 angular_velocity = 1.76d-4
 /
 &Transport_Namelist

--- a/input_examples/j2011_steady_mhd_input
+++ b/input_examples/j2011_steady_mhd_input
@@ -54,7 +54,6 @@ poly_Nrho = 3.0d0
 poly_mass = 1.9D30
 poly_rho_i = 1.1d0
 pressure_specific_heat = 1.0509d8
-dimensional = .true.
 angular_velocity = 1.76d-4
 /
 &Transport_Namelist

--- a/src/Physics/Benchmarking.F90
+++ b/src/Physics/Benchmarking.F90
@@ -228,7 +228,6 @@ Contains
             poly_mass = 1.9D30
             poly_rho_i = 1.1d0
             pressure_specific_heat = 1.0509d8
-            !dimensional = .true.
             angular_velocity = 1.76d-4
 
             !Transport Namelist
@@ -291,7 +290,6 @@ Contains
             poly_mass = 1.9D30
             poly_rho_i = 1.1d0
             pressure_specific_heat = 1.0509d8
-            !dimensional = .true.
             angular_velocity = 1.76d-4
 
             !Transport Namelist


### PR DESCRIPTION
This flag is no longer used by Rayleigh and will cause the code to crash if not deleted from the "_input" benchmark main_input files. 