### PR TITLE
add new configure option -ifort-march

### DIFF
--- a/configure
+++ b/configure
@@ -211,7 +211,11 @@ function displayhelp {
     echo "      library.  Set this flag to link statically instead."
     echo ""
 
-
+    echo "  --ifort-march ; -ifort-march:"
+    echo "      ifort only: Use the generic -march options for architecture selection "
+    echo "      instead of the -x options. This is needed for optimizing the code for "
+    echo "      non-Intel CPUs."
+    echo ""
 
     echo "  --with-mkl=<path to the MKL root directory>"
     echo "      Set this value if the MKLROOT environment variable is not set on your"
@@ -401,6 +405,10 @@ do
 
     --static-fftw | -static-fftw )
       STATICFFTW="TRUE";
+      ;;
+
+    --ifort-march | -ifort-march )
+      IFORTMARCH="TRUE";
       ;;
 
     --CC=*)
@@ -623,27 +631,41 @@ then
   echo " -- Support for all of the above    :  FAT"
   echo ""
     OPTIONS="SSE4.2 AVX AVX2 AVX512 ALL FAT NONE"
+    if [[ $IFORTMARCH == TRUE ]]
+    then
+            OSSE42="-march=corei7"
+            OAVX="-march=corei7-avx"
+            OAVX2="-march=core-avx2"
+            # There seems to be no direct equivalent for COMMON-AVX512 using the march option.
+            OAVX512="-xCOMMON-AVX512 -axCORE-AVX512,MIC-AVX512"
+    else
+            OSSE42="-xSSE4.2"
+            OAVX="-xAVX"
+            OAVX2="-xCORE-AVX2"
+            OAVX512="-xCOMMON-AVX512 -axCORE-AVX512,MIC-AVX512"
+    fi
+
     select opt in $OPTIONS; do
        if [ "$opt" = "SSE4.2" ]; then
-        FFLAGS[0]=$OPT_FLAGS" -xSSE4.2"
+        FFLAGS[0]=$OPT_FLAGS" $OSSE42"
         break
        elif [ "$opt" = "AVX" ]; then
-        FFLAGS[0]=$OPT_FLAGS" -xAVX"
+        FFLAGS[0]=$OPT_FLAGS" $OAVX"
         break        
        elif [ "$opt" = "AVX2" ]; then
-        FFLAGS[0]=$OPT_FLAGS" -xCORE-AVX2"
+        FFLAGS[0]=$OPT_FLAGS" $OAVX2"
         break            
        elif [ "$opt" = "AVX512" ]; then
-        FFLAGS[0]=$OPT_FLAGS" -xCOMMON-AVX512 -axCORE-AVX512,MIC-AVX512"
+        FFLAGS[0]=$OPT_FLAGS" $OAVX512"
         break      
        elif [ "$opt" = "ALL" ]; then
          DEFAULT='avx2'
          nvers=5
          MULTIVEC=TRUE
-         FFLAGS[0]=$OPT_FLAGS" -xCORE-AVX2"
-         FFLAGS[2]=$OPT_FLAGS" -xAVX"
-         FFLAGS[3]=$OPT_FLAGS" -xSSE4.2"
-         FFLAGS[4]=$OPT_FLAGS" -xCOMMON-AVX512 -axCORE-AVX512,MIC-AVX512"
+         FFLAGS[0]=$OPT_FLAGS" $OAVX2"
+         FFLAGS[2]=$OPT_FLAGS" $OAVX"
+         FFLAGS[3]=$OPT_FLAGS" $OSSE42"
+         FFLAGS[4]=$OPT_FLAGS" $OAVX512"
          RVALUES[0]=$DEFAULT 
          RVALUES[2]=avx
          RVALUES[3]=sse
@@ -653,7 +675,7 @@ then
          RVTAGS[4]="AVX512"
          break
        elif [ "$opt" = "FAT" ]; then
-        FFLAGS[0]=$OPT_FLAGS" -xSSE4.2 -axAVX,CORE-AVX2,CORE-AVX512,MIC-AVX512"
+        FFLAGS[0]=$OPT_FLAGS" $OSSE42 -axAVX,CORE-AVX2,CORE-AVX512,MIC-AVX512"
         break
        elif [ "$opt" == "NONE" ]; then
          FFLAGS[0]=$OPT_FLAGS


### PR DESCRIPTION
This makes ifort use the `-march` option instead of the equivalent `-x`
option. Executables built with the latter option do not run on non-Intel
CPUs. I am keeping this as a nondefault option as I am not sure if there
is a decrease in performance using `-march`.

There is no direct `-march` equivalent for the AVX512 option. Leaving it
as is, as there is no non-Intel AVX512 processor available at the time
of writing.