### PR TITLE
Small bug (missing pathname) for equation_coefficients file

### DIFF
--- a/src/Physics/PDE_Coefficients.F90
+++ b/src/Physics/PDE_Coefficients.F90
@@ -798,7 +798,7 @@ Contains
         If (present(filename)) Then
             ref_file = Trim(my_path)//filename
         Else
-            ref_file = 'reference'
+            ref_file = Trim(my_path)//'reference'
         Endif
 
         Open(unit=15,file=ref_file,form='unformatted', status='old',access='stream')

--- a/src/Physics/PDE_Coefficients.F90
+++ b/src/Physics/PDE_Coefficients.F90
@@ -755,7 +755,7 @@ Contains
         If (present(filename)) Then
             ref_file = Trim(my_path)//filename
         Else
-            ref_file = 'equation_coefficients'
+            ref_file = Trim(my_path)//'equation_coefficients'
         Endif
 
         If (my_rank .eq. 0) Then


### PR DESCRIPTION
The equation_coefficients file was going to the parent directory in ensamble mode, due to a missing "my_path" in front of the file name. 