### PR TITLE
Remove MPI warnings in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,6 +6,10 @@ concurrency:
   group: ${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  # Fix OpenMPI issue in Docker : https://github.com/open-mpi/ompi/issues/4948
+  OMPI_MCA_btl_vader_single_copy_mechanism: none
+
 jobs:
   test:
     name: linux-bionic-container-build


### PR DESCRIPTION
This fixes #277. I saw this in https://github.com/geodynamics/calypso/pull/20 so thanks @hirokemono for showing me the fix.
The results of the CI tests are now clean, as can be seen here: https://github.com/gassmoeller/Rayleigh/runs/3654465525?check_suite_focus=true