### PR TITLE
Thermal Energy Equation Output Bug Fixes

### DIFF
--- a/src/Diagnostics/Diagnostics_Thermal_Equation.F90
+++ b/src/Diagnostics/Diagnostics_Thermal_Equation.F90
@@ -109,7 +109,7 @@ Contains
 
             If (compute_quantity(s_diff)) Then
                 DO_PSI
-                    tmp1(PSI) = tmp1(PSI)+qty(PSI)
+                    qty(PSI) = tmp1(PSI)+qty(PSI)
                 END_DO
                 Call Add_Quantity(qty)
             Endif
@@ -169,7 +169,7 @@ Contains
 
             If (compute_quantity(sp_diff)) Then
                 DO_PSI
-                    tmp1(PSI) = tmp1(PSI)+qty(PSI)
+                    qty(PSI) = tmp1(PSI)+qty(PSI)
                 END_DO
                 Call Add_Quantity(qty)
             Endif
@@ -228,7 +228,7 @@ Contains
 
             If (compute_quantity(sm_diff)) Then
                 DO_PSI
-                    tmp1(PSI) = tmp1(PSI)+qty(PSI)
+                    qty(PSI) = tmp1(PSI)+qty(PSI)
                 END_DO
                 Call Add_Quantity(qty)
             Endif
@@ -885,7 +885,7 @@ Contains
             qty(PSI) = qty(PSI)-tmp*tmp*one_third   ! + 2*e_phi_theta**2
         END_DO
         DO_PSI
-            qty(PSI) = viscous_heating_coeff(r)*qty(PSI)
+            qty(PSI) = viscous_heating_coeff(r)*qty(PSI)*ref%density(r)*ref%temperature(r)
         END_DO
 
 


### PR DESCRIPTION
This commit fixes two bugs in the thermal energy equation output:
1)  For the full, mean, and fluctuating conductive heating terms (div dot F_cond), the contribution from horizontal diffusion was omitted, and only the radial contribution was recorded (see the changed lines of code).
2) For the viscous heating, a factor of density x temperature was erroneously omitted.  This is probably because that code was copied and modified from the main code, where the entropy equation, not the heat equation (rho_bar x T_bar x S) is solved.
 
In total, four lines of code are modified as part of this PR.