### PR TITLE
Ohmic Heating Prefactor Fix (output bug)

### DIFF
--- a/src/Diagnostics/Diagnostics_Thermal_Equation.F90
+++ b/src/Diagnostics/Diagnostics_Thermal_Equation.F90
@@ -775,7 +775,8 @@ Contains
                 DO_PSI
                     qty(PSI) = ohmic_heating_coeff(r)*(buffer(PSI,curlbr)**2 + &
                                &   buffer(PSI,curlbtheta)**2 + &
-                               &   buffer(PSI,curlbphi)**2)
+                               &   buffer(PSI,curlbphi)**2) &
+                               & *ref%density(r)*ref%temperature(r)
                 END_DO
             Else
                 qty(:,:,:) = 0.0d0
@@ -787,7 +788,8 @@ Contains
                 DO_PSI
                     qty(PSI) = ohmic_heating_coeff(r)*(fbuffer(PSI,curlbr)**2 + &
                                &   fbuffer(PSI,curlbtheta)**2 + &
-                               &   fbuffer(PSI,curlbphi)**2)
+                               &   fbuffer(PSI,curlbphi)**2) &
+                               & *ref%density(r)*ref%temperature(r)
                 END_DO
             Else
                 qty(:,:,:) = 0.0d0
@@ -800,7 +802,8 @@ Contains
                 DO_PSI
                     qty(PSI) = ohmic_heating_coeff(r)*(fbuffer(PSI,curlbr)*m0_values(PSI2,curlbr) + &
                                &   fbuffer(PSI,curlbtheta)*m0_values(PSI2,curlbtheta) + &
-                               &   fbuffer(PSI,curlbphi)*m0_values(PSI2,curlbphi))
+                               &   fbuffer(PSI,curlbphi)*m0_values(PSI2,curlbphi)) &
+                               & *ref%density(r)*ref%temperature(r)
                 END_DO
             Else
                 qty(:,:,:) = 0.0d0
@@ -814,7 +817,8 @@ Contains
                 DO_PSI
                     qty(PSI) = ohmic_heating_coeff(r)*(m0_values(PSI2,curlbr)**2 + &
                                &   m0_values(PSI2,curlbtheta)**2 + &
-                               &   m0_values(PSI2,curlbphi)**2)
+                               &   m0_values(PSI2,curlbphi)**2) &
+                               & *ref%density(r)*ref%temperature(r)
                 END_DO
 
             Else


### PR DESCRIPTION
Loren pointed out that the ohmic heating terms in Rayleigh's output (not in the main code loop) were missing a factor of density*temperature similarly to the viscous heating term.   This PR adds that factor.
-Nick