### PR TITLE
Advect ref

### DIFF
--- a/input_examples/benchmark_diagnostics_input
+++ b/input_examples/benchmark_diagnostics_input
@@ -16,6 +16,7 @@
  magnetism = .false.
  viscous_heating = .false.
  ohmic_heating = .false.
+ advect_reference_state = .false.
 /
 &temporal_controls_namelist
  max_time_step = 1.0d-4

--- a/input_examples/c2001_case0_input
+++ b/input_examples/c2001_case0_input
@@ -16,6 +16,7 @@
  magnetism = .false.
  viscous_heating = .false.
  ohmic_heating = .false.
+ advect_reference_state = .false. 
 /
 &temporal_controls_namelist
  max_time_step = 1.0d-4

--- a/input_examples/c2001_case1_input
+++ b/input_examples/c2001_case1_input
@@ -16,6 +16,7 @@
  magnetism = .true.
  viscous_heating = .false.
  ohmic_heating = .false.
+ advect_reference_state = .false.
 /
 &temporal_controls_namelist
  max_time_step = 1.0d-4

--- a/input_examples/j2011_steady_hydro_input
+++ b/input_examples/j2011_steady_hydro_input
@@ -14,6 +14,7 @@
  benchmark_mode = 3
  benchmark_integration_interval = 100
  benchmark_report_interval = 10000
+ advect_reference_state = .false. 
 /
 &temporal_controls_namelist
  max_time_step = 30.0d0

--- a/input_examples/j2011_steady_mhd_input
+++ b/input_examples/j2011_steady_mhd_input
@@ -14,6 +14,7 @@
  benchmark_mode = 4
  benchmark_integration_interval = 100
  benchmark_report_interval = 10000
+ advect_reference_state = .false.
 /
 &temporal_controls_namelist
  max_time_step = 200.0d0

--- a/input_examples/main_input_jupiter
+++ b/input_examples/main_input_jupiter
@@ -12,6 +12,7 @@
 /
 &physical_controls_namelist
  rotation  = .true.
+ advect_reference_state = .false.
 /
 &temporal_controls_namelist
  max_time_step = 0.05d0  ! timescale is 1/Omega, fastest wave is 1/2 that - divide by 10 to be safe

--- a/input_examples/main_input_sun
+++ b/input_examples/main_input_sun
@@ -15,6 +15,7 @@
 &physical_controls_namelist
  rotation  = .true.
  magnetism = .false.
+ advect_reference_state = .false. 
 /
 &temporal_controls_namelist
  max_time_step = 1000.0d0

--- a/src/Physics/Benchmarking.F90
+++ b/src/Physics/Benchmarking.F90
@@ -100,9 +100,12 @@ Contains
             shell_depth = 1.0d0
             aspect_ratio = 0.35d0
 
-            !Temporal Controls
+            !Physical Controls
             rotation = .true.
             viscous_heating = .false.
+            advect_reference_state = .false.
+            
+            !Temporal Controls            
             max_time_step = 1.0d-4
             alpha_implicit = 0.50001d0
             cflmin = 0.4d0
@@ -146,6 +149,7 @@ Contains
             magnetism = .true.
             viscous_heating = .false.
             ohmic_heating = .false.
+            advect_reference_state = .false.            
 
             !Temporal Controls
             max_time_step = 1.0d-4
@@ -193,6 +197,7 @@ Contains
 
             !Physical Controls
             rotation = .true.
+            advect_reference_state = .false.            
 
 
             !Temporal Controls
@@ -248,6 +253,7 @@ Contains
             !Physical Controls
             rotation = .true.
             magnetism = .true.
+            advect_reference_state = .false.
 
             !Temporal Controls
             max_time_step = 200.0d0

--- a/src/Physics/Controls.F90
+++ b/src/Physics/Controls.F90
@@ -59,8 +59,8 @@ Module Controls
     Logical :: lorentz_forces = .true.      ! Turn Lorentz forces on or off (default is on - as long as magnetism is on)
     Logical :: viscous_heating = .true.     ! Turns viscous heating on/off
     Logical :: ohmic_heating = .true.
-    Logical :: advect_reference_state = .false.  ! Set to true to advect the reference state
-                                                ! Generally only do this if reference state is nonadiabatic
+    Logical :: advect_reference_state = .true.  ! Set to true to advect the reference state temperature or entropy
+                                                ! This has no effect for adiabatic reference states.
 
     ! --- This flag determines if the code is run in benchmark mode
     !     0 (default) is no benchmarking.  1-5 are various accuracy benchmarks (see documentation)

--- a/src/Physics/Controls.F90
+++ b/src/Physics/Controls.F90
@@ -210,7 +210,7 @@ Contains
         lorentz_forces = .true.
         viscous_heating = .true.
         ohmic_heating = .true.
-        advect_reference_state = .false.
+        advect_reference_state = .true.
         benchmark_mode = 0
         benchmark_integration_interval = -1
         benchmark_report_interval = -1


### PR DESCRIPTION
This commit sets advect_reference_state to true by default.  As discussed in the issues section, this is probably the more intuitive default setting.  Note that with this commit, Rayleigh's internal benchmark routines now explicitly set this variable to false if one of the four benchmark modes are activated.   All input files have this variable set to false for consistency with the old default value that they assumed.