### PR TITLE
Shell slice and spectra consistency

### DIFF
--- a/post_processing/rayleigh_diagnostics.py
+++ b/post_processing/rayleigh_diagnostics.py
@@ -730,7 +730,7 @@ class Point_Probes:
                                                   : corresponding to each point in self.radius
     self.theta_inds[0:self.ntheta-1]              : theta indices (from the full simulation theta grid) 
                                                   : corresponding to each point in self.costheta
-    self.phi_inds[0:self.nphi-1]                  : phi indices (from the full simulation theta grid) 
+    self.phi_inds[0:self.nphi-1]                  : phi indices (from the full simulation phi grid) 
                                                   : corresponding to each point in self.phi
     self.vals[0:nphi-1,0:ntheta-1,0:nr-1,0:nq-1,0:niter-1] : The meridional slices 
     self.iters[0:niter-1]                         : The time step numbers stored in this output file
@@ -738,7 +738,7 @@ class Point_Probes:
     self.version                                  : The version code for this particular output (internal use)
     self.lut                                      : Lookup table for the different diagnostics output
     
-    --Note that the indices (phi_inds,rad_inds, theta_inds) uses Python's 0-based array indexing.
+    --Note that the indices (phi_inds,rad_inds, theta_inds) use Python's 0-based array indexing.
     --This means that if rad_inds are 1,2,5, say, then in Rayleigh they correspond to points 2,3,6 
     --on the global grid that runs from 1 through N_R.
     """
@@ -814,12 +814,17 @@ class Meridional_Slices:
     self.costheta[0:ntheta-1]                     : cos(theta grid)
     self.sintheta[0:ntheta-1]                     : sin(theta grid)
     self.phi[0:nphi-1]                            : phi values (radians)
-    self.phi_indices[0:nphi-1]                    : phi indices (from 1 to nphi)
+    self.phi_inds[0:nphi-1]                       : phi indices (from the full simulation phi grid) 
+
     self.vals[0:nphi-1,0:ntheta-1,0:nr-1,0:nq-1,0:niter-1] : The meridional slices 
     self.iters[0:niter-1]                         : The time step numbers stored in this output file
     self.time[0:niter-1]                          : The simulation time corresponding to each time step
     self.version                                  : The version code for this particular output (internal use)
     self.lut                                      : Lookup table for the different diagnostics output
+
+    --Note that the indices (phi_inds) use Python's 0-based array indexing.
+    --This means that if phi_inds are 1,2,5, say, then in Rayleigh they correspond to points 2,3,6 
+    --on the global grid that runs from 1 through n_phi.
     """
 
     def __init__(self,filename='none',path='Meridional_Slices/'):


### PR DESCRIPTION
Makes doc string (regarding indices) compatible with new doc strings for Point_Probes and Meridional_Slices. Also gives Shell_Slices, Shell_Spectra, SPH_Modes, and Power_Spectrum the alternate property

rad_inds (for compatability with Point_Probes)

identical to 

inds (for backwards compatability). 

There used to only be the property inds.