### PR TITLE
fix error in CPU autodetect message

### DIFF
--- a/configure
+++ b/configure
@@ -752,7 +752,7 @@ then
        fi
        FFLAGS[0]="${OPT_FLAGS} -march=${opt}"
        if [[ "$opt" == "native" && $FVERSION == "GNU" ]]; then
-               echo "CPU autodetect result: $(gfortran -march=native -Q --help=target|grep '^\s\+-march'|awk '{print $2}')"
+               echo "CPU autodetect result: $($FC -march=native -Q --help=target|grep '^\s\+-march'|awk '{print $2}')"
        fi
        break
     done


### PR DESCRIPTION
This should fix an error message displayed if the GNU compiler is used,
but `gfortran` is not a valid compiler. I don't see a downside to this
change because we already make sure `FVERSION` is set to `GNU`.

Fixes #302.