### PR TITLE
fix quotation marks in namelist

### DIFF
--- a/doc/source/User_Guide/io_control.rst
+++ b/doc/source/User_Guide/io_control.rst
@@ -81,7 +81,7 @@ namelist.
 
    &io_controls_namelist
    stdout_flush_interval = 1000
-   stdout_file = `routput'
+   stdout_file = 'routput'
    /
 
 Set stdout_file to the name of a file that will contain Rayleigh’s text


### PR DESCRIPTION
The docs had a wrong quotation mark in the Fortran namelist.