### PR TITLE
[Critical]  Fix CN implementation of radially varying magnetic diffusion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - None yet
 
 ### Fixed
-- Radially varying magnetic diffusivity is now correctly evolved using the Crank-Nicholson scheme for the toroidal magnetic scalar potential *A*. \[Nick Featherstone; 12-03-2021; [#289](github.com/GeodynamicWorldBuilder/WorldBuilder/issues/289)\]
+- Radially varying magnetic diffusivity is now correctly evolved using the Crank-Nicholson scheme for the toroidal magnetic scalar potential *A*. \[Nick Featherstone; 12-03-2021; [#346](https://github.com/geodynamics/Rayleigh/pull/346)\]
 
 
 ## [0.9.0] - 01-23-2018

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Changelog
-All notable changes to this project will be documented in this file.
+All notable changes **following the 1.0.0 release** of *Rayleigh* will be documented in this file.  Changes in 1.0.0 and prior versions are summarized.  
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 with the addition of author(s), date of change and optionally the relevant issue. 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,9 +19,25 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Fixed
 - Radially varying magnetic diffusivity is now correctly evolved using the Crank-Nicholson scheme for the toroidal magnetic scalar potential *A*. \[Nick Featherstone; 12-03-2021; [#346](https://github.com/geodynamics/Rayleigh/pull/346)\]
 
+## [1.0.0] - 11-12-2021
+- Online, up-to-date-documentation is now available [here](https://rayleigh-documentation.readthedocs.io/en/latest/index.html).  The source files for this documentation are provided as part of the repository and are stored in the ‘doc’ directory.
+- Customizability enhancements:  Users may specify custom boundary conditions and/or initial conditions as described [here](https://rayleigh-documentation.readthedocs.io/en/latest/doc/source/User_Guide/physics.html?highlight=generic#generic-boundary-conditions) and [here](https://rayleigh-documentation.readthedocs.io/en/latest/doc/source/User_Guide/physics.html?highlight=generic#generic-initial-conditions).  Users are also free to fully specify the set of constant and nonconstant coefficients that define the system of PDEs solved by Rayleigh, as described in
 
-## [0.9.0] - 01-23-2018
+## [0.9.1] - 04-28-2018
 ### Added
-- Initial release
+- The configure script now accepts the --with-custom and -devel flags (run ./configure --help for details)
+ 
+### Changed
+- None
+
+### Fixed
+- Several output-quantity codes were double-booked. The output quantity tables have been adjust accordingly.  This error produced issues with quantity codes in the following ranges:
+
+    - 1900--2000 (kinetic energy equation codes)
+    - 1400--1600 (thermal energy equation codes)
+    - 1600--1800 (magnetic energy equation codes)
+
+
+## [0.9.0] - 01-23-2018 - Initial Release
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - None yet
 
 ### Fixed
-- Radially varying magnetic diffusivity is now correctly evolved using the Crank-Nicholson scheme for the toroidal magnetic potential *A*.
+- Radially varying magnetic diffusivity is now correctly evolved using the Crank-Nicholson scheme for the toroidal magnetic scalar potential *A*. \[Nick Featherstone; 12-03-2021; [#289](github.com/GeodynamicWorldBuilder/WorldBuilder/issues/289)\]
 
 
 ## [0.9.0] - 01-23-2018

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,27 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+with the addition of author(s), date of change and optionally the relevant issue. 
+
+Add new entries a the bottom of the current list in the subheading. Item format: 
+- Description. [Name; date; relevant github issue tag(s) and or pull requests]
+
+This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+### Added
+- None yet
+ 
+### Changed
+- None yet
+
+### Fixed
+- Radially varying magnetic diffusivity is now correctly evolved using the Crank-Nicholson scheme for the toroidal magnetic potential *A*.
+
+
+## [0.9.0] - 01-23-2018
+### Added
+- Initial release
+
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,16 +20,17 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Radially varying magnetic diffusivity is now correctly evolved using the Crank-Nicholson scheme for the toroidal magnetic scalar potential *A*. \[Nick Featherstone; 12-03-2021; [#346](https://github.com/geodynamics/Rayleigh/pull/346)\]
 
 ## [1.0.0] - 11-12-2021
+### Added
 - Online, up-to-date-documentation is now available [here](https://rayleigh-documentation.readthedocs.io/en/latest/index.html).  The source files for this documentation are provided as part of the repository and are stored in the ‘doc’ directory.
-- Customizability enhancements:  Users may specify custom boundary conditions and/or initial conditions as described [here](https://rayleigh-documentation.readthedocs.io/en/latest/doc/source/User_Guide/physics.html?highlight=generic#generic-boundary-conditions) and [here](https://rayleigh-documentation.readthedocs.io/en/latest/doc/source/User_Guide/physics.html?highlight=generic#generic-initial-conditions).  Users are also free to fully specify the set of constant and nonconstant coefficients that define the system of PDEs solved by Rayleigh, as described in
+- Customizability enhancements:  Users may specify custom boundary conditions and/or initial conditions as described [here](https://rayleigh-documentation.readthedocs.io/en/latest/doc/source/User_Guide/physics.html?highlight=generic#generic-boundary-conditions) and [here](https://rayleigh-documentation.readthedocs.io/en/latest/doc/source/User_Guide/physics.html?highlight=generic#generic-initial-conditions).  Users are also free to fully specify the set of constant and nonconstant coefficients that define the system of PDEs solved by Rayleigh, as described in the [documentation](https://rayleigh-documentation.readthedocs.io/en/latest/doc/source/User_Guide/custom_reference_states.html).
+
+### Changed
+- Portable checkpoint format:  The checkpoint format has changed such that each checkpoint resides in its own directory.  All files and information needed to restart a model, including a copy of main_input, are now stored within each numbered checkpoint directory.
 
 ## [0.9.1] - 04-28-2018
 ### Added
 - The configure script now accepts the --with-custom and -devel flags (run ./configure --help for details)
  
-### Changed
-- None
-
 ### Fixed
 - Several output-quantity codes were double-booked. The output quantity tables have been adjust accordingly.  This error produced issues with quantity codes in the following ranges:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,5 @@
 # Changelog
-All notable changes **following the 1.0.0 release** of *Rayleigh* will be documented in this file.  Changes in 1.0.0 and prior versions are summarized.  
-
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+All notable changes **following the 1.0.0 release** of *Rayleigh* will be documented in this file.  Changes in 1.0.0 and prior versions are summarized.  The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 with the addition of author(s), date of change and optionally the relevant issue. 
 
 Add new entries a the bottom of the current list in the subheading. Item format: 

--- a/src/Physics/Sphere_Spectral_Space.F90
+++ b/src/Physics/Sphere_Spectral_Space.F90
@@ -208,6 +208,8 @@ Contains
             ! A-terms (Toroidal magnetic field)
 
             Call Add_Derivative(aeq,avar,0,wsp%p1b,wsp%p1a,avar)
+            
+            Call Add_Derivative(aeq,avar,1,wsp%p1b,wsp%p1a,dadr)
 
             !///////////////////
             ! C-terms (Poloidal magnetic field)


### PR DESCRIPTION
The benchmarks, as well as most users, run with diffusion coefficients (nu, kappa, eta) that are constant in radius.   Because of this, a bug in the code has gone unnoticed for a very long time.   The diffusive terms are evolved using the semi-implicit Crank-Nicholson method, which is effectively an average of the forward and backward Euler methods.   A magnetic diffusion term for the A-potential equation, namely dA/dr*deta/dr was being evolved without the explicit contribution from the CN scheme (i.e., the forward Euler component).   This PR fixes the issue.

Please do not accept this PR just yet.  I would like to hear from Rene about how we might automatically manage release notes before this is fully accepted.