### PR TITLE
CFL Condition:  Account for Rotation Rate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - None yet
 
 ### Changed
-- None yet
+- The rotation rate is now accounted for when computing the maximum allowable timestep.  The timestep may be no larger than c1/4*CFLMax, CFLMax is the CFL safety factor, and where c1 is the 1st Rayleigh constant and the inverse of the rotational timescale (2 Omega for reference_type=2 and 2/Ek for reference_type=1). \[Nick Featherstone; 12-11-2021; [#348](https://github.com/geodynamics/Rayleigh/pull/348)\]
 
 ### Fixed
 - None yet

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - None yet
 
 ### Changed
-- The rotation rate is now accounted for when computing the maximum allowable timestep.  The timestep may be no larger than c1/4*CFLMax, CFLMax is the CFL safety factor, and where c1 is the 1st Rayleigh constant and the inverse of the rotational timescale (2 Omega for reference_type=2 and 2/Ek for reference_type=1). \[Nick Featherstone; 12-11-2021; [#348](https://github.com/geodynamics/Rayleigh/pull/348)\]
+- The rotation rate is now accounted for when computing the maximum allowable timestep.  Now, the timestep may not exceed CFLMax/(c1*4), where CFLMax is the CFL safety factor.  c1 is the 1st Rayleigh constant, effectively the inverse of the rotational timescale (c1 = 2 Omega for reference_type=2 and 2/Ek for reference_type=1). \[Nick Featherstone; 12-11-2021; [#348](https://github.com/geodynamics/Rayleigh/pull/348)\]
 
 ### Fixed
 - None yet

--- a/src/Physics/PDE_Coefficients.F90
+++ b/src/Physics/PDE_Coefficients.F90
@@ -112,6 +112,11 @@ Module PDE_Coefficients
     Real*8 :: gravity_power           = 0.0d0
     Real*8 :: Dissipation_Number      = 0.0d0
     Real*8 :: Modified_Rayleigh_Number = 0.0d0
+    
+    !///////////////////////////////////////////////
+    ! Minimum time step based on rotation rate
+    ! (determined by the reference state)
+    Real*8 :: max_dt_rotation = 0.0d0
 
 
 
@@ -188,6 +193,8 @@ Contains
 
         If (with_custom_reference) Call Augment_Reference()  
 
+        If (rotation) Call Set_Rotation_dt()
+
     End Subroutine Initialize_Reference
 
     Subroutine Allocate_Reference_State
@@ -225,6 +232,20 @@ Contains
         ref%Lorentz_Coeff  = Zero
 
     End Subroutine Allocate_Reference_State
+
+    Subroutine Set_Rotation_dt()
+        Implicit None
+        Real*8 :: rotational_timescale
+        !Adjust the maximum timestep to account for rotation rate, if necessary.
+        
+        rotational_timescale = 1.0d0/ref%Coriolis_Coeff
+        
+        ! Minimum sampling would require two time samples per rotational timescale.
+        ! We specify 4 samples and further adjust by the CFL safety factor.
+        max_dt_rotation = rotational_timescale*0.25d0*cflmax  
+        max_time_step = Min(max_time_step,max_dt_rotation)
+    
+    End Subroutine Set_Rotation_dt
 
     Subroutine Constant_Reference()
         Implicit None

--- a/src/Physics/PDE_Coefficients.F90
+++ b/src/Physics/PDE_Coefficients.F90
@@ -243,7 +243,11 @@ Contains
         ! Minimum sampling would require two time samples per rotational timescale.
         ! We specify 4 samples and further adjust by the CFL safety factor.
         max_dt_rotation = rotational_timescale*0.25d0*cflmax  
-        max_time_step = Min(max_time_step,max_dt_rotation)
+        
+        ! We only modify the timestep if not running a benchmark.
+        ! Those models require set timesteps to satisfy the automated
+        ! benchmark test during continuous integration.
+        If (benchmark_mode .eq. 0) max_time_step = Min(max_time_step,max_dt_rotation)
     
     End Subroutine Set_Rotation_dt
 


### PR DESCRIPTION
This PR modifies the CFL calculation in Rayleigh to account for the rotation rate.  The timestep may now be no larger than CFLMax/(c1*4), where CFLMax is the CFL safety factor.  c1 is the 1st Rayleigh constant, effectively the inverse of the rotational timescale (c1 = 2 Omega for reference_type=2 and 2/Ek for reference_type=1).