### PR TITLE
Automatic calculation of dTdr_top for models with internal heating.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Changed
 - The rotation rate is now accounted for when computing the maximum allowable timestep.  Now, the timestep may not exceed CFLMax/(c1*4), where CFLMax is the CFL safety factor.  c1 is the 1st Rayleigh constant, effectively the inverse of the rotational timescale (c1 = 2 Omega for reference_type=2 and 2/Ek for reference_type=1). \[Nick Featherstone; 12-11-2021; [#348](https://github.com/geodynamics/Rayleigh/pull/348)\]
 
+- When running with both internal heating and fix_dTdr_top=.true., the value of dTdr_top is now set internally by Rayleigh.  This is done to ensure consistency with the internal heating as well as any flux passing through the lower boundary (if fixed flux lower boundary conditions are applied).   To override this behavior, set adjust_dTdr to .false. in the Boundary_Conditions namelist. \[Nick Featherstone; 12-13-2021; [#349](https://github.com/geodynamics/Rayleigh/pull/349)\]
 ### Fixed
 - None yet
 

--- a/doc/source/User_Guide/physics.rst
+++ b/doc/source/User_Guide/physics.rst
@@ -531,6 +531,12 @@ variable in radius, but constant in *energy density*. Namely
 The constant :math:`\gamma` in this case is also set by enforcing
 Equation eq_lum_.
 
+**Note:** If internal heating is used in combination with **fix_dTdr_top**, then the value of :math:`\partial\Theta/\partial r` 
+at the upper boundary is set by Rayleigh.  Any value for **dTdr_top** specified in main_input is ignored.  This is done to ensure consistency with the internal 
+heating and any flux passing through the lower boundary due
+to the use of a fixed-flux condition.  To override this behavior, set **adjust_dTdr_top** to .false. in the
+**Boundary_Conditions** namelist.
+
 General Physics Controls
 ------------------------
 

--- a/src/Physics/BoundaryConditions.F90
+++ b/src/Physics/BoundaryConditions.F90
@@ -45,6 +45,7 @@ Module BoundaryConditions
     Logical :: Fix_poloidalfield_bottom = .False.
     Logical :: Impose_Dipole_Field = .False.
     Logical :: Dipole_Field_Bottom = .False.
+    Logical :: adjust_dTdr_Top = .False.
 
     Real*8  :: T_Bottom     = 1.0d0
     Real*8  :: T_Top        = 0.0d0
@@ -80,13 +81,14 @@ Module BoundaryConditions
         C10_bottom, C10_top, C11_bottom, C11_top, C1m1_bottom, C1m1_top, Br_bottom, &
         dipole_tilt_degrees, impose_dipole_field, no_slip_top, no_slip_bottom, &
         stress_free_top, stress_free_bottom, T_top_file, T_bottom_file, dTdr_top_file, dTdr_bottom_file, &
-        C_top_file, C_bottom_file, dipole_field_bottom
+        C_top_file, C_bottom_file, dipole_field_bottom, adjust_dTdr_top
 
 Contains
 
     Subroutine Initialize_Boundary_Conditions()
         Implicit None
         Real*8 :: tilt_angle_radians,a,b
+        Real*8 :: Ftop, rhotk_top
 
         fix_tvar_top = .not. fix_dtdr_top
         fix_tvar_bottom = .not. fix_dtdr_bottom
@@ -127,6 +129,16 @@ Contains
             C1m1_bottom = 0.0d0 ! For the time being, we don't
             C1m1_top =  0.0d0   ! worry about phasing in longitude.
 
+        Endif
+
+        If (adjust_dTdr_top .and. fix_dtdr_top) Then
+            If (heating_type .gt. 0) Then
+
+                Ftop = ra_constants(10)/(four_pi*radius(1)*radius(1))
+                rhotk_top = ref%density(1)*ref%temperature(1)*kappa(1)
+                dTdr_top = -Ftop/rhotk_top
+                Write(6,*)'Adjusting dtdr: ', dtdr_top
+            Endif
         Endif
 
         Call Generate_Boundary_Mask()

--- a/src/Physics/BoundaryConditions.F90
+++ b/src/Physics/BoundaryConditions.F90
@@ -137,7 +137,7 @@ Contains
                 Ftop = ra_constants(10)/(four_pi*radius(1)*radius(1))
                 rhotk_top = ref%density(1)*ref%temperature(1)*kappa(1)
                 dTdr_top = -Ftop/rhotk_top
-                Write(6,*)'Adjusting dtdr: ', dtdr_top
+                if (my_rank .eq. 0) Write(6,*)'Adjusting dtdr: ', dtdr_top
             Endif
         Endif
 


### PR DESCRIPTION
This PR modifies the code so that the user no longer needs to specify dTdr_top when running models with internal heating and fix_dTdr_top set to true.   This process is very error-prone from a user standpoint, and so it is now done automatically.  Any additional flux passing through the lower boundary is also taken into account in the event that fix_dTdr_bottom is set.   The behavior may be overridden by setting adjust_dTdr to false in the Boundary_Conditions namelist.  