### PR TITLE
support for Cray compiler

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -20,11 +20,11 @@ three commands from within <rayleigh root>:
 (4.) Running 'make distclean' will revert <rayleigh root> to it's
 pre-configured state.
 
-The configure script automatically supports both GNU and Intel Compilers.  An
-IBM-compiler example is provided at the end of this document.  On many
-Intel-based machines, running ./configure or ./configure -mkl  will suffice.
-In other circumstances, it may be necessary to specify a subset of configure's
-options.  Some possible variations are illustrated in section III.
+The configure script automatically supports the GNU, Intel, AOCC, and Cray
+compilers.  An IBM-compiler example is provided at the end of this document.
+On many Intel-based machines, running ./configure or ./configure -mkl  will
+suffice.  In other circumstances, it may be necessary to specify a subset of
+configure's options.  Some possible variations are illustrated in section III.
 
 To see a detailed description of all available options, run ./configure -h.
 
@@ -167,11 +167,11 @@ FFTWROOT=/software/fftw/3.3.4
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 III.e  Configuration using Alternative Compilers / Customized Compiler Flags
 
-For compilers other than GNU or Intel, you will need to manually specify the
-optimization, library, and include flags.  You may also wish to do this if you
-are experimenting with new compilation flags that are not automatically
-provided by configure for Intel or GNU.   These flags can be set using
---LIBFLAGS, --FFLAGS_OPT, --FFLAGS_DBG, and --INCLUDE.  FFLAGS_OPT and
+For compilers other than GNU, Intel, AOCC, or Cray, you will need to manually
+specify the optimization, library, and include flags.  You may also wish to do
+this if you are experimenting with new compilation flags that are not
+automatically provided by configure for known compilers.   These flags can be set
+using --LIBFLAGS, --FFLAGS_OPT, --FFLAGS_DBG, and --INCLUDE.  FFLAGS_OPT and
 FFLAGS_DBG define the optimization flags used for rayleigh.opt and rayleigh.dbg
 respectively.
 

--- a/configure
+++ b/configure
@@ -9,6 +9,11 @@ function compiler_version {
   #$1 --version
   VSTR=$($1 --version)
   VTMP="unknown"
+  # List Cray first because other compilers might have Cray company name in their version string.
+  if [[ $VSTR == *"Cray"* ]]
+  then
+    VTMP="CRAY"
+  fi
   if [[ $VSTR == *"Intel"* ]]
   then
     VTMP="INTEL"
@@ -49,6 +54,11 @@ function opt_flags {
   then
     echo '-O3 -ffixed-line-length-132'
   fi
+
+  if [[ $1 == "CRAY" ]]
+  then
+    echo '-O3'
+  fi
 }
 
 function dbg_flags {
@@ -65,6 +75,10 @@ function dbg_flags {
   if [[ $1 == "AOCC" ]]
   then
     echo '-O0 -g -ffixed-line-length-132'
+  fi
+  if [[ $1 == "CRAY" ]]
+  then
+    echo '-O0 -g'
   fi
 }
 
@@ -539,6 +553,12 @@ else
   then
       OPT_FLAGS="$OPT_FLAGS -DAOCC_COMPILER"
       DBG_FLAGS="$DBG_FLAGS -DAOCC_COMPILER"
+  fi
+
+  if [ $FVERSION == "CRAY" ]
+  then
+      OPT_FLAGS="$OPT_FLAGS -DCRAY_COMPILER"
+      DBG_FLAGS="$DBG_FLAGS -DCRAY_COMPILER"
   fi
 
   echo ' '

--- a/doc/source/User_Guide/installation.rst
+++ b/doc/source/User_Guide/installation.rst
@@ -19,9 +19,9 @@ Third-Party Dependencies
 
 In order to compile Rayleigh, you will need to have MPI (Message Passing
 Interface) installed along with a Fortran 2003-compliant compiler.
-Rayleigh has been successfully compiled with GNU, Intel, and IBM
-compilers (PGI has not been tested yet). Rayleigh’s configure script
-provides native support for the Intel and GNU compilers. See
+Rayleigh has been successfully compiled with GNU, Intel, IBM, AOCC, and
+Cray compilers (PGI has not been tested yet). Rayleigh’s configure script
+provides native support for the Intel, GNU, AOCC, and Cray compilers. See
 Rayleigh/INSTALL for an example of configuration using the IBM compiler.
 
 Rayleigh depends on the following third party libraries:

--- a/doc/source/User_Guide/running.rst
+++ b/doc/source/User_Guide/running.rst
@@ -42,8 +42,8 @@ Soft-linking is recommended; if you recompile the code, the executable
 remains up-to-date. If running on an IBM machine, copy the script named
 Rayleigh/etc/make_dirs to your run directory and execute the script.
 This will create the directory structure expected by Rayleigh for its
-outputs. This step is unnecessary when compiling with the Intel or GNU
-compilers.
+outputs. This step is unnecessary when compiling with the Intel, GNU,
+AOCC, or Cray compilers.
 
 Next, you must create a main_input file. This file contains the
 information that describes how your simulation is run. Rayleigh always


### PR DESCRIPTION
This add `configure` support for the Cray compiler (`ftn`) and updates the documentation accordingly.

This should not interfere with any of the other compilers.