### PR TITLE
add a spack package

### DIFF
--- a/doc/source/User_Guide/devel_environment.rst
+++ b/doc/source/User_Guide/devel_environment.rst
@@ -149,3 +149,19 @@ You can check the newly built container is there using this command.
 .. code-block:: bash
 
     docker images
+
+Spack Environment
+-----------------
+
+`Spack <https://github.com/spack/spack>`_ can be used to create a development environment to build the code in a local directory. First set up Spack using the instructions in :ref:`spack-setup`
+
+Afterwards create a new environment, activate it and set the status of the Rayleigh package to development. We select ``$PWD`` as the path, so run this command from the base directory of your git clone.
+
+.. code-block:: bash
+
+    spack env create rayleigh
+    spack env activate rayleigh
+    spack add rayleigh@master
+    spack develop -p "$PWD" rayleigh@master
+
+A subsequent ``spack install`` will install necessary dependencies and build Rayleigh in the selected directory.

--- a/doc/source/User_Guide/installation.rst
+++ b/doc/source/User_Guide/installation.rst
@@ -85,7 +85,7 @@ described above, if Intel is used and *all* is selected, every version will
 be compiled. To build only a single version, the **target=<target>** option
 may be used at the **make** stage, for example:
 
-#. **make target=opt** - build only the optimzed version, **rayleigh.opt**
+#. **make target=opt** - build only the optimized version, **rayleigh.opt**
 
 #. **make target=dbg** - build only the debug version, **rayleigh.dbg**
 
@@ -105,9 +105,9 @@ option) will show a new file named **a.out**.
 If both the optimized version and the debug version have already been built, they
 can be renamed at install time as:
 
-#. **make** - build both optimized and debug verion (or all versions)
+#. **make** - build both optimized and debug version (or all versions)
 
-#. **make target=opt output=a.out.opt install** - install and rename the optimzed version
+#. **make target=opt output=a.out.opt install** - install and rename the optimized version
 
 #. **make target=dbg output=a.out.dbg install** - install and rename the debug version
 

--- a/doc/source/User_Guide/installation.rst
+++ b/doc/source/User_Guide/installation.rst
@@ -138,7 +138,7 @@ The next step has only to be performed once to add the Rayleigh package reposito
 
 .. code-block:: bash
 
-    spack add spack-repo
+    spack repo add spack-repo
 
 Afterwards you can just install Rayleigh and its dependencies using:
 

--- a/doc/source/User_Guide/installation.rst
+++ b/doc/source/User_Guide/installation.rst
@@ -123,3 +123,45 @@ installation is performing correctly. If you are running Rayleigh for
 the first time, or running on a new machine, follow along with the
 example in §\ :ref:`benchmarking`, that you receive an accurate benchmark report before running a custom
 model.
+
+.. _spack-setup:
+
+Alternative: Installation using Spack
+---------------------------------------
+
+Spack is a package management tool designed to support multiple versions and
+configurations of software on a wide variety of platforms and environments. It can be used to build Rayleigh with different compilers and a custom set of libraries for MPI, LAPACK, and FFTW. It can automatically build dependencies itself or use those provided by the HPC environment.
+
+To set up Spack in your environment follow the instructions in the `documentation <https://spack.readthedocs.io/en/latest/getting_started.html>`_. Add local `compilers <https://spack.readthedocs.io/en/latest/getting_started.html#compiler-configuration>`_ and `packages <https://spack.readthedocs.io/en/latest/getting_started.html#system-packages>`_ as desired.
+
+The next step has only to be performed once to add the Rayleigh package repository. Run this from the base directory of the Rayleigh repository.
+
+.. code-block:: bash
+
+    spack add spack-repo
+
+Afterwards you can just install Rayleigh and its dependencies using:
+
+.. code-block:: bash
+
+    spack install rayleigh
+
+Once the build succeeded the package can be loaded using the following command, which will make the ``rayleigh.opt`` and ``rayleigh.dbg`` executables available in the ``PATH`` and can be run to start simulations as usual.
+
+.. code-block:: bash
+
+    spack load rayleigh
+
+There are many ways in which to modify the compiler and dependencies being used. They can be found in the `Spack documentation <https://spack.readthedocs.io/en/latest/index.html>`_.
+
+As an example you can install Rayleigh using MKL for LAPACK and FFTW using:
+
+.. code-block:: bash
+
+    spack install rayleigh ^intel-mkl
+
+To see the dependencies being installed you can use:
+
+.. code-block:: bash
+
+    spack spec rayleigh ^intel-mkl

--- a/spack-repo/packages/rayleigh/package.py
+++ b/spack-repo/packages/rayleigh/package.py
@@ -1,0 +1,44 @@
+# Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+import os
+from spack import *
+
+class Rayleigh(MakefilePackage):
+    __doc__ = 'Rayleigh is a 3-D convection code designed for the study of dynamo behavior in spherical geometry.'
+    homepage = 'https://github.com/geodynamics/Rayleigh'
+    url = 'https://github.com/geodynamics/Rayleigh/archive/refs/tags/v1.0.1.tar.gz'
+    git = 'https://github.com/geodynamics/Rayleigh.git'
+    maintainers = [
+     'tukss']
+    version('master', branch='master')
+    version('1.0.1', sha256='9c9e3b0b180f32a889f158e2ea2967f4ac2bb2124f5d264f230efb8c8f19ea36')
+    version('1.0.0', sha256='4f2e8249256adff8c4b0bc377ceacf8a6441dcee54b7d36c784f05a454dc6dcf')
+    version('0.9.1', sha256='ab96445fc61822fe2d2cba8729a85b36de6b541febf5759de6d614847844573f')
+    version('0.9.0', sha256='63a80d1619cb639f3cb01ab82a441b77d736eee94469c47c50ab740fa81c08f4')
+    depends_on('mpi')
+    depends_on('fftw-api@3')
+    depends_on('lapack')
+
+    def edit(self, spec, prefix):
+        env['FC'] = spec['mpi'].mpifc
+        args = ['--prefix={}'.format(prefix)]
+
+        if spec.satisfies('^mkl'):
+            args.append('--with-mkl={}'.format(spec['mkl'].headers.directories[0][:-len('/include')]))
+        else:
+            args.append('--with-fftw={}'.format(spec['fftw'].prefix))
+
+            if spec.satisfies('^openblas'):
+                args.append('--openblas')
+            else:
+                args.append('--with-lapack={}'.format(spec['lapack'].prefix))
+                args.append('--with-blas={}'.format(spec['blas'].prefix))
+
+        args.append('--FFLAGS_DBG=-O0 -g')
+        args.append('--FFLAGS_OPT=-O3 {}'.format(spec.target.optimization_flags(spec.compiler.name, str(spec.compiler.version))))
+
+        # /dev/null as input to prevent interactive questions in configure
+        configure(*args, **{'input': os.devnull})

--- a/spack-repo/repo.yaml
+++ b/spack-repo/repo.yaml
@@ -1,0 +1,2 @@
+repo:
+  namespace: rayleigh


### PR DESCRIPTION
This adds a spack repository with a package for Rayleigh and the corresponding documentation. It's quite useful for building Rayleigh in HPC environments because it takes care of building all the dependencies with the right compiler, MPI etc. It can also be used to provide Rayleigh as a module to share with other users.