### PR TITLE
A fix for spectral input when trying to generate input from purely radial functions

### DIFF
--- a/pre_processing/rayleigh_spectral_input.py
+++ b/pre_processing/rayleigh_spectral_input.py
@@ -460,11 +460,11 @@ class SpectralInput(object):
     # work out lm_max, l_max, m_max & n_max
     lm_max = self.lm_max
     if lm_max is None: lm_max = dealias_g2m(n_theta)
-    l_max = min(lm_max, n_theta)
-    m_max = min(lm_max, n_phi)
+    l_max = min(lm_max, dealias_g2m(n_theta))
+    m_max = min(lm_max, dealias_g2m(n_phi))
     n_max = self.n_max
     if n_max is None: n_max = dealias_g2m(n_r)
-    n_max = min(n_max, n_r)
+    n_max = min(n_max, dealias_g2m(n_r))
 
     # get Legendre Gauss integration points and weights
     if costheta is None or weights is None:

--- a/tests/generic_input/radial_base/main_input
+++ b/tests/generic_input/radial_base/main_input
@@ -1,0 +1,63 @@
+! This is a smaller version of the input_examples/benchmark_diagnostics_input 
+! model that only runs for a single time-step so that we can check the initial condition.
+
+&problemsize_namelist
+ n_r = 48
+ n_theta = 64
+ nprow = 2
+ npcol = 2
+ rmin = 0.5
+ rmax = 1.0
+/
+&numerical_controls_namelist
+ chebyshev = .true.
+/
+&physical_controls_namelist
+ rotation  = .True.
+ magnetism = .false.
+ viscous_heating = .false.
+ ohmic_heating = .false.
+/
+&temporal_controls_namelist
+ max_time_step = 1.0d-4
+ max_iterations = 1
+ alpha_implicit = 0.50001d0
+ checkpoint_interval = 500000
+ quicksave_interval = 1000000
+ num_quicksaves = -1
+ cflmin = 0.4d0
+ cflmax = 0.6d0
+/
+&io_controls_namelist
+/
+&output_namelist
+full3d_values = 501
+full3d_frequency = 1
+/
+
+&Boundary_Conditions_Namelist
+no_slip_boundaries = .true.
+strict_L_Conservation = .false.
+T_Top    = 0.0d0
+T_Bottom = 1.0d0
+fix_tvar_top = .true.
+fix_tvar_bottom = .true.
+/
+&Initial_Conditions_Namelist
+init_type = 7  ! initialize a random thermal field
+temp_amp = 0   ! but with zero amplitude
+conductive_profile = .true. ! on top of a conductive profile
+/
+&Test_Namelist
+/
+&Reference_Namelist
+Ekman_Number = 1.0d-3
+Rayleigh_Number = 1.0d5
+Prandtl_Number = 1.0d0
+Magnetic_Prandtl_Number = 5.0d0
+reference_type = 1
+heating_type = 0      ! No heating
+gravity_power = 1.0d0  ! g ~ radius
+/
+&Transport_Namelist
+/

--- a/tests/generic_input/radial_dense/generate_input.py
+++ b/tests/generic_input/radial_dense/generate_input.py
@@ -1,0 +1,10 @@
+### Use rayleigh_spectral_input.py to generate generic input.
+### Christensen Benchmark case 1.
+
+from rayleigh_spectral_input import *
+
+rmin = 0.5; rmax = 1.0
+
+si = SpectralInput(n_theta=64,n_r=48)
+si.transform_from_rtp_function(lambda radius: 1.0 - (rmax/radius)*(radius - rmin)/(rmax - rmin), rmin=rmin, rmax=rmax)
+si.write('radial_t_init')

--- a/tests/generic_input/radial_dense/main_input
+++ b/tests/generic_input/radial_dense/main_input
@@ -1,0 +1,62 @@
+! This is a smaller version of the input_examples/benchmark_diagnostics_input 
+! model that only runs for a single time-step so that we can check the initial condition.
+
+&problemsize_namelist
+ n_r = 48
+ n_theta = 64
+ nprow = 2
+ npcol = 2
+ rmin = 0.5
+ rmax = 1.0
+/
+&numerical_controls_namelist
+ chebyshev = .true.
+/
+&physical_controls_namelist
+ rotation  = .True.
+ magnetism = .false.
+ viscous_heating = .false.
+ ohmic_heating = .false.
+/
+&temporal_controls_namelist
+ max_time_step = 1.0d-4
+ max_iterations = 1
+ alpha_implicit = 0.50001d0
+ checkpoint_interval = 500000
+ quicksave_interval = 1000000
+ num_quicksaves = -1
+ cflmin = 0.4d0
+ cflmax = 0.6d0
+/
+&io_controls_namelist
+/
+&output_namelist
+full3d_values = 501
+full3d_frequency = 1
+/
+
+&Boundary_Conditions_Namelist
+no_slip_boundaries = .true.
+strict_L_Conservation = .false.
+T_Top    = 0.0d0
+T_Bottom = 1.0d0
+fix_tvar_top = .true.
+fix_tvar_bottom = .true.
+/
+&Initial_Conditions_Namelist
+init_type = 8 ! File init
+t_init_file = 'radial_t_init'
+/
+&Test_Namelist
+/
+&Reference_Namelist
+Ekman_Number = 1.0d-3
+Rayleigh_Number = 1.0d5
+Prandtl_Number = 1.0d0
+Magnetic_Prandtl_Number = 5.0d0
+reference_type = 1
+heating_type = 0      ! No heating
+gravity_power = 1.0d0  ! g ~ radius
+/
+&Transport_Namelist
+/

--- a/tests/generic_input/radial_sparse/generate_input.py
+++ b/tests/generic_input/radial_sparse/generate_input.py
@@ -1,0 +1,10 @@
+### Use rayleigh_spectral_input.py to generate generic input.
+### Christensen Benchmark case 1.
+
+from rayleigh_spectral_input import *
+
+rmin = 0.5; rmax = 1.0
+
+si = SpectralInput(n_theta=1,n_r=48)
+si.transform_from_rtp_function(lambda radius: 1.0 - (rmax/radius)*(radius - rmin)/(rmax - rmin), rmin=rmin, rmax=rmax)
+si.write('radial_t_init')

--- a/tests/generic_input/radial_sparse/main_input
+++ b/tests/generic_input/radial_sparse/main_input
@@ -1,0 +1,62 @@
+! This is a smaller version of the input_examples/benchmark_diagnostics_input 
+! model that only runs for a single time-step so that we can check the initial condition.
+
+&problemsize_namelist
+ n_r = 48
+ n_theta = 64
+ nprow = 2
+ npcol = 2
+ rmin = 0.5
+ rmax = 1.0
+/
+&numerical_controls_namelist
+ chebyshev = .true.
+/
+&physical_controls_namelist
+ rotation  = .True.
+ magnetism = .false.
+ viscous_heating = .false.
+ ohmic_heating = .false.
+/
+&temporal_controls_namelist
+ max_time_step = 1.0d-4
+ max_iterations = 1
+ alpha_implicit = 0.50001d0
+ checkpoint_interval = 500000
+ quicksave_interval = 1000000
+ num_quicksaves = -1
+ cflmin = 0.4d0
+ cflmax = 0.6d0
+/
+&io_controls_namelist
+/
+&output_namelist
+full3d_values = 501
+full3d_frequency = 1
+/
+
+&Boundary_Conditions_Namelist
+no_slip_boundaries = .true.
+strict_L_Conservation = .false.
+T_Top    = 0.0d0
+T_Bottom = 1.0d0
+fix_tvar_top = .true.
+fix_tvar_bottom = .true.
+/
+&Initial_Conditions_Namelist
+init_type = 8 ! File init
+t_init_file = 'radial_t_init'
+/
+&Test_Namelist
+/
+&Reference_Namelist
+Ekman_Number = 1.0d-3
+Rayleigh_Number = 1.0d5
+Prandtl_Number = 1.0d0
+Magnetic_Prandtl_Number = 5.0d0
+reference_type = 1
+heating_type = 0      ! No heating
+gravity_power = 1.0d0  ! g ~ radius
+/
+&Transport_Namelist
+/

--- a/tests/generic_input/run_test.sh
+++ b/tests/generic_input/run_test.sh
@@ -38,6 +38,24 @@ cd bcs_script
 mpirun -np 4 $RAYLEIGH_TEST_MPI_PARAMS ../../../bin/rayleigh.dbg
 cd ..
 
+# test the radial case...
+# first a base case not using generic input
+cd radial_base
+mpirun -np 4 $RAYLEIGH_TEST_MPI_PARAMS ../../../bin/rayleigh.dbg
+cd ..
+
+# then a case that generates a sparse radial generic input file
+cd radial_sparse
+PYTHONPATH=../../../pre_processing:$PYTHONPATH python generate_input.py
+mpirun -np 4 $RAYLEIGH_TEST_MPI_PARAMS ../../../bin/rayleigh.dbg
+cd ..
+
+# finally a version that generates a dense radial generic input file
+cd radial_dense
+PYTHONPATH=../../../pre_processing:$PYTHONPATH python generate_input.py
+mpirun -np 4 $RAYLEIGH_TEST_MPI_PARAMS ../../../bin/rayleigh.dbg
+cd ..
+
 # after both versions have run, we test the output for errors
 PYTHONPATH=../../post_processing:../../pre_processing:$PYTHONPATH python test_output.py
 

--- a/tests/generic_input/test_output.py
+++ b/tests/generic_input/test_output.py
@@ -74,6 +74,31 @@ if maxabsdiff > 1.e-10:
   print("ERROR: generic input bc produced an unexpected result (within a tolerance of 1.e-10)!")
   error = True
 
+# test using the raw data imported from the output files for radial case
+base_r = Spherical_3D_multi('00000001_0501', path='radial_base/Spherical_3D/')
+sparse_r = Spherical_3D_multi('00000001_0501', path='radial_sparse/Spherical_3D/')
+maxabsdiff = 0.0
+for k in base_r.vals.keys():
+  maxabsdiffk = np.abs(base_r.vals[k] - sparse_r.vals[k]).max() 
+  print("Maximum difference ({}) = {}".format(k, maxabsdiffk,))
+  maxabsdiff = max(maxabsdiff, maxabsdiffk)
+
+if maxabsdiff > 1.e-10:
+  print("ERROR: init_type 7 and init_type 8 (sparse) produced different initial conditions (within a tolerance of 1.e-10)!")
+  error = True
+
+# test using the raw data imported from the output files for radial case
+dense_r = Spherical_3D_multi('00000001_0501', path='radial_dense/Spherical_3D/')
+maxabsdiff = 0.0
+for k in base_r.vals.keys():
+  maxabsdiffk = np.abs(base_r.vals[k] - dense_r.vals[k]).max() 
+  print("Maximum difference ({}) = {}".format(k, maxabsdiffk,))
+  maxabsdiff = max(maxabsdiff, maxabsdiffk)
+
+if maxabsdiff > 1.e-10:
+  print("ERROR: init_type 7 and init_type 8 (dense) produced different initial conditions (within a tolerance of 1.e-10)!")
+  error = True
+
 # test spectral input reading and inverse transforming
 maxabsdiff = 0.0
 


### PR DESCRIPTION
Errors in the assumed size of l_max and m_max when converting purely radial functions would lead to index errors.  Hopefully some minor changes to the script fixes this.

Most of the rest of this PR just adds tests that compare purely radial input hard-coded into rayleigh (init_type 7) with sparse and dense generic inputs generated with scripts.