### PR TITLE
Custom Initial Entropy Profile

### DIFF
--- a/doc/source/User_Guide/physics.rst
+++ b/doc/source/User_Guide/physics.rst
@@ -642,6 +642,22 @@ main_input file:
    temp_amp = 1.0d-4
    conductive_profile=.true.
    /
+   
+Alternatively, you may wish to specify an ell=0 initial thermal profile
+that is neither random nor conductive.  To create your own profile, follow the example found in
+Rayleigh/examples/custom_thermal_profile/custom_thermal_profile.ipynb.   Then, use the following combination
+of input parameters in main_input:
+
+::
+
+   &initial_conditions_namelist
+   init_type=7
+   temp_amp = 1.0d-4
+   custom_thermal_file = 'my_custom_profile.dat' 
+   /
+
+This will use the radial profile stored in my_custom_profile.dat for the ell=0 component of entropy/temperature
+Random values will be used to initialize all other modes.
 
 Magnetic-field initialization follows a similar pattern. Available
 values for magnetic_input type are:

--- a/examples/custom_thermal_profile/custom_thermal_profile.ipynb
+++ b/examples/custom_thermal_profile/custom_thermal_profile.ipynb
@@ -1,0 +1,198 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "edca7fc5",
+   "metadata": {},
+   "source": [
+    "### Custom Thermal Profile Creation\n",
+    "\n",
+    "While Rayleigh can define an initial, conductive thermal profile based on the details of internal heating and boundary conditions, alternative ell=0 initial profiles may be desired.  This notebook illustrates how to do this using the rayleigh_spectral_input module."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "197f891b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "import matplotlib.pyplot as plt\n",
+    "import numpy as np\n",
+    "from rayleigh_spectral_input import *\n",
+    "from rayleigh_diagnostics import Shell_Avgs"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2e9afa04",
+   "metadata": {},
+   "source": [
+    "We first define a function that accepts a parameter named radius, assumed to be a numpy array of points at which you wish to compute your custom profile.  The name of this non-optional parameter must be 'radius.'  The function should return f(radius), where f is the custom thermal profile. \n",
+    "\n",
+    "Additional options should be specified as optional keyword parameters."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "910a58b4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def rpower(radius,amp=1,power=1):\n",
+    "    f = amp*radius**power\n",
+    "    return f\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ae67792e",
+   "metadata": {},
+   "source": [
+    "Next, we initialize the grid on which we wish to compute this function.  We use the rayleigh_spectral_input module for this.  Since we are generating a spherically symmetric function, ntheta is set to 1.   Nr can be larger or smaller than the grid you plan to use in Rayleigh.   It only needs to be large enough to fully resolve your function f(radius).  The spectral input object will contain the Chebyshev coefficients needed to represent this profile on a Rayleigh Chebyshev grid."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9b2391ec",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ntheta = 1\n",
+    "nr = 128\n",
+    "rmin = 0.5\n",
+    "rmax = 1\n",
+    "si = SpectralInput(n_theta=ntheta, n_r=nr)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "99b18047",
+   "metadata": {},
+   "source": [
+    "Next, we define our function parameters via a dictionary whose keys match the names of those optional parameters needed to fully specify our function."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5c6e9d59",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "func_pars = {}\n",
+    "func_pars['amp']=1.0\n",
+    "func_pars['power']=0.5\n",
+    "\n",
+    "si.transform_from_rtp_function(rpower, func_kwargs=func_pars, rmin=rmin, rmax=rmax)\n",
+    "\n",
+    "\n",
+    "print('Coefficients array shape: ', si.coeffs.shape)\n",
+    "fig,ax = plt.subplots()\n",
+    "ax.plot(np.abs(si.coeffs[:,0,0]))\n",
+    "ax.set_yscale('log')\n",
+    "ax.set_xscale('log')\n",
+    "ax.set_xlabel('Chebyshev Degree n')\n",
+    "ax.set_ylabel('Amplitude')\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3928d442",
+   "metadata": {},
+   "source": [
+    "Finally, we save the profile to a file that can be read in when Rayleigh is initialized."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bc62955c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "si.write('my_custom_profile.dat')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "df29570a",
+   "metadata": {},
+   "source": [
+    "To use this profile, with random thermal perturbations for the non-spherically symmetric components of temperature/entropy, we include the following in our main_input:  \n",
+    "\n",
+    "&Initial_Conditions_Namelist  \n",
+    "init_type = 7  \n",
+    "custom_thermal_file = 'my_custom_profile.dat'  \n",
+    "temp_amp = 0.1  \n",
+    "/\n",
+    "\n",
+    "We can then check the results by outputting a Shell_Avgs file on timestep 1.  Note that we use a pretty large temp_amp here for illustration purposes.  This let's us easily view the standard deviation about the spherically symmetric mean.  This let's us verify that non-spherically symmetric modes were not set to zero.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "168b4c88-4d51-469b-b539-a0dfa61ac55c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sa = Shell_Avgs('00000001')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4f9ba7a4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig, ax = plt.subplots()\n",
+    "thermal = sa.vals[:,0,sa.lut[501],0]\n",
+    "thermal_stdev = np.sqrt(sa.vals[:,1,sa.lut[501],0])\n",
+    "ax.plot(sa.radius,thermal, 'ro',label='T (from Rayleigh)')\n",
+    "ax.plot(sa.radius,func_pars['amp']*sa.radius**func_pars['power'], label='T (supplied)')\n",
+    "ax.plot(sa.radius,thermal+thermal_stdev, color = 'gray')\n",
+    "ax.plot(sa.radius,thermal-thermal_stdev, color = 'gray')\n",
+    "ax.set_xlabel('Radius')\n",
+    "ax.set_ylabel('Temperature')\n",
+    "ax.legend()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bfcb3a30",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
This commit adds functionality.   Rayleigh already possesses an initial condition option to specify a conductive entropy/temperature profile + random thermal perturbations.  This commit extends that functionality to allow a user-specified ell=0 profile to be used instead.   Documentation and an example notebook are included.    This is accomplished via the generic input interface, so I would suggest Cian review this.