### PR TITLE
switch to newer conda compilers to fix CI

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -19,7 +19,7 @@ dependencies:
   - nbsphinx=0.8
   - pandoc=2.13
   - recommonmark=0.7
-  - compilers=1.1.3
+  - compilers=1.4.2
   - mkl=2020.4
   - fftw=3.3
   - mpich=3.4


### PR DESCRIPTION
It turns out that the failure in the CI pipeline was due to a change in the conda `mpich` package and not in our `configure` script. The `mpif90`/`mpifort` wrapper script injects the `-fallow-argument-mismatch` option, probably to work around issues with some versions of MPICH. As the script doesn't check of the compiler is new enough to actually provide that options we get the error. I've bumped the version of the `compilers` package to fix this. We are now using gfortran 10.3.0. I don't think this should break anything else in Rayleigh.