### PR TITLE
fix use of undeclared variable in OMP PARALLLEL clause

### DIFF
--- a/src/Math_Layer/Chebyshev_Polynomials.F90
+++ b/src/Math_Layer/Chebyshev_Polynomials.F90
@@ -568,7 +568,7 @@ Contains
         Integer, Intent(In)    :: ind, dind, dorder
         Real*8, Allocatable :: dbuffer(:,:,:)
         Integer :: dims(4), n,n2,n3, i,j,k, order
-        Integer :: kstart, kend, trank
+        Integer :: kstart, kend, trank, nthr
         Integer :: nglobal, nsub, hoff, hh
         dims = shape(buffer)
         nglobal = dims(1)
@@ -601,14 +601,14 @@ Contains
             !$OMP PARALLEL PRIVATE(i,j,k,trank,order,kstart,kend,nthr,n,hh,hoff)
 #ifdef useomp
                 trank = omp_get_thread_num()
-                  nthr  = omp_get_num_threads()
-                  kstart = (trank*n3)/nthr+1
-                  kend = ((trank+1)*n3)/nthr
+                nthr  = omp_get_num_threads()
 #else
                 trank = 0
-                kstart = 1
-                kend = n3
+                nthr = 1
 #endif
+                kstart = (trank*n3)/nthr+1
+                kend = ((trank+1)*n3)/nthr
+
                 Do k = kstart,kend
 
                     Do j = 1, n2


### PR DESCRIPTION
The Cray compiler (cce) is giving an error because we are mentioning the undeclared variable `nthr` in the `OMP PARALLEL` clause. It isn't being using if `useomp` is not set in the preprocessor, which is probably why we haven't seen problems with the other compilers. I see several ways to fix this. Which is the best depends on our handling of OpenMP, which I don't know much about.

1. Declare `nthr` and set it in both parts of the `#ifdef useomp`. Actually we can use one consistent definition of `kstart` and `kend` here, which makes the code cleaner in my opinion. _This is what I implemented in this PR so far._
2. Remove `nthr` altogether and call `omp_get_num_threads()` twice to the the number of threads. These calls should be very cheap.
3. Define `nthr` locally within a Fortran `BLOCK`.
4. Move the whole `OMP PARALLEL` clause into the `#ifdef useomp` and capture the `OMP END PARALLEL` accordingly. This might have an impact on compiling the code with the OpenMP option being used but `useomp` being unset. I'm not sure we support this anyway, because the other `OMP` clauses would need to be `#ifdef`ed as well.

I don't have a particular preference. Maybe @feathern can make a call here.