### PR TITLE
Reading with byte swapping should be used to read self.version, self.…

### DIFF
--- a/post_processing/rayleigh_diagnostics.py
+++ b/post_processing/rayleigh_diagnostics.py
@@ -979,16 +979,16 @@ class G_Avgs:
 
         """
         self.fd = open(the_file,'rb')        
-        specs = np.fromfile(self.fd,dtype='int32',count=4)
+        specs = np.fromfile(self.fd,dtype='int32',count=1)
         bcheck = specs[0]       # If not 314, we need to swap the bytes
         self.byteswap = False
         if (bcheck != 314):
             specs.byteswap()
             self.byteswap = True
             
-        self.version = specs[1]
-        self.niter = specs[2]
-        self.nq = specs[3]
+        self.version = swapread(self.fd,dtype='int32',count=1,swap=self.byteswap)
+        self.niter = swapread(self.fd,dtype='int32',count=1,swap=self.byteswap)
+        self.nq = swapread(self.fd,dtype='int32',count=1,swap=self.byteswap)
         if (closefile):
             self.fd.close()
    


### PR DESCRIPTION
If the global average data G_Avgs with different endian,  self.version, self, niter, self.nq flooring with "bcheck" should be swapped the byte order.