### PR TITLE
Move some documentation sections into the user guide

### DIFF
--- a/doc/source/User_Guide/index.rst
+++ b/doc/source/User_Guide/index.rst
@@ -11,11 +11,14 @@ Rayleigh User Manual
    running
    benchmarking
    physics
+   ../Model_Setup/index.rst
    checkpointing
    cookbooks
+   ../../../CONTRIBUTING.md
    custom_reference_states
    diagnostics
    io_control
    ensemble_mode
    references
    examples
+   ../diagnostic_values/index

--- a/index.rst
+++ b/index.rst
@@ -10,9 +10,6 @@ Welcome to Rayleigh's documentation!
    :maxdepth: 2
 
    doc/source/User_Guide/index.rst
-   doc/source/Model_Setup/index.rst
-   CONTRIBUTING.md
-   doc/source/diagnostic_values/index
    doc/source/diagnostic_codes/qcodes
    doc/source/Namelist_Definitions/Namelist_Variables.rst
    doc/source/publications/publications


### PR DESCRIPTION
This is a suggestion for how to reduce the number of top-level sections in the documentation. I think all three of these are really sub-parts of the user guide. I am not entirely sure where to put them, but we can easily reorder the sections in the user guide. If you want me to put them in a different place I can move them around.