### PR TITLE
Add workflow that creates a docker container of Rayleigh

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,54 @@
+name: github-docker
+
+on: 
+  push: 
+    branches:
+      - 'master'
+  release:
+    types: [created]
+
+concurrency:
+  group: docker-build
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build-docker:
+    runs-on: ubuntu-latest
+    if: github.repository == 'geodynamics/rayleigh'
+    steps:    
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_LOGIN }}
+
+      - name: Build and push Docker image for master
+        if: contains(github.event_name, 'push')
+        uses: docker/build-push-action@v3
+        with:
+          context: ./docker/rayleigh/
+          cache-from: type=registry,ref=geodynamics/rayleigh-buildenv-bionic
+          cache-to: type=inline
+          push: true
+          tags: geodynamics/rayleigh:latest
+
+      - name: Build and push Docker image for release
+        if: contains(github.event_name, 'release')
+        uses: docker/build-push-action@v3
+        with:
+          context: ./docker/rayleigh/
+          cache-from: type=registry,ref=geodynamics/rayleigh-buildenv-bionic
+          cache-to: type=inline
+          push: true
+          tags: geodynamics/rayleigh:${{github.ref_name}}
+


### PR DESCRIPTION
This adds a github action workflow to automatically create a docker image of Rayleigh when:
1. A PR is merged into master. A new docker image with the tag geodynamics/rayleigh:latest is generated.
2. A Rayleigh release is generated. A new docker image with the tag geodynamics/rayleigh:RELEASE_TAG is generated (where RELEASE_TAG is replaced by the tag of the release used by github).

The image that is generated itself is a bit outdated at the moment (it is based on the tester container using Ubuntu 18.04), but the workflow will use the Dockerfile in docker/rayleigh to build the image, so updating the Dockerfile will automatically update the docker image.