### PR TITLE
new buildenv using Ubuntu Jammy

### DIFF
--- a/docker/rayleigh-buildenv-jammy/Dockerfile
+++ b/docker/rayleigh-buildenv-jammy/Dockerfile
@@ -1,0 +1,41 @@
+FROM ubuntu:jammy
+
+RUN apt-get update && \
+  DEBIAN_FRONTEND='noninteractive' \
+  DEBCONF_NONINTERACTIVE_SEEN='true' \
+  apt-get install --yes \
+    g++ \
+    gfortran \
+    git \
+    intel-mkl \
+    libopenmpi-dev \
+    make \
+    nano \
+    wget \
+    python3-pip \
+    sphinx-common \
+    texlive-base \
+    texlive-latex-base \
+    texlive-latex-recommended \
+    texlive-latex-extra \
+    lmodern \
+    makedepf90 \
+    latexmk \
+    pandoc \
+    python3-numpy \
+    python3-scipy \
+    python3-funcsigs \
+    python3-sphinxcontrib.bibtex \
+    python3-sphinx-book-theme \
+    python3-recommonmark \
+    python3-nbsphinx \
+    python3-vtk7 \
+    jupyter \
+    && apt-get clean && rm -r /var/lib/apt/lists/*
+
+RUN pip3 install nbstripout
+
+# Export compilers
+ENV CC mpicc
+ENV CXX mpicxx
+ENV FC mpifort

--- a/docker/rayleigh-buildenv-jammy/README.md
+++ b/docker/rayleigh-buildenv-jammy/README.md
@@ -1,0 +1,1 @@
+Build environment for Rayleigh using the Ubuntu Jammy Docker container.

--- a/docker/rayleigh-devel-jammy/Dockerfile
+++ b/docker/rayleigh-devel-jammy/Dockerfile
@@ -1,0 +1,16 @@
+FROM geodynamics/rayleigh-buildenv-jammy
+
+RUN apt update && \
+  DEBIAN_FRONTEND='noninteractive' \
+  DEBCONF_NONINTERACTIVE_SEEN='true' \
+  apt install --yes \
+    sudo
+
+COPY /entrypoint.sh /entrypoint.sh
+
+ENTRYPOINT /entrypoint.sh
+
+# Export compilers
+ENV CC mpicc
+ENV CXX mpicxx
+ENV FC mpifort

--- a/docker/rayleigh-devel-jammy/entrypoint.sh
+++ b/docker/rayleigh-devel-jammy/entrypoint.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+
+export HOME=/work
+cd "$HOME"
+
+if [ -n "$HOSTGID" -a -n "$HOSTUSER" -a -n "$HOSTUID" ]
+then
+	# only create user if all options are provided
+
+	# This only creates the group if a group with that GID does not already exist.
+	getent group $HOSTGID > /dev/null || groupadd -g $HOSTGID $HOSTUSER
+	useradd -u $HOSTUID -g $HOSTGID -d /work -s /bin/bash $HOSTUSER
+
+	echo "$HOSTUSER ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/nopasswd
+
+	sudo -u $HOSTUSER /bin/bash --rcfile /etc/bash.bashrc -i
+else
+        if [ "${NOUIDWARN}" != 1 ]
+        then
+                echo
+                echo "You are running this container without providing the HOSTUSER, HOSTGID, and HOSTUID"
+                echo "environment variables. This means the container will use the root user and it might create files"
+                echo "owned by root in your home directory if you run this on Docker with Linux as a host system."
+                echo 'Consider running this using the "docker-devel" script from the Rayleigh main directory.'
+                echo
+        fi
+	/bin/bash --rcfile /etc/bash.bashrc -i
+fi


### PR DESCRIPTION
This creates a new buildenv container using the most recent LTS version of Ubuntu. As packages got updated since Ubuntu Bionic, we can now build Rayleigh and the documentation without relying on pip, except for `nbstripout`, which still does not have a package. This also switches from the standard LAPACK and FFTW to the MKL versions, which are available in the Ubuntu repository.

Other small changes:
- Using `apt-get` instead of `apt` to avoid the warning about the unstable command-line interface
- Remove the repository lists after package install to keep the container size down.