### PR TITLE
Disable execution of jupyter notebook on readthedocs

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -49,6 +49,7 @@ templates_path = ['_templates']
 # This pattern also affects html_static_path and html_extra_path.
 exclude_patterns = ['_build', '**.ipynb_checkpoints']
 nbsphinx_allow_errors = True
+nbsphinx_execute = 'never'
 
 # -- Options for HTML output -------------------------------------------------
 


### PR DESCRIPTION
This PR fixes #353 by disabling the execution of jupyter notebooks when the documentation is build on readthedocs. We can later figure out a fancy way of getting the necessary data to readthedocs, but for now this is the simplest way to remove the error messages in the documentation.