### PR TITLE
Update containers available to users

### DIFF
--- a/docker-devel
+++ b/docker-devel
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-docker run -it --rm -v $HOME:/work -e HOSTUID=$(id -u) -e HOSTGID=$(id -g) -e HOSTUSER=$(id -n -u) geodynamics/rayleigh-devel-bionic:latest
+docker run -it --rm -v $HOME:/work -e HOSTUID=$(id -u) -e HOSTGID=$(id -g) -e HOSTUSER=$(id -n -u) geodynamics/rayleigh-devel-jammy:latest

--- a/docker-devel.bat
+++ b/docker-devel.bat
@@ -1,3 +1,3 @@
 :: echo off
 
-docker run -it --rm -v "%USERPROFILE%":/work -e NOUIDWARN=1 geodynamics/rayleigh-devel-bionic:latest
+docker run -it --rm -v "%USERPROFILE%":/work -e NOUIDWARN=1 geodynamics/rayleigh-devel-jammy:latest

--- a/docker/rayleigh/Dockerfile
+++ b/docker/rayleigh/Dockerfile
@@ -1,4 +1,4 @@
-FROM geodynamics/rayleigh-buildenv-bionic:latest
+FROM geodynamics/rayleigh-buildenv-jammy:latest
 
 RUN useradd \
   --create-home \
@@ -13,9 +13,7 @@ RUN git clone 'https://github.com/geodynamics/Rayleigh.git'
 WORKDIR /home/rayleigh_user/Rayleigh
 
 RUN ./configure \
-    --with-blas='/usr' \
-    --with-fftw='/usr' \
-    --with-lapack='/usr' \
+    -debian-mkl \
   && make \
   && make install \
   && make clean

--- a/docker/rayleigh/Dockerfile
+++ b/docker/rayleigh/Dockerfile
@@ -1,5 +1,7 @@
 FROM geodynamics/rayleigh-buildenv-jammy:latest
 
+EXPOSE 8888
+
 RUN useradd \
   --create-home \
   rayleigh_user
@@ -21,3 +23,5 @@ RUN ./configure \
 ENV RAYLEIGH_DIR /home/rayleigh_user/Rayleigh
 
 ENV PATH="${RAYLEIGH_DIR}/bin:${PATH}"
+
+ENV PYTHONPATH="${RAYLEIGH_DIR}/post_processing${PYTHONPATH:+:$PYTHONPATH}"


### PR DESCRIPTION
This updates all containers to the new Ubuntu Jammy base. Before we merge this the corresponding base containers (`rayleigh-buildenv-jammy`, `rayleigh-devel-jammy`) should be pushed to the `geodynamics` namespace on Docker Hub.

This also exposes port 8888 so that Jupyter notebooks can be accessed from outside the container with a command like:

```sh
docker run -it --rm -p 8888:8888 geodynamics/rayleigh
jupyter notebook --ip=\*
```
