### PR TITLE
Update test workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,12 +1,17 @@
 name: continuous-integration
 
-on: [push, pull_request]
+on: pull_request
 
 concurrency:
-  group: ${{ github.ref }}
+  group: ${{ github.actor }}-${{ github.ref }}
   cancel-in-progress: true
 
 env:
+  OMPI_MCA_btl_base_warn_component_unused: 0
+  OMPI_MCA_mpi_yield_when_idle: 1
+  OMPI_MCA_rmaps_base_oversubscribe: 1
+  OMPI_ALLOW_RUN_AS_ROOT: 1
+  OMPI_ALLOW_RUN_AS_ROOT_CONFIRM: 1
   # Fix OpenMPI issue in Docker : https://github.com/open-mpi/ompi/issues/4948
   OMPI_MCA_btl_vader_single_copy_mechanism: none
 
@@ -14,7 +19,7 @@ jobs:
   test:
     name: linux-jammy-container-build
     runs-on: [ubuntu-latest]
-    container: tuks/rayleigh-buildenv-jammy
+    container: geodynamics/rayleigh-buildenv-jammy
 
     steps:
     - uses: actions/checkout@v1
@@ -37,13 +42,8 @@ jobs:
         make install
     - name: Test
       run: |
-        # Set some environment variables necessary for OpenMPI to run as root
-        # and on more MPI ranks than available cores
-        export RAYLEIGH_TEST_MPI_PARAMS="--oversubscribe --allow-run-as-root"
-
         cd "$GITHUB_WORKSPACE"/tests/c2001_case0
-
-        mpirun -np 4 $RAYLEIGH_TEST_MPI_PARAMS ../../bin/rayleigh.dbg
+        mpirun -np 4 ../../bin/rayleigh.dbg
 
         # Generic input test
         cd "$GITHUB_WORKSPACE"
@@ -54,13 +54,8 @@ jobs:
 
     - name: Unit Tests
       run: |
-        # Set some environment variables necessary for OpenMPI to run as root
-        # and on more MPI ranks than available cores
-        export RAYLEIGH_TEST_MPI_PARAMS="--oversubscribe --allow-run-as-root"
-
         cd "$GITHUB_WORKSPACE"/tests/unit_tests/SHT
-
-        mpirun -np 4 $RAYLEIGH_TEST_MPI_PARAMS ../../../bin/rayleigh.dbg > expected_output.out
+        mpirun -np 4 ../../../bin/rayleigh.dbg > expected_output.out
 
         git diff > changes.diff
         git diff --exit-code --name-only


### PR DESCRIPTION
This makes use of #391 to simplify some of the mpirun options, which can now be handled by environment variables. Also change the trigger action for the workflow to avoid running the workflow when users push random branches to their personal forks (= waste of energy).
