### PR TITLE
Fix path to CIG logo on subpages of documentation.

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -75,7 +75,7 @@ html_theme_options = {
     "use_repository_button": True,
     "use_edit_page_button": True,
     "use_issues_button": True,
-    "extra_navbar": "<p><img src=\"_static/cig_logo_dots.png\" alt=\"CIG Logo\" height=\"80px\"  style=\"padding: 5px;\"/></p>",
+    "extra_navbar": "<p><img src=\"/en/latest/_static/cig_logo_dots.png\" alt=\"CIG Logo\" height=\"80px\"  style=\"padding: 5px;\"/></p>",
     "home_page_in_toc": True,
 }
 


### PR DESCRIPTION
This fixes a little quirk in the current documentation. The CIG logo is only displayed correctly on the homepage, because it is inserted as static html code to every page. On subpages the path is currently not correct.
 In order for this to work the path needs to be absolute to the homepage, not relative to the current page.