### PR TITLE
Add TACC docker image

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -73,3 +73,30 @@ jobs:
           tags: |
             ghcr.io/${{env.REPO_NAME_LC}}:${{github.ref_name}}
             ${{env.REPO_NAME_LC}}:${{github.ref_name}}
+
+
+      - name: Build and push TACC image for main
+        if: contains(github.event_name, 'push')
+        uses: docker/build-push-action@v4
+        with:
+          context: ./docker/rayleigh-tacc/
+          cache-from: type=registry,ref=geodynamics/rayleigh-buildenv-bionic
+          cache-to: type=inline
+          platforms: linux/amd64
+          push: true
+          tags: |
+            ghcr.io/${{env.REPO_NAME_LC}}:latest-tacc
+            ${{env.REPO_NAME_LC}}:latest-tacc
+
+      - name: Build and push TACC image for release
+        if: contains(github.event_name, 'release')
+        uses: docker/build-push-action@v4
+        with:
+          context: ./docker/rayleigh-tacc/
+          cache-from: type=registry,ref=geodynamics/rayleigh-buildenv-bionic
+          cache-to: type=inline
+          platforms: linux/amd64
+          push: true
+          tags: |
+            ghcr.io/${{env.REPO_NAME_LC}}:${{github.ref_name}}-tacc
+            ${{env.REPO_NAME_LC}}:${{github.ref_name}}-tacc

--- a/doc/source/User_Guide/getting_started.rst
+++ b/doc/source/User_Guide/getting_started.rst
@@ -363,6 +363,29 @@ After cloning a Rayleigh repository, rayleigh can be configured and compiled as:
 
 We suggest choosing 'AVX512' at the configure menu.  This vectorization is supported by both the Skylake and Ice Lake nodes available on Stampede2.  An example jobscript for Stampede2 may be found in *Rayleigh/job_scripts/TACC_Stampede2*.
 
+Using the Apptainer container system
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+We provide a precompiled container that provides an alternative way to use Rayleigh on the  TACC computing systems Stampede3 and Frontera.
+
+To activate the container system and download the container:
+
+.. code-block:: bash
+
+   module load tacc-apptainer
+   apptainer pull docker://gassmoeller/rayleigh:tacc-latest
+
+This will create a file `rayleigh_tacc-latest.sif` that you can think of as a Rayleigh executable.
+To run Rayleigh models using the downloaded container run (on a compute node):
+
+.. code-block:: bash
+
+   ibrun -n N_CORES apptainer run rayleigh_tacc-latest.sif rayleigh.opt
+
+Make sure to replace N_CORES with the number of requested cores (or remove -n option to run with the
+total number of cores requested). Also make sure to provide the correct path to `rayleigh_tacc-latest.sif`
+if it is not in the current directory.
+
 .. _pleiades:
 
 NASA Pleiades

--- a/docker/rayleigh-tacc/Dockerfile
+++ b/docker/rayleigh-tacc/Dockerfile
@@ -1,0 +1,25 @@
+FROM tacc/tacc-base:ubuntu22.04-impi19.0.9-common
+
+LABEL maintainer <rene.gassmoeller@mailbox.org>
+
+RUN apt-get update || true && \
+    DEBIAN_FRONTEND=noninteractive apt-get install --yes \
+    git libmkl-dev libfftw3-dev
+
+RUN cd /opt && git clone 'https://github.com/geodynamics/Rayleigh.git'
+
+ENV FC mpifc
+ENV CC mpicc
+ENV MKLROOT /opt/intel/compilers_and_libraries_2020.0.166/linux/mkl
+ENV LD_LIBRARY_PATH="${MKLROOT}/lib/intel64:${LD_LIBRARY_PATH}"
+
+RUN cd /opt/Rayleigh && \
+   ./configure --with-fftw=/usr --FFLAGS_OPT="-march=skylake-avx512 -O3 -ffixed-line-length-132" \
+     \
+  && make -j \
+  && make install \
+  && make clean
+
+ENV RAYLEIGH_DIR /opt/Rayleigh
+
+ENV PATH="${RAYLEIGH_DIR}/bin:${PATH}"

--- a/docker/rayleigh-tacc/Readme.md
+++ b/docker/rayleigh-tacc/Readme.md
@@ -1,0 +1,6 @@
+This is a docker container that can be used to run Rayleigh on the set of TACC
+supercomputers, in particular Frontera and Stampede3, without having to manually
+compile the code.
+
+Steps to use this container on Stampede3/Frontera are described on
+https://rayleigh-documentation.readthedocs.io/en/latest/doc/source/User_Guide/getting_started.html.

--- a/docker/rayleigh-tacc/build.sh
+++ b/docker/rayleigh-tacc/build.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# This script generates a docker image from the latest Rayleigh development version.
+# It requires a docker installation on the local machine, and the ability to
+# communicate with the docker daemon without root user privileges (see the docker
+# webpage for an explanation).
+# Note: This container is build from the developer version on Github, it does not use
+# the local Rayleigh folder. Therefore local changes are not included in the container.
+
+docker build --no-cache -t geodynamics/rayleigh:tacc-latest . 2>&1 | tee build.log


### PR DESCRIPTION
This is a preliminary PR that can create a docker image that runs on TACC Stampede2. So far I have it  only running on a single node, and unfortunately the image is quite a bit slower. I suspect this is because I have no access to MKL inside the container. I will think about this a bit more.