### PR TITLE
WIP:  Switching from conda to mamba for Readthedocs build

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -5,6 +5,12 @@
 # Required
 version: 2
 
+#Use Mamba
+build:
+  os: "ubuntu-20.04"
+  tools:
+    python: "mambaforge-4.10"
+
 # Build documentation in the root directory with Sphinx
 sphinx:
   configuration: ./conf.py

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -5,7 +5,7 @@
 # Required
 version: 2
 
-#Use Mamba
+#Use Mamba instead of Conda to avoid running into memory limits (recommended by ReadtheDocs)
 build:
   os: "ubuntu-20.04"
   tools:


### PR DESCRIPTION
Please don't merge this yet.

When building our documentation, we seem to be hitting a memory limit at Readthedocs.   They suggest switching to mamba.  This PR is a first attempt at this.