### PR TITLE
Bug Fix: Augment_Reference

### DIFF
--- a/src/Physics/PDE_Coefficients.F90
+++ b/src/Physics/PDE_Coefficients.F90
@@ -703,7 +703,10 @@ Contains
         Allocate(temp_functions(1:n_r, 1:n_ra_functions))
         Allocate(temp_constants(1:n_ra_constants))
         temp_functions(:,:) = ra_functions(:,:)
-        temp_constants(:) = ra_constants(:)
+
+        ! Note that ra_constants is allocated up to max_ra_constants
+        temp_constants(:) = ra_constants(1:n_ra_constants)
+
 
         Call Read_Custom_Reference_File(custom_reference_file)
 
@@ -729,7 +732,7 @@ Contains
             temp_constants(2) = ra_constants(2)
         Endif
 
-        ra_constants(:) = temp_constants(:)
+        ra_constants(1:n_ra_constants) = temp_constants(:)
         ra_functions(:,:) = temp_functions(:,:)
         DeAllocate(temp_functions, temp_constants)
 


### PR DESCRIPTION
This small but important bug fix addresses an array-bounds issue that arose as part of the multiple-scalar fields addition.  The ra_constants array is now initialized to be max_ra_constants in size.  The augment_reference routine expected that array to be n_ra_constants in size, however, resulting in a seg fault.  This PR fixes the issue.  I would like for @cianwilson to review this PR if time allows.