### PR TITLE
Adding Custom Background dSdr and dTdr via augment_reference.

### DIFF
--- a/src/Physics/PDE_Coefficients.F90
+++ b/src/Physics/PDE_Coefficients.F90
@@ -686,6 +686,7 @@ Contains
     Subroutine Augment_Reference()
         Implicit None
         Real*8, Allocatable :: temp_functions(:,:), temp_constants(:)
+        Integer :: n_func_copy, n_const_copy
 
         If (my_rank .eq. 0) Then
             Call stdout%print('Reference state will be augmented.')
@@ -704,7 +705,9 @@ Contains
         Allocate(temp_functions(1:n_r, 1:n_ra_functions))
         Allocate(temp_constants(1:n_ra_constants))
         temp_functions(:,:) = ra_functions(:,:)
-        temp_constants(:) = ra_constants(:)
+        
+        ! Note that ra_constants is allocated up to max_ra_constants
+        temp_constants(:) = ra_constants(1:n_ra_constants)
 
         Call Read_Custom_Reference_File(custom_reference_file)
 
@@ -741,7 +744,7 @@ Contains
         Endif
 
 
-        ra_constants(:) = temp_constants(:)
+        ra_constants(1:n_ra_constants) = temp_constants(:)
         ra_functions(:,:) = temp_functions(:,:)
         DeAllocate(temp_functions, temp_constants)
 

--- a/src/Physics/PDE_Coefficients.F90
+++ b/src/Physics/PDE_Coefficients.F90
@@ -686,7 +686,6 @@ Contains
     Subroutine Augment_Reference()
         Implicit None
         Real*8, Allocatable :: temp_functions(:,:), temp_constants(:)
-        Integer :: n_func_copy, n_const_copy
 
         If (my_rank .eq. 0) Then
             Call stdout%print('Reference state will be augmented.')
@@ -735,7 +734,7 @@ Contains
 
         If (use_custom_function(14)) Then
             If (my_rank .eq. 0) Then
-                Call stdout%print('Background temperature/entropy gradient is set to:')
+                Call stdout%print('Background thermal gradient is set to:')
                 Call stdout%print('f_14')
                 Call stdout%print(' ')
             Endif        

--- a/src/Physics/PDE_Coefficients.F90
+++ b/src/Physics/PDE_Coefficients.F90
@@ -689,9 +689,10 @@ Contains
 
         If (my_rank .eq. 0) Then
             Call stdout%print('Reference state will be augmented.')
-            Call stdout%print('Only heating and buoyancy may be modified.')
+            Call stdout%print('Only heating, buoyancy, or background dTdr/dSdr may be modified.')
             Call stdout%print('Heating requires both c_10 and f_6 to be set.')
             Call stdout%print('Buoyancy requires both c_2 and f_2 to be set.')
+            Call stdout%print('dTdr/dSdr requires f_14 to be set.')            
             Call stdout%print('Reading from: '//Trim(custom_reference_file))
         Endif
 
@@ -728,6 +729,17 @@ Contains
             temp_functions(:,2) = ra_functions(:,2)
             temp_constants(2) = ra_constants(2)
         Endif
+
+        If (use_custom_function(14)) Then
+            If (my_rank .eq. 0) Then
+                Call stdout%print('Background temperature/entropy gradient is set to:')
+                Call stdout%print('f_14')
+                Call stdout%print(' ')
+            Endif        
+            ref%dsdr(:) = ra_functions(:,14)
+            temp_functions(:,14) = ra_functions(:,14)
+        Endif
+
 
         ra_constants(:) = temp_constants(:)
         ra_functions(:,:) = temp_functions(:,:)


### PR DESCRIPTION
This PR adds the ability for the user to modify the background dSdr and dTdr through the augment_reference routine.  This functionality has been added to allow advection of a background temperature gradient in a Boussinesq model without the need to specify a full custom reference state.   I've added this at the request of @jorafb , so I am assigning the review of this PR to him. 