### PR TITLE
Updated HPC Installation Section

### DIFF
--- a/doc/source/User_Guide/getting_started.rst
+++ b/doc/source/User_Guide/getting_started.rst
@@ -343,13 +343,17 @@ To see the dependencies being installed you can use:
 
 .. _hpc_installation_instructions:
 
-Installation Instructions for HPC systems
+Installation on HPC systems
 -----------------------------------------
+
+Given the amount of computational resources required to simulate convection in highly turbulent parameter regimes, many users will want to run Rayleigh in a HPC environment.  Here we provide instructions for compilation on two widely-used, national-scale supercomputing systems:  TACC Stampede2 and NASA Pleiades.   
+
+Example jobscripts containing the necessary commands to compile and run Rayleigh on various systems may be found in *Rayleigh/job_scripts/*.
 
 .. _stampede2:
 
-Stampede2
-~~~~~~~~~
+TACC Stampede2
+~~~~~~~~~~~~~~
 
 Installing Rayleigh on NSF's Stampede 2 system is straightforward. At the time
 this documentation is written (Sep 2022) the loaded default modules work out of
@@ -365,36 +369,35 @@ After cloning a Rayleigh repository, rayleigh can be configured and compiled as:
 
 .. code-block:: bash
 
-   FC=mpifc CC=mpicc ./configure
+   FC=mpifc CC=mpicc ./configure  # select 'AVX512'
    make -j
    make install
 
-The architecture for most Stampede2 nodes is Skylake (AVX512), with a few
-Ice Lake nodes (also AVX512).
+We suggest choosing 'AVX512' at the configure menu.  This vectorization is supported by both the Skylake and Ice Lake nodes available on Stampede2.  An example jobscript for Stampede2 may be found in *Rayleigh/job_scripts/TACC_Stampede2*.
 
-A minimal job script for Rayleigh could look like this:
+.. _pleiades:
+
+NASA Pleiades
+~~~~~~~~~~~~~
+
+Installation on NASA's Pleiades cluster is similarly straightforward.  After cloning the repository, Rayleigh can be configured and compiled via the following commands:
 
 .. code-block:: bash
 
-    #!/bin/bash
-    #SBATCH -J geodynamo-test           # Job name
-    #SBATCH -o log.o%j       # Name of stdout output file
-    #SBATCH -e error.e%j       # Name of stderr error file
-    #SBATCH -p skx-dev      # Queue (partition) name; skx-dev for testing; skx-normal for production.
-    #SBATCH -N 1               # Total # of nodes. 1-4 for skx-dev. >=4 for skx-normal
-    #SBATCH --ntasks-per-node 48
-    #SBATCH -t 00:10:00        # Run time (hh:mm:ss) max 2h on skx-dev, max 48h on skx-normal
-    #SBATCH --mail-user=
-    #SBATCH --mail-type=none    # Send no email
+   module purge
+   module load comp-intel
+   module load mpi-hpe
+   ./configure --FC=mpif90 --CC=icc  # select 'ALL'
+   make -j
+   make install
+   
+We suggest using the default Intel and MPI compilers provided by Pleiades as in the example above.  As of December, 2022, this corresponded to the following version combination:
 
-    module list
+.. code-block:: bash
 
-    # Launch MPI code...
+   1) comp-intel/2020.4.304   2) mpi-hpe/mpt.2.25
 
-    export RAYLEIGH_PATH=...
-    # Replace -n X with correct number of MPI ranks, or remove to use all ranks
-    # requested on the nodes above.
-    ibrun -n 48 $RAYLEIGH_PATH
+Note that Pleiades is a hetergenous cluster, composed of many (primarily Intel) processor types. We suggest selecting the 'ALL' option when configuring Rayleigh to ensure that a unique executable is created for each of the possible vectorization options.  An example jobscript for Pleiades may be found in *Rayleigh/job_scripts/NASA_Pleiades*.
 
 
 

--- a/doc/source/User_Guide/getting_started.rst
+++ b/doc/source/User_Guide/getting_started.rst
@@ -397,7 +397,7 @@ We suggest using the default Intel and MPI compilers provided by Pleiades as in 
 
    1) comp-intel/2020.4.304   2) mpi-hpe/mpt.2.25
 
-Note that Pleiades is a hetergenous cluster, composed of many (primarily Intel) processor types. We suggest selecting the 'ALL' option when configuring Rayleigh to ensure that a unique executable is created for each of the possible vectorization options.  An example jobscript for Pleiades may be found in *Rayleigh/job_scripts/NASA_Pleiades*.
+Note that Pleiades is a heterogeneous cluster, composed of many (primarily Intel) processor types. We suggest selecting the 'ALL' option when configuring Rayleigh to ensure that a unique executable is created for each of the possible vectorization options.  An example jobscript for Pleiades may be found in *Rayleigh/job_scripts/NASA_Pleiades*.
 
 
 

--- a/job_scripts/NASA_Pleiades/pleiades_script.sh
+++ b/job_scripts/NASA_Pleiades/pleiades_script.sh
@@ -5,7 +5,7 @@
 #PBS -m e
 #PBS -N nrho5_ff_5          # job name
 #PBS -l walltime=120:00:00  # run for 120 hours
-#PBS -l select=74:ncpus=28:mpiprocs=28:model=bro  # Request Broadwell nodes.  28 MPI ranks per node.
+#PBS -l select=74:ncpus=28:mpiprocs=28:model=bro  # Request 74 Broadwell nodes.  28 MPI ranks per node.
 
 module purge
 module load comp-intel
@@ -17,6 +17,7 @@ ln -s /home4/nfeather/Ra_share/Rayleigh/bin/* .
 sleep 10
 
 # Run the code
+# Make sure that the number of cores is <= select*mpiprocs
 mpiexec -np 2048 ./rayleigh.avx2 -nprow 64 -npcol 32
 
 

--- a/job_scripts/NASA_Pleiades/pleiades_script.sh
+++ b/job_scripts/NASA_Pleiades/pleiades_script.sh
@@ -1,12 +1,13 @@
 #PBS -S /bin/bash
 #PBS -q long                # 'long' queue allows jobs up to 5 days (use 'normal' for 8 hours or less).
 #PBS -j oe
-#PBS -W group_list=s2100    # account number
+#PBS -W group_list=s1234    # account number
 #PBS -m e
 #PBS -N nrho5_ff_5          # job name
 #PBS -l walltime=120:00:00  # run for 120 hours
 #PBS -l select=74:ncpus=28:mpiprocs=28:model=bro  # Request Broadwell nodes.  28 MPI ranks per node.
 
+module purge
 module load comp-intel
 module load mpi-hpe
 export OMP_NUM_THREADS=1
@@ -17,6 +18,18 @@ sleep 10
 
 # Run the code
 mpiexec -np 2048 ./rayleigh.avx2 -nprow 64 -npcol 32
+
+
+# Compilation Notes
+#
+# To configure and build Rayleigh, the following commands should suffice:
+#
+# module purge
+# module load comp-intel
+# module load mpi-hpe
+# ./configure --FC=mpif90 --CC=icc  (select 'ALL')
+# make -j
+# make install
 
 # Additional notes
 # (1) Pleiades is a hetergenous cluster, composed of many (primarily Intel) processor types.

--- a/job_scripts/NASA_Pleiades/pscript_bro
+++ b/job_scripts/NASA_Pleiades/pscript_bro
@@ -1,0 +1,43 @@
+#PBS -S /bin/bash
+#PBS -q long                # 'long' queue allows jobs up to 5 days (use 'normal' for 8 hours or less).
+#PBS -j oe
+#PBS -W group_list=s2100    # account number
+#PBS -m e
+#PBS -N nrho5_ff_5          # job name
+#PBS -l walltime=120:00:00  # run for 120 hours
+#PBS -l select=74:ncpus=28:mpiprocs=28:model=bro  # Request Broadwell nodes.  28 MPI ranks per node.
+
+module load comp-intel
+module load mpi-hpe
+export OMP_NUM_THREADS=1
+
+# Link the Rayleigh executables from your home directory (modify the path below accordingly)
+ln -s /home4/nfeather/Ra_share/Rayleigh/bin/* .
+sleep 10
+
+# Run the code
+mpiexec -np 2048 ./rayleigh.avx2 -nprow 64 -npcol 32
+
+# Additional notes
+# (1) Pleiades is a hetergenous cluster, composed of many (primarily Intel) processor types.
+#     We suggest selecting the 'ALL' option when configuring Rayleigh to ensure that a unique
+#     executable is created for each of the possible vectorization options.3
+#
+# (2) This script is set up to run Rayleigh on 2048 Pleiades Broadwell cores.
+#     Each Broadwell node has 28 cores, so 74 nodes (2072 cores) must be requested
+#     in order to have access to 2048 cores.  This is typical of most Pleiades node
+#     configurations as most node types do not possess a core-count that is a power of 2.
+#
+# (3) To change the node type, change (i) the PBS 'select' line and the Rayleigh 
+#     executable correspondingly.  Some alternative examples are:
+#
+#   a) Sandybridge Nodes (128 nodes, 2048 cores):  
+#                   PBS -l select=128:ncpus=16:mpiprocs=16:model=san
+#                   mpiexec -np 2048 ./rayleigh.avx -nprow 64 -npcol 32
+#   b) Ivybridge Nodes (103 nodes, 2060 cores):
+#                   PBS -l select=103:ncpus=20:mpiprocs=20:model=ivy
+#                   mpiexec -np 2048 ./rayleigh.avx -nprow 64 -npcol 32
+#   c) Haswell Nodes (86 nodes, 2064 cores):
+#                   PBS -l select=86:ncpus=24:mpiprocs=24:model=has
+#                   mpiexec -np 2048 ./rayleigh.avx2 -nprow 64 -npcol 32
+

--- a/job_scripts/TACC_Stampede2/stampede2_jobscript.sh
+++ b/job_scripts/TACC_Stampede2/stampede2_jobscript.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+#SBATCH -J geodynamo-test  # Job name
+#SBATCH -o log.o%j         # Name of stdout output file
+#SBATCH -e error.e%j       # Name of stderr error file
+#SBATCH -p skx-dev         # Queue (partition) name; skx-dev for testing; skx-normal for production.
+#SBATCH -N 1               # Total # of nodes. 1-4 for skx-dev. >=4 for skx-normal
+#SBATCH --ntasks-per-node 48
+#SBATCH -t 00:10:00        # Run time (hh:mm:ss) max 2h on skx-dev, max 48h on skx-normal
+#SBATCH --mail-user=
+#SBATCH --mail-type=none   # Send no email
+
+module list
+
+# Launch MPI code...
+
+export OMP_NUM_THREADS=1
+# Replace -n X with correct number of MPI ranks, or remove to use all ranks
+# requested on the nodes above.
+
+ibrun -n 48 ./rayleigh.opt
+
+# Compilation Notes
+# At the time this documentation was written, the default-loaded module 
+# stack works without problems (Sep 2022).
+#
+# To configure and compile the code, the following commands should suffice:
+#
+# FC=mpifc CC=mpicc ./configure  (choose 'AVX512')
+# make -j
+# make install


### PR DESCRIPTION
This PR adds instructions for compilation on the NASA Pleiades system.  It also adds a Rayleigh/job_scripts directory with subdirectories for Stampede2 and Pleiades, each of which contains a sample jobscript along with commands needed to compile the code.    That way, everything is easily accessible once the repository is cloned.  I removed the TACC jobscript from the main documentation to streamline things and avoid too much duplication of information.  I think the installation instructions are useful to retain, even if they're summarized in the jobscripts.

Happy to iterate on this, change directory names etc.  
