### PR TITLE
BUG FIX: Restore_Reference_Defaults and Angular_Velocity

### DIFF
--- a/src/Physics/PDE_Coefficients.F90
+++ b/src/Physics/PDE_Coefficients.F90
@@ -1150,7 +1150,7 @@ Contains
         poly_mass = 0.0d0
         poly_rho_i = 0.0d0
 
-        Angular_Velocity = 1.0d0
+        Angular_Velocity = -1.0d0
 
         Rayleigh_Number         = 1.0d0
         Ekman_Number            = 1.0d0


### PR DESCRIPTION
The restore_reference_defaults routine was incorrectly setting the default value of angular_velocity to 1.0 instead of -1.0.  This creates a logical error when running benchmark mode alongside a custom reference state.  The result is that the angular_velocity variable is set to 2, regardless of what is specified in the custom_reference file.   Benchmarking mode is intended to work with custom reference states, in part so that this functionality can be validated against known solutions.  The one-line change in PDE_Coefficients.F90 fixes this issue.