### PR TITLE
Fix bugs for custom diffusions

### DIFF
--- a/src/Physics/PDE_Coefficients.F90
+++ b/src/Physics/PDE_Coefficients.F90
@@ -828,9 +828,9 @@ Contains
         ref%dlnrho(:)  = ra_functions(:,8)
         ref%d2lnrho(:) = ra_functions(:,9)
         ref%buoyancy_coeff(:) = ra_constants(2)*ra_functions(:,2)
-        do i = 0, n_active_scalars-1
-            ref%chi_buoyancy_coeff(i,:) = ra_constants(12+i*2)*ra_functions(:,2)
-        end do
+        Do i = 1, n_active_scalars
+            ref%chi_buoyancy_coeff(i,:) = ra_constants(12+(i-1)*2)*ra_functions(:,2)
+        Enddo
 
         ref%temperature(:) = ra_functions(:,4)
         ref%dlnT(:) = ra_functions(:,10)

--- a/src/Physics/PDE_Coefficients.F90
+++ b/src/Physics/PDE_Coefficients.F90
@@ -1317,11 +1317,6 @@ Contains
             ! We "back up" the current reference state in temp_constants and temp_functions
             ! Below, we modify only the "temp" equation coefficients associated with custom diffusions
             ! Then we restore ra_constants and ra_functions from the "temp" arrays
-            ! BUG IN OUTPUT (Loren, 12/24/22, Merry Christmas!): If one diffusion type is custom
-            ! but another isn't, then the ra_constants/ra_functions associated with the non-custom diffusion
-            ! will be set correctly by the Initialize_Diffusivity routine, but then overwritten,
-            ! likely with erroneous values, in the "restore" process below. 
-            ! Will fix this issue in a later pull request. 
             Call Read_Custom_Reference_File(custom_reference_file)
         EndIf
 


### PR DESCRIPTION
There was an issue in the logic for specifying custom scalar diffusions. Only nu_type, kappa_type, and eta_type were checked to be 3, with the result that if custom scalar diffusions were used, they might not be read from the binary file (unless reference_type was 4, in which case, the custom reference file had already been read). 

Similarly, for reference_type != 4 there was an indexing issue in temp_constants, that led to seg faults if one of the reference_types was 3. @feathern perhaps this is related to the issues you were seeing regarding custom reference and the scalar fields? 

Anyway, this pull request should fix these bugs. It incorporates my other pull requests (#427 and #426). 

Finally, there is an outstanding issue (that is supported by my preliminary testing) with custom diffusions (and again reference_type !=4 ). If one custom diffusion is used (but not all), then temp_functions for the other diffusions will be whatever ra_functions used to be before the initialize_diffusivity calls (likely zero). I think the actual diffusions in Rayleigh will be set correctly (and so will ra_functions), but then ra_functions will get overwritten by the incorrect temp_functions. The code will then run correctly but the output of the equation_coefficients file will be corrupt. Leaving this for now.