### PR TITLE
Set ra_constants/ra_functions before "ref" in PDE_Coefficients.F90

### DIFF
--- a/src/Physics/Main.F90
+++ b/src/Physics/Main.F90
@@ -85,6 +85,7 @@ Contains
 
         Call Initialize_Reference()
         Call Initialize_Transport_Coefficients()
+        Call Initialize_PDE_Coefficients()
 
         Call Initialize_Field_Structure()
         Call Initialize_Checkpointing()

--- a/src/Physics/Main.F90
+++ b/src/Physics/Main.F90
@@ -82,13 +82,14 @@ Contains
         Call Initialize_Benchmarking()
 
         Call Initialize_FFts()
+
         Call Initialize_Reference()
+        Call Initialize_Transport_Coefficients()
 
         Call Initialize_Field_Structure()
         Call Initialize_Checkpointing()
-        Call Initialize_Transport_Coefficients()
-        Call Initialize_Boundary_Conditions()
 
+        Call Initialize_Boundary_Conditions()
 
         Call Write_Equation_Coefficients_File()
 

--- a/src/Physics/PDE_Coefficients.F90
+++ b/src/Physics/PDE_Coefficients.F90
@@ -1173,13 +1173,13 @@ Contains
 
         ! Custom reference-state variables (reference_type = 4)
         !       NOTE: n_ra_constants / n_ra_functions do not have default values (but maybe do, if you consider the Allocate_Reference_State() routine)
-        with_custom_reference = .false.
-        override_constants = .false.
-        override_constant(1:max_ra_constants) = .false. ! in namelist
-        with_custom_constants(1:max_ra_constants) = 0   ! in namelist
-        with_custom_functions(1:max_ra_functions) = 0   ! in namelist
-        ra_constants(1:max_ra_constants) = 0.0d0        ! in namelist
-        custom_reference_read = .false.
+        !with_custom_reference = .false.
+        !override_constants = .false.
+        !override_constant(1:max_ra_constants) = .false. ! in namelist
+        !with_custom_constants(1:max_ra_constants) = 0   ! in namelist
+        !with_custom_functions(1:max_ra_functions) = 0   ! in namelist
+        !ra_constants(1:max_ra_constants) = 0.0d0        ! in namelist
+        !custom_reference_read = .false.
         custom_reference_file ='nothing'  
 
         ! Internal heating variables
@@ -1240,11 +1240,11 @@ Contains
         If (allocated(s_conductive)) DeAllocate(s_conductive)
     
         ! Deallocate custom-reference stuff
-        If (allocated(ra_constant_set)) DeAllocate(ra_constant_set)
-        If (allocated(ra_function_set)) DeAllocate(ra_function_set)
-        If (allocated(use_custom_constant)) DeAllocate(use_custom_constant)
-        If (allocated(use_custom_function)) DeAllocate(use_custom_function)
-        If (allocated(ra_functions)) DeAllocate(ra_functions)
+        !If (allocated(ra_constant_set)) DeAllocate(ra_constant_set)
+        !If (allocated(ra_function_set)) DeAllocate(ra_function_set)
+        !If (allocated(use_custom_constant)) DeAllocate(use_custom_constant)
+        !If (allocated(use_custom_function)) DeAllocate(use_custom_function)
+        !If (allocated(ra_functions)) DeAllocate(ra_functions)
 
         ! Deallocate transport-coefficient stuff
         If (allocated(nu)) DeAllocate(nu)

--- a/src/Physics/PDE_Coefficients.F90
+++ b/src/Physics/PDE_Coefficients.F90
@@ -817,9 +817,9 @@ Contains
         ref%dlnrho(:)  = ra_functions(:,8)
         ref%d2lnrho(:) = ra_functions(:,9)
         ref%buoyancy_coeff(:) = ra_constants(2)*ra_functions(:,2)
-        do i = 0, n_active_scalars-1
-            ref%chi_buoyancy_coeff(i,:) = ra_constants(12+i*2)*ra_functions(:,2)
-        end do
+        Do i = 1, n_active_scalars
+            ref%chi_buoyancy_coeff(i,:) = ra_constants(12+(i-1)*2)*ra_functions(:,2)
+        Enddo
 
         ref%temperature(:) = ra_functions(:,4)
         ref%dlnT(:) = ra_functions(:,10)

--- a/src/Physics/PDE_Coefficients.F90
+++ b/src/Physics/PDE_Coefficients.F90
@@ -711,7 +711,6 @@ Contains
                 Call stdout%print('f_6*c_10')
                 Call stdout%print(' ')
             Endif
-            ref%heating(:) = ra_functions(:,6)/(ref%density*ref%temperature)*ra_constants(10)
             temp_functions(:,6) = ra_functions(:,6)
             temp_constants(10)  = ra_constants(10)
         Endif
@@ -722,7 +721,6 @@ Contains
                 Call stdout%print('f_2*c_2')
                 Call stdout%print(' ')
             Endif
-            ref%buoyancy_coeff(:) = ra_constants(2)*ra_functions(:,2)
             temp_functions(:,2) = ra_functions(:,2)
             temp_constants(2) = ra_constants(2)
         Endif

--- a/src/Physics/PDE_Coefficients.F90
+++ b/src/Physics/PDE_Coefficients.F90
@@ -330,13 +330,13 @@ Contains
             ref%Buoyancy_Coeff(i) = amp*(radius(i)/radius(1))**gravity_power
         Enddo
 
-        do j = 1, n_active_scalars
-          amp = -chi_a_Rayleigh_Number(j)/chi_a_Prandtl_Number(j)
+        Do j = 1, n_active_scalars
+            amp = -chi_a_Rayleigh_Number(j)/chi_a_Prandtl_Number(j)
 
-          Do i = 1, N_R
-              ref%chi_buoyancy_coeff(j,i) = amp*(radius(i)/radius(1))**gravity_power
-          Enddo
-        enddo
+            Do i = 1, N_R
+                ref%chi_buoyancy_coeff(j,i) = amp*(radius(i)/radius(1))**gravity_power
+            Enddo
+        Enddo
 
         pressure_specific_heat = 1.0d0
         Call initialize_reference_heating()
@@ -398,6 +398,13 @@ Contains
         ra_constants(4) = ref%Lorentz_Coeff
         ra_constants(8) = 0.0d0
         ra_constants(9) = 0.0d0
+
+        ! c_10 is managed by Initialize_Reference_Heating() here
+        ! and Initialize_Boundary_Conditions/Transport_Dependencies() in BoundaryConditions.F90
+        ! Set the active-scalar buoyancy coefficients, c_[12 + (j-1)*2], here:
+        Do j = 1, n_active_scalars
+            ra_constants(12+(j-1)*2) = -chi_a_Rayleigh_Number(j)/chi_a_Prandtl_Number(j)
+        Enddo        
 
     End Subroutine Constant_Reference
 
@@ -506,6 +513,14 @@ Contains
             ra_constants(9) = Ekman_Number**2*Dissipation_Number/(Magnetic_Prandtl_Number**2*Modified_Rayleigh_Number)
         Endif ! if not magnetism, ra_constants(9) was initialized to zero
         DeAllocate(dtmparr, gravity)
+
+        ! c_10 is managed by Initialize_Reference_Heating() here
+        ! and Initialize_Boundary_Conditions/Transport_Dependencies() in BoundaryConditions.F90
+        ! Set the active-scalar buoyancy coefficients, c_[12 + (j-1)*2], here:
+        Do i = 1, n_active_scalars
+            ra_constants(12+(i-1)*2) = -chi_a_modified_rayleigh_number(i)
+        Enddo 
+
     End Subroutine Polytropic_ReferenceND
 
     Subroutine Polytropic_Reference()
@@ -632,7 +647,14 @@ Contains
         ra_constants(3) = 1.0d0
         ra_constants(4) = ref%Lorentz_Coeff
         ra_constants(8) = 1.0d0
-        ra_constants(9) = ref%Lorentz_Coeff       
+        ra_constants(9) = ref%Lorentz_Coeff 
+      
+        ! c_10 is managed by Initialize_Reference_Heating() here
+        ! and Initialize_Boundary_Conditions/Transport_Dependencies() in BoundaryConditions.F90
+        ! Set the active-scalar buoyancy coefficients, c_[12 + (j-1)*2], here:
+        Do i = 1, n_active_scalars
+            ra_constants(12+(i-1)*2) = -1.0d0
+        Enddo 
 
     End Subroutine Polytropic_Reference
 

--- a/src/Physics/PDE_Coefficients.F90
+++ b/src/Physics/PDE_Coefficients.F90
@@ -1283,21 +1283,51 @@ Contains
         Implicit None
         Integer :: i
         Real*8, Allocatable :: temp_functions(:,:), temp_constants(:)
-        Logical :: restore
+        Logical :: restore, need_custom
 
         restore = .false.
 
         Call Allocate_Transport_Coefficients
 
-        If ((.not. custom_reference_read) .and. &
-            ((nu_type .eq. 3) .or. (kappa_type .eq. 3) .or. (eta_type .eq. 3))) Then
+        ! Figure out if we need to read anything from the custom file 
+        ! (many "types" to check now because of the new scalar diffusion coefficients)
+        need_custom = .false. 
+        If ( (nu_type .eq. 3) .or. (kappa_type .eq. 3) .or. (eta_type .eq. 3) ) Then
+            need_custom = .true.
+        EndIf
+
+        Do i = 1, n_active_scalars
+            If (kappa_chi_a_type(i) .eq. 3) Then
+                need_custom = .true.
+            Endif
+        Enddo
+
+        Do i = 1, n_passive_scalars
+            If (kappa_chi_p_type(i) .eq. 3) Then
+                need_custom = .true.
+            Endif
+        Enddo
+
+        If ((.not. custom_reference_read) .and. need_custom) Then
             Allocate(temp_functions(1:n_r, 1:n_ra_functions))
             Allocate(temp_constants(1:n_ra_constants))
             temp_functions(:,:) = ra_functions(:,:)
-            temp_constants(:) = ra_constants(:)
+            ! Note that ra_constants is allocated up to max_ra_constants,
+            ! which could be more than n_ra_constants
+            temp_constants(:) = ra_constants(1:n_ra_constants)
             restore = .true.
+            ! If we read the custom file, we may overwrite things besides the diffusion coefficients
+            ! We "back up" the current reference state in temp_constants and temp_functions
+            ! Below, we modify only the "temp" equation coefficients associated with custom diffusions
+            ! Then we restore ra_constants and ra_functions from the "temp" arrays
+            ! BUG IN OUTPUT (Loren, 12/24/22, Merry Christmas!): If one diffusion type is custom
+            ! but another isn't, then the ra_constants/ra_functions associated with the non-custom diffusion
+            ! will be set correctly by the Initialize_Diffusivity routine, but then overwritten,
+            ! likely with erroneous values, in the "restore" process below. 
+            ! Will fix this issue in a later pull request. 
             Call Read_Custom_Reference_File(custom_reference_file)
         EndIf
+
 
         Call Initialize_Diffusivity(nu,dlnu,nu_top,nu_type,nu_power,5,3,11)
         Call Initialize_Diffusivity(kappa,dlnkappa,kappa_top,kappa_type,kappa_power,6,5,12)
@@ -1365,7 +1395,7 @@ Contains
                 temp_constants(5)    = ra_constants(5)
             Endif
 
-            ra_constants(:) = temp_constants(:)
+            ra_constants(1:n_ra_constants) = temp_constants(:)
             ra_functions(:,:) = temp_functions(:,:)
             DeAllocate(temp_functions, temp_constants)
 

--- a/src/Physics/PDE_Coefficients.F90
+++ b/src/Physics/PDE_Coefficients.F90
@@ -39,10 +39,10 @@ Module PDE_Coefficients
     Use General_MPI, Only : BCAST2D
     Implicit None
 
-    Integer, Parameter :: n_scalar_max = 50
     !///////////////////////////////////////////////////////////
     ! I.  Variables describing the background reference state
 
+    ! The following object (handle for which is "ref") is used by the code to access the PDE coefficients
     Type ReferenceInfo
         Real*8, Allocatable :: Density(:)
         Real*8, Allocatable :: dlnrho(:)
@@ -57,20 +57,52 @@ Module PDE_Coefficients
 
         Real*8 :: Coriolis_Coeff ! Multiplies z_hat x u in momentum eq.
         Real*8 :: Lorentz_Coeff ! Multiplies (Del X B) X B in momentum eq.
-        Real*8, Allocatable :: Buoyancy_Coeff(:)    ! Multiplies {S,T} in momentum eq. ..typically = gravity/cp
-        Real*8, Allocatable :: chi_buoyancy_coeff(:,:)    ! Multiplies Chis in momentum eq.
-        Real*8, Allocatable :: dpdr_w_term(:)  ! multiplies d_by_dr{P/rho} in momentum eq.
-        Real*8, Allocatable :: pressure_dwdr_term(:) !multiplies l(l+1)/r^2 (P/rho) in Div dot momentum eq.
+        Real*8, Allocatable :: Buoyancy_Coeff(:) ! Multiplies {S,T} in momentum eq. ..typically = gravity/cp
+        Real*8, Allocatable :: chi_buoyancy_coeff(:,:) ! Multiplies Chis in momentum eq.
+        Real*8, Allocatable :: dpdr_w_term(:) ! Multiplies d_by_dr{P/rho} in momentum eq.
+        Real*8, Allocatable :: pressure_dwdr_term(:) ! Multiplies l(l+1)/r^2 (P/rho) in Div dot momentum eq.
 
         ! The following two terms are used to compute the ohmic and viscous heating
-        Real*8, Allocatable :: ohmic_amp(:) !multiplied by {eta(r),H(r)}J^2 in dSdt eq.
-        Real*8, Allocatable :: viscous_amp(:) !multiplied by {nu(r),N(r)}{e_ij terms) in dSdt eq.
+        Real*8, Allocatable :: ohmic_amp(:) ! Multiplied by {eta(r),H(r)}J^2 in dSdt eq.
+        Real*8, Allocatable :: viscous_amp(:) ! Multiplied by {nu(r),N(r)}{e_ij terms) in dSdt eq.
 
     End Type ReferenceInfo
 
+    Type(ReferenceInfo) :: ref
+    ! Allow up to 50 active/passive scalar fields
+    Integer, Parameter :: n_scalar_max = 50
+
+    ! Version number for the "equation_coefficients" container that is output to the simulation directory
+    ! (i.e., the human-obtainable version of "ref")
     Integer, Parameter  :: eqn_coeff_version = 1
 
-    ! Custom reference state variables
+    ! Which background state to use; default 1 (non-dimensional Boussinesq)
+    Integer :: reference_type = 1 
+
+    ! Nondimensional variables (reference_type = 1,3)
+    Real*8 :: Rayleigh_Number         = 1.0d0
+    Real*8 :: Ekman_Number            = 1.0d0
+    Real*8 :: Prandtl_Number          = 1.0d0
+    Real*8 :: Magnetic_Prandtl_Number = 1.0d0
+    Real*8 :: gravity_power           = 0.0d0
+    Real*8 :: Dissipation_Number      = 0.0d0
+    Real*8 :: Modified_Rayleigh_Number = 0.0d0
+
+    ! Nondimensional variables for the active/passive scalar fields
+    Real*8 :: chi_a_rayleigh_number(1:n_scalar_max)          = 0.0d0
+    Real*8 :: chi_a_prandtl_number(1:n_scalar_max)           = 1.0d0
+    Real*8 :: chi_a_modified_rayleigh_number(1:n_scalar_max) = 0.0d0
+    Real*8 :: chi_p_prandtl_number(1:n_scalar_max)           = 1.0d0
+
+    ! Dimensional anelastic variables (reference_type = 2)
+    Real*8 :: pressure_specific_heat  = 1.0d0 ! CP (not CV)
+    Real*8 :: poly_n = 0.0d0 ! Polytropic index
+    Real*8 :: poly_Nrho = 0.0d0 ! Number of density scale heights across domain
+    Real*8 :: poly_mass = 0.0d0 ! Stellar mass; g(r) = G*poly_mass/r^2
+    Real*8 :: poly_rho_i = 0.0d0 ! Density (g/cm^3) at the inner radius rmin
+    Real*8 :: Angular_Velocity = -1.0d0 ! Frame rotation rate (sets Coriolis force)
+
+    ! Custom reference-state variables (reference_type = 4)
     Integer, Parameter   :: max_ra_constants = 10 + 2*n_scalar_max
     Integer, Parameter   :: max_ra_functions = 14 + 2*n_scalar_max
     Integer              :: n_ra_constants
@@ -89,56 +121,28 @@ Module PDE_Coefficients
     Logical              :: custom_reference_read = .false.
     Character*120        :: custom_reference_file ='nothing'    
 
-    Real*8, Allocatable :: s_conductive(:)
-
-    Integer :: reference_type =1
+    ! Internal heating variables
     Integer :: heating_type = 0 ! 0 means no reference heating.  > 0 selects optional reference heating
-    Real*8  :: Luminosity = 0.0d0 ! specifies the integral of the heating function
-    Real*8  :: Heating_Integral = 0.0d0  !same as luminosity (for non-star watchers)
-    Real*8  :: Heating_EPS = 1.0D-12  !Small number to test whether luminosity specified
-    Logical :: adjust_reference_heating = .false.  ! Flag used to decide if luminosity determined via boundary conditions
-
-    Type(ReferenceInfo) :: ref
-
-    Real*8 :: pressure_specific_heat  = 1.0d0 ! CP (not CV)
-    Real*8 :: poly_n = 0.0d0    !polytropic index
-    Real*8 :: poly_Nrho = 0.0d0
-    Real*8 :: poly_mass = 0.0d0
-    Real*8 :: poly_rho_i =0.0d0
-    Real*8 :: Angular_Velocity = -1.0d0
-
-    !/////////////////////////////////////////////////////////////////////////////////////
-    ! Nondimensional Parameters
-    Real*8 :: Rayleigh_Number         = 1.0d0
-    Real*8 :: Ekman_Number            = 1.0d0
-    Real*8 :: Prandtl_Number          = 1.0d0
-    Real*8 :: Magnetic_Prandtl_Number = 1.0d0
-    Real*8 :: gravity_power           = 0.0d0
-    Real*8 :: Dissipation_Number      = 0.0d0
-    Real*8 :: Modified_Rayleigh_Number = 0.0d0
-
-    Real*8 :: chi_a_rayleigh_number(1:n_scalar_max)          = 0.0d0
-    Real*8 :: chi_a_prandtl_number(1:n_scalar_max)           = 1.0d0
-    Real*8 :: chi_a_modified_rayleigh_number(1:n_scalar_max) = 0.0d0
-    Real*8 :: chi_p_prandtl_number(1:n_scalar_max)           = 1.0d0
+    Real*8  :: Luminosity = 0.0d0 ! Specifies the integral of the heating function
+    Real*8  :: Heating_Integral = 0.0d0  ! Same as luminosity (for non-star watchers)
+    Real*8  :: Heating_EPS = 1.0d-12  ! Small number to test whether luminosity was specified
+    Logical :: adjust_reference_heating = .false. ! Flag used to decide if luminosity determined via boundary conditions
+    Real*8, Allocatable :: s_conductive(:)
     
-    !///////////////////////////////////////////////
     ! Minimum time step based on rotation rate
     ! (determined by the reference state)
     Real*8 :: max_dt_rotation = 0.0d0
 
-
-
-    Namelist /Reference_Namelist/ reference_type,poly_n, poly_Nrho, poly_mass,poly_rho_i, &
-            & pressure_specific_heat, heating_type, luminosity, Angular_Velocity,     &
+    ! Alter some of the above (I) by reading the main_input file
+    Namelist /Reference_Namelist/ reference_type,poly_n, poly_Nrho, poly_mass, poly_rho_i, &
+            & pressure_specific_heat, heating_type, luminosity, Angular_Velocity, &
             & Rayleigh_Number, Ekman_Number, Prandtl_Number, Magnetic_Prandtl_Number, &
-            & gravity_power, custom_reference_file,       &
+            & gravity_power, custom_reference_file, &
             & Dissipation_Number, Modified_Rayleigh_Number, &
             & Heating_Integral, override_constants, override_constant, ra_constants, with_custom_constants, &
             & with_custom_functions, with_custom_reference, &
             & chi_a_rayleigh_number, chi_a_prandtl_number, &
             & chi_a_modified_rayleigh_number, chi_p_prandtl_number
-
 
     !///////////////////////////////////////////////////////////////////////////////////////
     ! II.  Variables Related to the Transport Coefficients
@@ -157,7 +161,7 @@ Module PDE_Coefficients
     Real*8, Allocatable :: A_Diffusion_Coefs_1(:)
     real*8, allocatable :: chi_a_diffusion_coefs_1(:,:), chi_p_diffusion_coefs_1(:,:)
 
-    Integer :: kappa_type =1, nu_type = 1, eta_type = 1
+    Integer :: kappa_type = 1, nu_type = 1, eta_type = 1
     Real*8  :: nu_top = -1.0d0, kappa_top = -1.0d0,  eta_top = -1.0d0
     Real*8  :: nu_power = 0, eta_power = 0, kappa_power = 0
     Integer :: kappa_chi_a_type(1:n_scalar_max) = 1
@@ -171,13 +175,13 @@ Module PDE_Coefficients
     Real*8  :: hyperdiffusion_beta = 0.0d0
     Real*8  :: hyperdiffusion_alpha = 1.0d0
 
+    ! Alter some of the above (II) by reading the main_input file
     Namelist /Transport_Namelist/ nu_type, kappa_type, eta_type, &
             & nu_power, kappa_power, eta_power, &
             & nu_top, kappa_top, eta_top, &
             & hyperdiffusion, hyperdiffusion_beta, hyperdiffusion_alpha, &
             & kappa_chi_a_type, kappa_chi_a_top, kappa_chi_a_power, &
             & kappa_chi_p_type, kappa_chi_p_top, kappa_chi_p_power
-
 
 Contains
 

--- a/src/Physics/PDE_Coefficients.F90
+++ b/src/Physics/PDE_Coefficients.F90
@@ -1613,4 +1613,104 @@ Contains
 
     End Subroutine Compute_Diffusion_Coefs
 
+    Subroutine Initialize_PDE_Coefficients()
+        ! Sets Rayleigh's internal ReferenceInfo ("ref") structure from 
+        ! ra_constants and ra_functions (i.e., the arrays more familiar to the user/coder)
+        ! This routine is called at the end of everything the user/coder does to specify 
+        ! ra_constants and ra_functions
+
+        Implicit None
+        Integer :: i
+      
+        ! Thermodynamic (historical "reference-state") variables
+        ref%density(:) = ra_functions(:,1)
+        ref%buoyancy_coeff(:) = ra_constants(2)*ra_functions(:,2)
+        ref%temperature(:) = ra_functions(:,4)
+
+        ref%dlnrho(:)  = ra_functions(:,8)
+        ref%d2lnrho(:) = ra_functions(:,9)
+        ref%dlnt(:) = ra_functions(:,10)
+        ref%dsdr(:)     = ra_functions(:,14)
+
+        ref%dpdr_w_term(:) = ra_constants(3)*ra_functions(:,1)
+        ref%pressure_dwdr_term(:)= -ref%dpdr_w_term(:) 
+        ref%viscous_amp(:) = 2.0*ra_constants(8)/ref%temperature(:)
+        ref%lorentz_coeff = ra_constants(4)
+        ref%ohmic_amp(:) = ra_constants(9)/(ref%density(:)*ref%temperature(:))
+
+        Do i = 1, n_active_scalars
+            ref%chi_buoyancy_coeff(i,:) = ra_constants(12+(i-1)*2)*ra_functions(:,2)
+        Enddo
+
+        ! Heating 
+        ref%heating(:) = ra_functions(:,6)/(ra_functions(:,1)*ra_functions(:,4))
+        ! Here we may rescale ref%heating to yield c_10 under integration. But if
+        ! adjust_reference_heating is .True., then c_10 hasn't been set yet and will be
+        ! (and ref%heating rescaled) in the BoundaryConditions.F90 file. 
+        If (.not. adjust_reference_heating) Then
+            ref%heating(:) = ra_constants(10)*ref%heating(:)
+        Endif
+
+        ! Coriolis coefficient 
+        ! Before setting, allow angular_velocity to overwrite c_1
+        If (angular_velocity .gt. 0) Then
+            ra_constants(1) = 2.0d0*angular_velocity 
+        Endif
+        ref%coriolis_coeff = ra_constants(1)
+
+        ! Diffusion coefficients
+        ! Before setting, allow nu_top (and so on) to overwrite c_5 (and so on)
+        ! NOTE: User should NOT set (e.g.) nu_top > 0 if f_3 (e.g.) has somehow been set to zero,
+        ! since division by zero would then ensue here...
+        !Call Allocate_Transport_Coefficients
+
+        If (nu_top .gt. 0.0d0) Then
+            ra_constants(5) = nu_top/ra_functions(1,3)
+        Endif
+        nu(:) = ra_constants(5)*ra_functions(:,3)
+        dlnu(:) = ra_functions(:,11)
+        If (viscous_heating) Then
+            !Allocate(viscous_heating_coeff(1:N_R))
+            viscous_heating_coeff(:) = ref%viscous_amp(:)*nu(:)
+        Endif
+
+        If (kappa_top .gt. 0.0d0) Then
+            ra_constants(6) = kappa_top/ra_functions(1,5)
+        Endif
+        kappa(:) = ra_constants(6)*ra_functions(:,5)
+        dlnkappa(:) = ra_functions(:,12)
+
+        If (magnetism) Then
+            If (eta_top .gt. 0.0d0) Then
+                ra_constants(7) = eta_top/ra_functions(1,7)
+            Endif
+            eta(:) = ra_constants(7)*ra_functions(:,7)
+            dlneta(:) = ra_functions(:,13)
+            If (ohmic_heating) Then
+                !Allocate(ohmic_heating_coeff(1:N_R))
+                ohmic_heating_coeff(:) = ref%ohmic_amp(:)*eta(:)
+            Endif
+        Endif
+
+        Do i = 1, n_active_scalars
+            If (kappa_chi_a_top(i) .gt. 0.0d0) Then
+                ra_constants(11+(i-1)*2) = kappa_chi_a_top(i)/ra_functions(1,15+(i-1)*2)
+            Endif
+            kappa_chi_a(i,:) = ra_constants(11+(i-1)*2)*ra_functions(:,15+(i-1)*2)
+            dlnkappa_chi_a(i,:) = ra_functions(:,16+(i-1)*2)
+        Enddo
+
+        Do i = 1, n_passive_scalars
+            If (kappa_chi_p_top(i) .gt. 0.0d0) Then
+                ra_constants(11+(n_active_scalars+i-1)*2) = kappa_chi_p_top(i)/ra_functions(1,15+(n_active_scalars+i-1)*2)
+            Endif
+            kappa_chi_p(i,:) = ra_constants(11+(n_active_scalars+i-1)*2)*ra_functions(:,15+(n_active_scalars+i-1)*2)
+            dlnkappa_chi_p(i,:) = ra_functions(:,16+(n_active_scalars+i-1)*2)
+        Enddo
+
+        ! Finally, get the other "internal" diffusion coefficients
+        !Call Compute_Diffusion_Coefs()
+
+    End Subroutine Initialize_PDE_Coefficients
+
 End Module PDE_Coefficients

--- a/src/Physics/PDE_Coefficients.F90
+++ b/src/Physics/PDE_Coefficients.F90
@@ -744,8 +744,12 @@ Contains
             Write(6,*)'Reading from: ', custom_reference_file
         Endif
 
+        ! All we have to do for this type is read the custom_reference_file
         Call Read_Custom_Reference_File(custom_reference_file)
 
+        ! Consistency check
+        ! Potential issue (Loren, 01/04/2023): if it's an "ERROR", the code should exit below; 
+        ! if not, then ERROR --> WARNING
         Do i=1,4
             fi = fi_to_check(i)
             If (ra_function_set(fi) .eq. 0) Then
@@ -755,40 +759,6 @@ Contains
                 Endif
             Endif
         Enddo
-
-        ref%density(:) = ra_functions(:,1)
-        ref%dlnrho(:)  = ra_functions(:,8)
-        ref%d2lnrho(:) = ra_functions(:,9)
-        ref%buoyancy_coeff(:) = ra_constants(2)*ra_functions(:,2)
-        Do i = 1, n_active_scalars
-            ref%chi_buoyancy_coeff(i,:) = ra_constants(12+(i-1)*2)*ra_functions(:,2)
-        Enddo
-
-        ref%temperature(:) = ra_functions(:,4)
-        ref%dlnT(:) = ra_functions(:,10)
-
-        If (abs(Luminosity) .gt. heating_eps) Then
-            ra_constants(10) = Luminosity
-        Endif
-
-        If (abs(Heating_Integral) .gt. heating_eps) Then
-            ra_constants(10) = Heating_Integral
-        Endif
-
-        ref%heating(:) = ra_functions(:,6)/(ref%density*ref%temperature)*ra_constants(10)
-        
-        ref%Coriolis_Coeff = ra_constants(1)
-        If (Angular_Velocity .gt. 0) Then
-            ref%Coriolis_Coeff  = 2.0d0*Angular_velocity
-            ra_constants(1) = ref%Coriolis_Coeff
-        Endif
-        ref%dpdr_w_term(:) = ra_constants(3)*ra_functions(:,1)
-        ref%pressure_dwdr_term(:)= - ref%dpdr_w_term(:) 
-        ref%viscous_amp(:) = 2.0/ref%temperature(:)*ra_constants(8)
-        ref%Lorentz_Coeff = ra_constants(4)
-        ref%ohmic_amp(:) = ra_constants(9)/(ref%density(:)*ref%temperature(:))
-
-        ref%dsdr(:)     = ra_functions(:,14)
 
     End Subroutine Get_Custom_Reference
 

--- a/src/Physics/PDE_Coefficients.F90
+++ b/src/Physics/PDE_Coefficients.F90
@@ -280,7 +280,7 @@ Contains
         Real*8 :: rotational_timescale
         !Adjust the maximum timestep to account for rotation rate, if necessary.
         
-        rotational_timescale = 1.0d0/ref%Coriolis_Coeff
+        rotational_timescale = 1.0d0/ra_constants(1)
         
         ! Minimum sampling would require two time samples per rotational timescale.
         ! We specify 4 samples and further adjust by the CFL safety factor.

--- a/src/Physics/PDE_Coefficients.F90
+++ b/src/Physics/PDE_Coefficients.F90
@@ -1142,38 +1142,136 @@ Contains
 
     Subroutine Restore_Reference_Defaults
         Implicit None
-        !Restore all values in this module to their default state.
-        !Deallocates all allocatable module variables.
-        reference_type =1
-        heating_type = 0
-        Luminosity =0.0d0
+        ! Restore all variables in this module to their default state.
+        ! Deallocates all allocatable module variables.
 
-        pressure_specific_heat = 0.0d0 ! CP (not CV)
-        poly_n = 0.0d0
-        poly_Nrho = 0.0d0
-        poly_mass = 0.0d0
-        poly_rho_i = 0.0d0
+        ! Which background state to use; default 1 (non-dimensional Boussinesq)
+        reference_type = 1 
 
-        Angular_Velocity = -1.0d0
-
+        ! Nondimensional variables (reference_type = 1,3)
         Rayleigh_Number         = 1.0d0
         Ekman_Number            = 1.0d0
         Prandtl_Number          = 1.0d0
         Magnetic_Prandtl_Number = 1.0d0
         gravity_power           = 0.0d0
+        Dissipation_Number      = 0.0d0
+        Modified_Rayleigh_Number = 0.0d0
 
-        custom_reference_file ='nothing'
+        ! Nondimensional variables for the active/passive scalar fields
+        chi_a_rayleigh_number(1:n_scalar_max)          = 0.0d0
+        chi_a_prandtl_number(1:n_scalar_max)           = 1.0d0
+        chi_a_modified_rayleigh_number(1:n_scalar_max) = 0.0d0
+        chi_p_prandtl_number(1:n_scalar_max)           = 1.0d0
 
-        If (allocated(s_conductive)) DeAllocate(s_conductive)
+        ! Dimensional anelastic variables (reference_type = 2)
+        pressure_specific_heat  = 1.0d0 ! CP (not CV)
+        poly_n = 0.0d0 ! Polytropic index
+        poly_Nrho = 0.0d0 ! Number of density scale heights across domain
+        poly_mass = 0.0d0 ! Stellar mass; g(r) = G*poly_mass/r^2
+        poly_rho_i = 0.0d0 ! Density (g/cm^3) at the inner radius rmin
+        Angular_Velocity = -1.0d0 ! Frame rotation rate (sets Coriolis force)
+
+        ! Custom reference-state variables (reference_type = 4)
+        !       NOTE: n_ra_constants / n_ra_functions do not have default values (but maybe do, if you consider the Allocate_Reference_State() routine)
+        with_custom_reference = .false.
+        override_constants = .false.
+        override_constant(1:max_ra_constants) = .false. ! in namelist
+        with_custom_constants(1:max_ra_constants) = 0   ! in namelist
+        with_custom_functions(1:max_ra_functions) = 0   ! in namelist
+        ra_constants(1:max_ra_constants) = 0.0d0        ! in namelist
+        custom_reference_read = .false.
+        custom_reference_file ='nothing'  
+
+        ! Internal heating variables
+        heating_type = 0 ! 0 means no reference heating.  > 0 selects optional reference heating
+        Luminosity = 0.0d0 ! Specifies the integral of the heating function
+        Heating_Integral = 0.0d0  ! Same as luminosity (for non-star watchers)
+        Heating_EPS = 1.0d-12  ! Small number to test whether luminosity was specified
+        adjust_reference_heating = .false. ! Flag used to decide if luminosity determined via boundary conditions
+
+        ! Minimum time step based on rotation rate
+        ! (determined by the reference state)
+        max_dt_rotation = 0.0d0
+
+        ! Diffusion-coefficient (transport-namelist) variables
+        kappa_type = 1
+        nu_type = 1
+        eta_type = 1
+        nu_top = -1.0d0
+        kappa_top = -1.0d0
+        eta_top = -1.0d0
+        nu_power = 0
+        eta_power = 0
+        kappa_power = 0
+
+        kappa_chi_a_type(1:n_scalar_max) = 1
+        kappa_chi_a_top(1:n_scalar_max) = -1.0d0
+        kappa_chi_a_power(1:n_scalar_max) = 0
+        kappa_chi_p_type(1:n_scalar_max) = 1
+        kappa_chi_p_top(1:n_scalar_max) = -1.0d0
+        kappa_chi_p_power(1:n_scalar_max) = 0
+
+        hyperdiffusion = .false.
+        hyperdiffusion_beta = 0.0d0
+        hyperdiffusion_alpha = 1.0d0
+
+        ! Deallocate "ref" object
         If (allocated(ref%Density)) DeAllocate(ref%density)
         If (allocated(ref%dlnrho)) DeAllocate(ref%dlnrho)
         If (allocated(ref%d2lnrho)) DeAllocate(ref%d2lnrho)
+
         If (allocated(ref%Temperature)) DeAllocate(ref%Temperature)
         If (allocated(ref%dlnT)) DeAllocate(ref%dlnT)
+
         If (allocated(ref%dsdr)) DeAllocate(ref%dsdr)
+
+        If (allocated(ref%heating)) DeAllocate(ref%heating)
+
+        !       NOTE: ref%Coriolis_Coeff and ref%Lorentz_Coeff have no default values (but maybe do, if you consider the Allocate_Reference_State() routine)
         If (allocated(ref%Buoyancy_Coeff)) DeAllocate(ref%Buoyancy_Coeff)
         If (allocated(ref%chi_buoyancy_coeff)) DeAllocate(ref%chi_buoyancy_coeff)
-        If (allocated(ref%Heating)) DeAllocate(ref%Heating)
+        If (allocated(ref%dpdr_w_term)) DeAllocate(ref%dpdr_w_term)
+        If (allocated(ref%pressure_dwdr_term)) DeAllocate(ref%pressure_dwdr_term)
+
+        If (allocated(ref%ohmic_amp)) DeAllocate(ref%ohmic_amp)
+        If (allocated(ref%viscous_amp)) DeAllocate(ref%viscous_amp)
+
+        ! Deallocate s_conductive
+        If (allocated(s_conductive)) DeAllocate(s_conductive)
+    
+        ! Deallocate custom-reference stuff
+        If (allocated(ra_constant_set)) DeAllocate(ra_constant_set)
+        If (allocated(ra_function_set)) DeAllocate(ra_function_set)
+        If (allocated(use_custom_constant)) DeAllocate(use_custom_constant)
+        If (allocated(use_custom_function)) DeAllocate(use_custom_function)
+        If (allocated(ra_functions)) DeAllocate(ra_functions)
+
+        ! Deallocate transport-coefficient stuff
+        If (allocated(nu)) DeAllocate(nu)
+        If (allocated(kappa)) DeAllocate(kappa)
+        If (allocated(eta)) DeAllocate(eta)
+        If (allocated(dlnu)) DeAllocate(dlnu)
+        If (allocated(dlnkappa)) DeAllocate(dlnkappa)
+        If (allocated(dlneta)) DeAllocate(dlneta)
+        If (allocated(kappa_chi_a)) DeAllocate(kappa_chi_a)
+        If (allocated(kappa_chi_p)) DeAllocate(kappa_chi_p)
+        If (allocated(dlnkappa_chi_a)) DeAllocate(dlnkappa_chi_a)
+        If (allocated(dlnkappa_chi_p)) DeAllocate(dlnkappa_chi_p)
+
+        If (allocated(ohmic_heating_coeff)) DeAllocate(ohmic_heating_coeff)
+        If (allocated(viscous_heating_coeff)) DeAllocate(viscous_heating_coeff)
+
+        If (allocated(W_Diffusion_Coefs_0)) DeAllocate(W_Diffusion_Coefs_0)
+        If (allocated(W_Diffusion_Coefs_1)) DeAllocate(W_Diffusion_Coefs_1)
+        If (allocated(dW_Diffusion_Coefs_0)) DeAllocate(dW_Diffusion_Coefs_0)
+        If (allocated(dW_Diffusion_Coefs_1)) DeAllocate(dW_Diffusion_Coefs_1)
+        If (allocated(dW_Diffusion_Coefs_2)) DeAllocate(dW_Diffusion_Coefs_2)
+        If (allocated(S_Diffusion_Coefs_1)) DeAllocate(S_Diffusion_Coefs_1)
+        If (allocated(Z_Diffusion_Coefs_0)) DeAllocate(Z_Diffusion_Coefs_0)
+        If (allocated(Z_Diffusion_Coefs_1)) DeAllocate(Z_Diffusion_Coefs_1)
+        If (allocated(A_Diffusion_Coefs_1)) DeAllocate(A_Diffusion_Coefs_1)
+        If (allocated(chi_a_diffusion_coefs_1)) DeAllocate(chi_a_diffusion_coefs_1)
+        If (allocated(chi_p_diffusion_coefs_1)) DeAllocate(chi_p_diffusion_coefs_1)
 
     End Subroutine Restore_Reference_Defaults
 


### PR DESCRIPTION
A replacement version of #430 (now closed). That pull request wasn't passing the "linux-jammy-container-build", so I am integrating the changes slowly (one at a time) to make sure they pass all checks. 

The purpose of this pull request is to leave the current reference state framework entirely unchanged (I am, however, including my pending pull requests, https://github.com/geodynamics/Rayleigh/pull/426, https://github.com/geodynamics/Rayleigh/pull/427, and https://github.com/geodynamics/Rayleigh/pull/429), but re-order the logic in setting each reference type. Essentially, I want ra_constants and ra_functions to be set before the "ref" object that Rayleigh actually uses.

This would mean that each reference type sets the ra_constants and ra_functions arrays directly, and there is a separate routine (Initialize_PDE_Coefficients(), called by Main_Initialization() after "Call Initialize_Reference()" and "Call Initialize_Transport_Coefficients()" that sets the "ref" object.

I think this formulation would be better for two reasons: First, future reference types should be easier to implement, since all the coder needs to do is formulate the problem according Rayleigh's "constants and functions" documentation, and then transcribe that problem into a new subroutine. No one will have to worry about the non-documented "ref" object (or "nu" or "kappa", etc.) ever again! Second, I've uncovered at least two instances where the "ref" object is set correctly, but ra_constants/ra_functions are not. I think the new logic should minimize the instances where this can happen, since the ra_constants/ra_functions will necessarily be consistent with "ref" at least at the point "Call Initialize_PDE_Coefficents()" happens.

For the old pull request, I tested basic prototypes for reference_type = 1, 2, 3, 4 and tested the benchmarks (even the MHD Anelastic one!) But something was messing up the continuous integration, so I am taking things more modularly this time around. 