### PR TITLE
Initialize buoyancy coefficients for the scalar diffusions (reference_type = 1, 2, 3)

### DIFF
--- a/src/Physics/PDE_Coefficients.F90
+++ b/src/Physics/PDE_Coefficients.F90
@@ -828,9 +828,9 @@ Contains
         ref%dlnrho(:)  = ra_functions(:,8)
         ref%d2lnrho(:) = ra_functions(:,9)
         ref%buoyancy_coeff(:) = ra_constants(2)*ra_functions(:,2)
-        do i = 0, n_active_scalars-1
-            ref%chi_buoyancy_coeff(i,:) = ra_constants(12+i*2)*ra_functions(:,2)
-        end do
+        Do i = 1, n_active_scalars
+            ref%chi_buoyancy_coeff(i,:) = ra_constants(12+(i-1)*2)*ra_functions(:,2)
+        Enddo
 
         ref%temperature(:) = ra_functions(:,4)
         ref%dlnT(:) = ra_functions(:,10)

--- a/src/Physics/PDE_Coefficients.F90
+++ b/src/Physics/PDE_Coefficients.F90
@@ -1317,11 +1317,6 @@ Contains
             ! We "back up" the current reference state in temp_constants and temp_functions
             ! Below, we modify only the "temp" equation coefficients associated with custom diffusions
             ! Then we restore ra_constants and ra_functions from the "temp" arrays
-            ! BUG IN OUTPUT (Loren, 12/24/22, Merry Christmas!): If one diffusion type is custom
-            ! but another isn't, then the ra_constants/ra_functions associated with the non-custom diffusion
-            ! will be set correctly by the Initialize_Diffusivity routine, but then overwritten,
-            ! likely with erroneous values, in the "restore" process below. 
-            ! Will fix this issue in a later pull request. 
             Call Read_Custom_Reference_File(custom_reference_file)
         EndIf
 

--- a/src/Physics/PDE_Coefficients.F90
+++ b/src/Physics/PDE_Coefficients.F90
@@ -331,13 +331,13 @@ Contains
             ref%Buoyancy_Coeff(i) = amp*(radius(i)/radius(1))**gravity_power
         Enddo
 
-        do j = 1, n_active_scalars
-          amp = -chi_a_Rayleigh_Number(j)/chi_a_Prandtl_Number(j)
+        Do j = 1, n_active_scalars
+            amp = -chi_a_Rayleigh_Number(j)/chi_a_Prandtl_Number(j)
 
-          Do i = 1, N_R
-              ref%chi_buoyancy_coeff(j,i) = amp*(radius(i)/radius(1))**gravity_power
-          Enddo
-        enddo
+            Do i = 1, N_R
+                ref%chi_buoyancy_coeff(j,i) = amp*(radius(i)/radius(1))**gravity_power
+            Enddo
+        Enddo
 
         pressure_specific_heat = 1.0d0
         Call initialize_reference_heating()
@@ -399,6 +399,13 @@ Contains
         ra_constants(4) = ref%Lorentz_Coeff
         ra_constants(8) = 0.0d0
         ra_constants(9) = 0.0d0
+
+        ! c_10 is managed by Initialize_Reference_Heating() here
+        ! and Initialize_Boundary_Conditions/Transport_Dependencies() in BoundaryConditions.F90
+        ! Set the active-scalar buoyancy coefficients, c_[12 + (j-1)*2], here:
+        Do j = 1, n_active_scalars
+            ra_constants(12+(j-1)*2) = -chi_a_Rayleigh_Number(j)/chi_a_Prandtl_Number(j)
+        Enddo        
 
     End Subroutine Constant_Reference
 
@@ -507,6 +514,14 @@ Contains
             ra_constants(9) = Ekman_Number**2*Dissipation_Number/(Magnetic_Prandtl_Number**2*Modified_Rayleigh_Number)
         Endif ! if not magnetism, ra_constants(9) was initialized to zero
         DeAllocate(dtmparr, gravity)
+
+        ! c_10 is managed by Initialize_Reference_Heating() here
+        ! and Initialize_Boundary_Conditions/Transport_Dependencies() in BoundaryConditions.F90
+        ! Set the active-scalar buoyancy coefficients, c_[12 + (j-1)*2], here:
+        Do i = 1, n_active_scalars
+            ra_constants(12+(i-1)*2) = -chi_a_modified_rayleigh_number(i)
+        Enddo 
+
     End Subroutine Polytropic_ReferenceND
 
     Subroutine Polytropic_Reference()
@@ -633,7 +648,14 @@ Contains
         ra_constants(3) = 1.0d0
         ra_constants(4) = ref%Lorentz_Coeff
         ra_constants(8) = 1.0d0
-        ra_constants(9) = ref%Lorentz_Coeff       
+        ra_constants(9) = ref%Lorentz_Coeff 
+      
+        ! c_10 is managed by Initialize_Reference_Heating() here
+        ! and Initialize_Boundary_Conditions/Transport_Dependencies() in BoundaryConditions.F90
+        ! Set the active-scalar buoyancy coefficients, c_[12 + (j-1)*2], here:
+        Do i = 1, n_active_scalars
+            ra_constants(12+(i-1)*2) = -1.0d0
+        Enddo 
 
     End Subroutine Polytropic_Reference
 


### PR DESCRIPTION
The constants associated with the buoyancy forcing for the active scalars (I believe c_[12 + (j-1)*2], where j runs from 1 to n_active_scalars) were never initialized for the default reference types. 

Hopefully they are initialized properly now. This pull request incorporates my previous #426, #427, and #429. 