### PR TITLE
move Call Initialize_Transport_Coefficients() further up

### DIFF
--- a/src/Physics/Main.F90
+++ b/src/Physics/Main.F90
@@ -82,13 +82,14 @@ Contains
         Call Initialize_Benchmarking()
 
         Call Initialize_FFts()
+
         Call Initialize_Reference()
+        Call Initialize_Transport_Coefficients()
 
         Call Initialize_Field_Structure()
         Call Initialize_Checkpointing()
-        Call Initialize_Transport_Coefficients()
-        Call Initialize_Boundary_Conditions()
 
+        Call Initialize_Boundary_Conditions()
 
         Call Write_Equation_Coefficients_File()
 


### PR DESCRIPTION
This moves the call to Initialize_Transport_Coefficients() further up (to directly follow Initialize_Reference_State()) in Main_Initialization(). 