### PR TITLE
Remove ref from reference routines

### DIFF
--- a/src/Physics/Main.F90
+++ b/src/Physics/Main.F90
@@ -85,6 +85,7 @@ Contains
 
         Call Initialize_Reference()
         Call Initialize_Transport_Coefficients()
+        Call Initialize_PDE_Coefficients()
 
         Call Initialize_Field_Structure()
         Call Initialize_Checkpointing()

--- a/src/Physics/Main.F90
+++ b/src/Physics/Main.F90
@@ -82,13 +82,14 @@ Contains
         Call Initialize_Benchmarking()
 
         Call Initialize_FFts()
+
         Call Initialize_Reference()
+        Call Initialize_Transport_Coefficients()
 
         Call Initialize_Field_Structure()
         Call Initialize_Checkpointing()
-        Call Initialize_Transport_Coefficients()
-        Call Initialize_Boundary_Conditions()
 
+        Call Initialize_Boundary_Conditions()
 
         Call Write_Equation_Coefficients_File()
 

--- a/src/Physics/PDE_Coefficients.F90
+++ b/src/Physics/PDE_Coefficients.F90
@@ -1525,7 +1525,7 @@ Contains
 
         Implicit None
         Integer :: i
-		      
+
         ! Thermodynamic (historical "reference-state") variables
         !Call Allocate_Reference_State()
         
@@ -1576,7 +1576,7 @@ Contains
         nu(:) = ra_constants(5)*ra_functions(:,3)
         dlnu(:) = ra_functions(:,11)
         If (viscous_heating) Then
-            !Allocate(viscous_heating_coeff(1:N_R))
+            Allocate(viscous_heating_coeff(1:N_R))
             viscous_heating_coeff(:) = ref%viscous_amp(:)*nu(:)
         Endif
 
@@ -1593,7 +1593,7 @@ Contains
             eta(:) = ra_constants(7)*ra_functions(:,7)
             dlneta(:) = ra_functions(:,13)
             If (ohmic_heating) Then
-                !Allocate(ohmic_heating_coeff(1:N_R))
+                Allocate(ohmic_heating_coeff(1:N_R))
                 ohmic_heating_coeff(:) = ref%ohmic_amp(:)*eta(:)
             Endif
         Endif

--- a/src/Physics/PDE_Coefficients.F90
+++ b/src/Physics/PDE_Coefficients.F90
@@ -368,7 +368,7 @@ Contains
         ref%viscous_amp(1:N_R) = 2.0d0
         do i = 1, n_active_scalars
             kappa_chi_a_top(i)   = 1.0d0/chi_a_prandtl_number(i)
-            ra_constants(12+(j-1)*2) = -chi_a_Rayleigh_Number(j)/chi_a_Prandtl_Number(j)
+            ra_constants(12+(i-1)*2) = -chi_a_Rayleigh_Number(i)/chi_a_Prandtl_Number(i)
         enddo
         do i = 1, n_passive_scalars
             kappa_chi_p_top(i)   = 1.0d0/chi_p_prandtl_number(i)

--- a/src/Physics/PDE_Coefficients.F90
+++ b/src/Physics/PDE_Coefficients.F90
@@ -197,7 +197,19 @@ Contains
             Call stdout%print(" ---- Specified parameters:")
         Endif
 
-        Call Allocate_Reference_State()
+        n_ra_constants = 10 + 2*(n_active_scalars + n_passive_scalars)
+        e_ra_functions = 14 + 2*(n_active_scalars + n_passive_scalars)
+
+        Allocate(ra_constant_set(1:n_ra_constants))
+        ra_constant_set = 0
+        Allocate(ra_function_set(1:n_ra_functions))
+        ra_function_set = 0
+        Allocate(use_custom_constant(1:n_ra_constants))
+        use_custom_constant = .false.
+        Allocate(use_custom_function(1:n_ra_functions))
+        use_custom_function = .false.
+        Allocate(ra_functions(1:N_R, 1:n_ra_functions))
+        ra_functions(:,:) = Zero
 
         If (reference_type .eq. 1) Then
             Call Constant_Reference()
@@ -229,9 +241,6 @@ Contains
     Subroutine Allocate_Reference_State
         Implicit None
 
-        n_ra_constants = 10 + 2*(n_active_scalars + n_passive_scalars)
-        n_ra_functions = 14 + 2*(n_active_scalars + n_passive_scalars)
-
         Allocate(ref%density(1:N_R))
         Allocate(ref%temperature(1:N_R))
         Allocate(ref%dlnrho(1:N_R))
@@ -245,17 +254,6 @@ Contains
         Allocate(ref%viscous_amp(1:N_R))
         Allocate(ref%heating(1:N_R))
         Allocate(ref%chi_buoyancy_coeff(n_active_scalars,1:N_R))
-
-        Allocate(ra_constant_set(1:n_ra_constants))
-        ra_constant_set = 0
-        Allocate(ra_function_set(1:n_ra_functions))
-        ra_function_set = 0
-        Allocate(use_custom_constant(1:n_ra_constants))
-        use_custom_constant = .false.
-        Allocate(use_custom_function(1:n_ra_functions))
-        use_custom_function = .false.
-        Allocate(ra_functions(1:N_R, 1:n_ra_functions))
-        ra_functions(:,:) = Zero
 
         ref%density(:)            = Zero
         ref%temperature(:)        = Zero
@@ -1435,7 +1433,7 @@ Contains
         Integer :: i
 
         ! Thermodynamic (historical "reference-state") variables
-        !Call Allocate_Reference_State()
+        Call Allocate_Reference_State()
         
         ref%density(:) = ra_functions(:,1)
         ref%buoyancy_coeff(:) = ra_constants(2)*ra_functions(:,2)

--- a/src/Physics/PDE_Coefficients.F90
+++ b/src/Physics/PDE_Coefficients.F90
@@ -198,7 +198,7 @@ Contains
         Endif
 
         n_ra_constants = 10 + 2*(n_active_scalars + n_passive_scalars)
-        e_ra_functions = 14 + 2*(n_active_scalars + n_passive_scalars)
+        n_ra_functions = 14 + 2*(n_active_scalars + n_passive_scalars)
 
         Allocate(ra_constant_set(1:n_ra_constants))
         ra_constant_set = 0

--- a/src/Physics/PDE_Coefficients.F90
+++ b/src/Physics/PDE_Coefficients.F90
@@ -368,6 +368,7 @@ Contains
         ref%viscous_amp(1:N_R) = 2.0d0
         do i = 1, n_active_scalars
             kappa_chi_a_top(i)   = 1.0d0/chi_a_prandtl_number(i)
+            ra_constants(12+(j-1)*2) = -chi_a_Rayleigh_Number(j)/chi_a_Prandtl_Number(j)
         enddo
         do i = 1, n_passive_scalars
             kappa_chi_p_top(i)   = 1.0d0/chi_p_prandtl_number(i)
@@ -469,6 +470,7 @@ Contains
         kappa_top     = Ekman_Number/Prandtl_Number
         do i = 1, n_active_scalars
             kappa_chi_a_top(i)   = Ekman_Number/chi_a_prandtl_number(i)
+            ra_constants(12+(i-1)*2) = -chi_a_modified_rayleigh_number(i)
         enddo
         do i = 1, n_passive_scalars
             kappa_chi_p_top(i)   = Ekman_Number/chi_p_prandtl_number(i)
@@ -634,6 +636,10 @@ Contains
         ra_constants(4) = ref%Lorentz_Coeff
         ra_constants(8) = 1.0d0
         ra_constants(9) = ref%Lorentz_Coeff       
+
+        Do i = 1, n_active_scalars
+            ra_constants(12+(i-1)*2) = -1.0d0
+        Enddo 
 
     End Subroutine Polytropic_Reference
 

--- a/src/Physics/PDE_Coefficients.F90
+++ b/src/Physics/PDE_Coefficients.F90
@@ -1283,11 +1283,18 @@ Contains
         Implicit None
         Integer :: i
         Real*8, Allocatable :: temp_functions(:,:), temp_constants(:)
-        Logical :: restore, need_custom
+        Logical :: need_custom
 
-        restore = .false.
-
-        Call Allocate_Transport_Coefficients
+        ! In this routine, we may need to read in the custom file, which will overwrite
+        ! ra_constants and ra_functions
+        ! To be safe, we save the original ra_constants and ra_functions in temporary arrays
+        ! Below, we only modify the diffusion-related parts of the temporary arrays, then copy 
+        ! everything over to ra_constants and ra_functions at the end
+        Allocate(temp_functions(1:n_r, 1:n_ra_functions))
+        Allocate(temp_constants(1:n_ra_constants))
+        temp_functions(:,:) = ra_functions(:,:)
+        ! Note that ra_constants is allocated up to max_ra_constants
+        temp_constants(:) = ra_constants(1:n_ra_constants)   
 
         ! Figure out if we need to read anything from the custom file 
         ! (many "types" to check now because of the new scalar diffusion coefficients)
@@ -1309,95 +1316,34 @@ Contains
         Enddo
 
         If ((.not. custom_reference_read) .and. need_custom) Then
-            Allocate(temp_functions(1:n_r, 1:n_ra_functions))
-            Allocate(temp_constants(1:n_ra_constants))
-            temp_functions(:,:) = ra_functions(:,:)
-            ! Note that ra_constants is allocated up to max_ra_constants,
-            ! which could be more than n_ra_constants
-            temp_constants(:) = ra_constants(1:n_ra_constants)
-            restore = .true.
-            ! If we read the custom file, we may overwrite things besides the diffusion coefficients
-            ! We "back up" the current reference state in temp_constants and temp_functions
-            ! Below, we modify only the "temp" equation coefficients associated with custom diffusions
-            ! Then we restore ra_constants and ra_functions from the "temp" arrays
             Call Read_Custom_Reference_File(custom_reference_file)
         EndIf
 
-
-        Call Initialize_Diffusivity(nu,dlnu,nu_top,nu_type,nu_power,5,3,11)
-        Call Initialize_Diffusivity(kappa,dlnkappa,kappa_top,kappa_type,kappa_power,6,5,12)
-        do i = 1, n_active_scalars
-          Call Initialize_Diffusivity(kappa_chi_a(i,:),dlnkappa_chi_a(i,:),&
-                                      kappa_chi_a_top(i),kappa_chi_a_type(i),kappa_chi_a_power(i),&
-                                      11+(i-1)*2,15+(i-1)*2,16+(i-1)*2)
-        end do
-        do i = 1, n_passive_scalars
-          Call Initialize_Diffusivity(kappa_chi_p(i,:),dlnkappa_chi_p(i,:),&
-                                      kappa_chi_p_top(i),kappa_chi_p_type(i),kappa_chi_p_power(i),&
-                                      11+(n_active_scalars+i-1)*2,15+(n_active_scalars+i-1)*2,16+(n_active_scalars+i-1)*2)
-        end do
-
-        If (viscous_heating) Then
-            Allocate(viscous_heating_coeff(1:N_R))
-            viscous_heating_coeff(1:N_R) = ref%viscous_amp(1:N_R)*nu(1:N_R)
-        Endif
-
+        Call Initialize_Diffusivity(temp_constants,temp_functions,nu_top,nu_type,nu_power,5,3,11)
+        Call Initialize_Diffusivity(temp_constants,temp_functions,kappa_top,kappa_type,kappa_power,6,5,12)
         If (magnetism) Then
-
-            Call Initialize_Diffusivity(eta,dlneta,eta_top,eta_type,eta_power,7,7,13)
-            If (ohmic_heating) Then
-                Allocate(ohmic_heating_coeff(1:N_R))
-                ohmic_heating_coeff(1:N_R) = ref%ohmic_amp(1:N_R)*eta(1:N_R)
-            Endif
+            Call Initialize_Diffusivity(temp_constants,temp_functions,eta_top,eta_type,eta_power,7,7,13)
         Else
-            eta(:)    = 0.0d0 ! eta was already allocated, but never initialized since this
-            dlneta(:) = 0.0d0 ! run has magnetism = False. Explicitly set eta to zero
+            temp_functions(:,7) = 0.0d0 ! eta was already allocated, but never initialized since this
+            temp_functions(:,13) = 0.0d0 ! run has magnetism = False. Explicitly set eta to zero
         Endif
 
-        If (restore) Then
+        Do i = 1, n_active_scalars
+            Call Initialize_Diffusivity(temp_constants,temp_functions,&
+                kappa_chi_a_top(i),kappa_chi_a_type(i),kappa_chi_a_power(i),&
+                11+(i-1)*2,15+(i-1)*2,16+(i-1)*2)
+        Enddo
 
-            If (eta_type .eq. 3) Then
-                temp_functions(:,7)  = ra_functions(:,7)
-                temp_functions(:,13) = ra_functions(:,13)
-                temp_constants(7)    = ra_constants(7)
-            Endif
+        Do i = 1, n_passive_scalars
+            Call Initialize_Diffusivity(temp_constants,temp_functions,&
+                kappa_chi_p_top(i),kappa_chi_p_type(i),kappa_chi_p_power(i),&
+                11+(n_active_scalars+i-1)*2,15+(n_active_scalars+i-1)*2,16+(n_active_scalars+i-1)*2)
+        Enddo
 
-            If (kappa_type .eq. 3) Then
-                temp_functions(:,5)  = ra_functions(:,5)
-                temp_functions(:,12) = ra_functions(:,12)
-                temp_constants(6)    = ra_constants(6)
-            Endif
-
-            do i = 0, n_active_scalars-1
-              If (kappa_chi_a_type(i+1) .eq. 3) Then
-                  temp_functions(:,15+i*2) = ra_functions(:,15+i*2)
-                  temp_functions(:,16+i*2) = ra_functions(:,16+i*2)
-                  temp_constants(11+i*2)   = ra_constants(11+i*2)
-              Endif
-            end do
-
-            do i = 0, n_passive_scalars-1
-              If (kappa_chi_p_type(i+1) .eq. 3) Then
-                  temp_functions(:,15+(n_active_scalars+i)*2) = ra_functions(:,15+(n_active_scalars+i)*2)
-                  temp_functions(:,16+(n_active_scalars+i)*2) = ra_functions(:,16+(n_active_scalars+i)*2)
-                  temp_constants(11+(n_active_scalars+i)*2)   = ra_constants(11+(n_active_scalars+i)*2)
-              Endif
-            end do
-
-            If (nu_type .eq. 3) Then
-                temp_functions(:,3)  = ra_functions(:,3)
-                temp_functions(:,11) = ra_functions(:,11)
-                temp_constants(5)    = ra_constants(5)
-            Endif
-
-            ra_constants(1:n_ra_constants) = temp_constants(:)
-            ra_functions(:,:) = temp_functions(:,:)
-            DeAllocate(temp_functions, temp_constants)
-
-
-        Endif
-
-        Call Compute_Diffusion_Coefs()
+        ! copy temporary arrays to ra_constants and ra_functions
+        ra_constants(1:n_ra_constants) = temp_constants(:)
+        ra_functions(:,:) = temp_functions(:,:)
+        DeAllocate(temp_functions, temp_constants)
 
     End Subroutine Initialize_Transport_Coefficients
 
@@ -1417,11 +1363,10 @@ Contains
 
     End Subroutine Allocate_Transport_Coefficients
 
-    Subroutine Initialize_Diffusivity(x,dlnx,xtop,xtype,xpower,ci,fi,dlnfi)
+    Subroutine Initialize_Diffusivity(temp_constants,temp_functions,xtop,xtype,xpower,ci,fi,dlnfi)
         Implicit None
-        Real*8, Intent(InOut) :: x(:), dlnx(:)
-        Real*8, Intent(InOut) :: xtop
-        Integer, Intent(In) :: ci, fi, dlnfi, xtype
+        Real*8, Intent(InOut) :: xtop, temp_constants(:), temp_functions(:,:)
+        Integer, Intent(In) :: xtype, ci, fi, dlnfi
         Real*8, Intent(In) :: xpower
         Character(len=2) :: ind
 
@@ -1440,28 +1385,27 @@ Contains
 
         Select Case(xtype)
             Case(1)
-                x(:) = xtop
-                dlnx(:) = 0.0d0
-                ra_constants(ci) = xtop
-                ra_functions(:,fi) = 1.0d0
-                ra_functions(:,dlnfi) = 0.0d0
+                temp_constants(ci) = xtop
+                temp_functions(:,fi) = 1.0d0
+                temp_functions(:,dlnfi) = 0.0d0
             Case(2)
-                Call vary_with_density(x,dlnx,xtop, xpower)
-                ra_constants(ci) = xtop
-                ra_functions(:,fi) = x(:)/xtop
-                ra_functions(:,dlnfi) = dlnx
+                temp_constants(ci) = xtop
+                temp_functions(:,fi) = (temp_functions(:,1)/temp_functions(1,1))**xpower
+                temp_functions(:,dlnfi) = xpower*temp_functions(:,8)
             Case(3)
                 If ((ra_function_set(fi) .eq. 1) .and. (ra_constant_set(ci) .eq. 1)) Then
-                    x(:) = ra_constants(ci)*ra_functions(:,fi)
-                    dlnx(:) = ra_functions(:,dlnfi)
-                    xtop = x(1)
-                    ! Nothing to be done here for functions and constants -- completely set
+                    ! user specified both the constant and the function in the custom file
+                    temp_constants(ci) = ra_constants(ci)                    
+                    temp_functions(:,fi) = ra_functions(:,fi)
+                    temp_functions(:,dlnfi) = ra_functions(:,dlnfi)
                 ElseIf ((ra_function_set(fi) .eq. 1) .and. (ra_constant_set(ci) .eq. 0)) Then
-                    ra_constants(ci) = xtop
-                    x(:) = xtop*ra_functions(:,fi)/ra_functions(1,fi)
-                    dlnx(:) = ra_functions(:,dlnfi)
-                    xtop = x(1)
+                    ! User specified the function in the custom file, but not the constant
+                    ! Get the constant from main_input (and normalize the function to its top value)
+                    temp_constants(ci) = xtop
+                    temp_functions(:,fi) = ra_functions(:,fi)/ra_functions(1,fi)
+                    temp_functions(:,dlnfi) = ra_functions(:,dlnfi)
                 Else
+                    ! No function specified...user has messed up
                     If (my_rank .eq. 0) Then
                         Write(ind, '(I2)') fi
                         Call stdout%print('ERROR: function f_'//Adjustl(ind)//' must be set in the custom reference file')
@@ -1471,19 +1415,6 @@ Contains
         End Select
 
     End Subroutine Initialize_Diffusivity
-
-    Subroutine Vary_With_Density(coeff, dln, coeff_top, coeff_power)
-        Implicit None
-        Real*8, Intent(InOut) :: coeff(:), dln(:)
-        Real*8, Intent(In) :: coeff_top, coeff_power
-
-        ! Computes a transport coefficient and its logarithmic derivative
-        ! using a density-dependent form for the coefficient:
-        !        coeff = coeff_top*(rho/rho_top)**coeff_power
-        coeff = coeff_top*(ref%density/ref%density(1))**coeff_power
-        dln = coeff_power*ref%dlnrho
-
-    End Subroutine Vary_With_Density
 
     Subroutine Restore_Transport_Defaults
         Implicit None
@@ -1637,7 +1568,7 @@ Contains
         ! Before setting, allow nu_top (and so on) to overwrite c_5 (and so on)
         ! NOTE: User should NOT set (e.g.) nu_top > 0 if f_3 (e.g.) has somehow been set to zero,
         ! since division by zero would then ensue here...
-        !Call Allocate_Transport_Coefficients
+        Call Allocate_Transport_Coefficients
 
         If (nu_top .gt. 0.0d0) Then
             ra_constants(5) = nu_top/ra_functions(1,3)
@@ -1684,7 +1615,7 @@ Contains
         Enddo
 
         ! Finally, get the other "internal" diffusion coefficients
-        !Call Compute_Diffusion_Coefs()
+        Call Compute_Diffusion_Coefs()
 
     End Subroutine Initialize_PDE_Coefficients
 

--- a/src/Physics/PDE_Coefficients.F90
+++ b/src/Physics/PDE_Coefficients.F90
@@ -281,7 +281,7 @@ Contains
         Real*8 :: rotational_timescale
         !Adjust the maximum timestep to account for rotation rate, if necessary.
         
-        rotational_timescale = 1.0d0/ref%Coriolis_Coeff
+        rotational_timescale = 1.0d0/ra_constants(1)
         
         ! Minimum sampling would require two time samples per rotational timescale.
         ! We specify 4 samples and further adjust by the CFL safety factor.
@@ -727,7 +727,6 @@ Contains
                 Call stdout%print('f_6*c_10')
                 Call stdout%print(' ')
             Endif
-            ref%heating(:) = ra_functions(:,6)/(ref%density*ref%temperature)*ra_constants(10)
             temp_functions(:,6) = ra_functions(:,6)
             temp_constants(10)  = ra_constants(10)
         Endif
@@ -738,7 +737,6 @@ Contains
                 Call stdout%print('f_2*c_2')
                 Call stdout%print(' ')
             Endif
-            ref%buoyancy_coeff(:) = ra_constants(2)*ra_functions(:,2)
             temp_functions(:,2) = ra_functions(:,2)
             temp_constants(2) = ra_constants(2)
         Endif
@@ -749,7 +747,6 @@ Contains
                 Call stdout%print('f_14')
                 Call stdout%print(' ')
             Endif        
-            ref%dsdr(:) = ra_functions(:,14)
             temp_functions(:,14) = ra_functions(:,14)
         Endif
 


### PR DESCRIPTION
This removes "ref" code from the ...Reference() routines (i.e., reference_types = 1, 2, 3, 4). This completes this series of pull requests, since now only ra_constants/ra_functions is specified by all the routines and "ref" (and nu and kappa, etc.) are purely set by Initialize_PDE_Coefficients(). 