### PR TITLE
Initialize scalar buoyancy coeffs2

### DIFF
--- a/src/Physics/PDE_Coefficients.F90
+++ b/src/Physics/PDE_Coefficients.F90
@@ -368,7 +368,7 @@ Contains
         ref%viscous_amp(1:N_R) = 2.0d0
         do i = 1, n_active_scalars
             kappa_chi_a_top(i)   = 1.0d0/chi_a_prandtl_number(i)
-            ra_constants(12+(j-1)*2) = -chi_a_Rayleigh_Number(j)/chi_a_Prandtl_Number(j)
+            ra_constants(12+(i-1)*2) = -chi_a_Rayleigh_Number(i)/chi_a_Prandtl_Number(i)
         enddo
         do i = 1, n_passive_scalars
             kappa_chi_p_top(i)   = 1.0d0/chi_p_prandtl_number(i)

--- a/src/Physics/PDE_Coefficients.F90
+++ b/src/Physics/PDE_Coefficients.F90
@@ -368,7 +368,6 @@ Contains
         ref%viscous_amp(1:N_R) = 2.0d0
         do i = 1, n_active_scalars
             kappa_chi_a_top(i)   = 1.0d0/chi_a_prandtl_number(i)
-            ra_constants(12+(i-1)*2) = -chi_a_Rayleigh_Number(i)/chi_a_Prandtl_Number(i)
         enddo
         do i = 1, n_passive_scalars
             kappa_chi_p_top(i)   = 1.0d0/chi_p_prandtl_number(i)
@@ -400,6 +399,9 @@ Contains
         ra_constants(4) = ref%Lorentz_Coeff
         ra_constants(8) = 0.0d0
         ra_constants(9) = 0.0d0
+        Do i = 1, n_active_scalars
+            ra_constants(12+(i-1)*2) = -chi_a_Rayleigh_Number(i)/chi_a_Prandtl_Number(i)
+        Enddo
 
     End Subroutine Constant_Reference
 
@@ -470,7 +472,6 @@ Contains
         kappa_top     = Ekman_Number/Prandtl_Number
         do i = 1, n_active_scalars
             kappa_chi_a_top(i)   = Ekman_Number/chi_a_prandtl_number(i)
-            ra_constants(12+(i-1)*2) = -chi_a_modified_rayleigh_number(i)
         enddo
         do i = 1, n_passive_scalars
             kappa_chi_p_top(i)   = Ekman_Number/chi_p_prandtl_number(i)
@@ -508,6 +509,10 @@ Contains
         If (magnetism) Then
             ra_constants(9) = Ekman_Number**2*Dissipation_Number/(Magnetic_Prandtl_Number**2*Modified_Rayleigh_Number)
         Endif ! if not magnetism, ra_constants(9) was initialized to zero
+
+        Do i = 1, n_active_scalars
+            ra_constants(12+(i-1)*2) = -chi_a_modified_rayleigh_number(i)
+        Enddo
         DeAllocate(dtmparr, gravity)
     End Subroutine Polytropic_ReferenceND
 

--- a/src/Physics/PDE_Coefficients.F90
+++ b/src/Physics/PDE_Coefficients.F90
@@ -368,6 +368,7 @@ Contains
         ref%viscous_amp(1:N_R) = 2.0d0
         do i = 1, n_active_scalars
             kappa_chi_a_top(i)   = 1.0d0/chi_a_prandtl_number(i)
+            ra_constants(12+(j-1)*2) = -chi_a_Rayleigh_Number(j)/chi_a_Prandtl_Number(j)
         enddo
         do i = 1, n_passive_scalars
             kappa_chi_p_top(i)   = 1.0d0/chi_p_prandtl_number(i)
@@ -469,6 +470,7 @@ Contains
         kappa_top     = Ekman_Number/Prandtl_Number
         do i = 1, n_active_scalars
             kappa_chi_a_top(i)   = Ekman_Number/chi_a_prandtl_number(i)
+            ra_constants(12+(i-1)*2) = -chi_a_modified_rayleigh_number(i)
         enddo
         do i = 1, n_passive_scalars
             kappa_chi_p_top(i)   = Ekman_Number/chi_p_prandtl_number(i)
@@ -634,6 +636,10 @@ Contains
         ra_constants(4) = ref%Lorentz_Coeff
         ra_constants(8) = 1.0d0
         ra_constants(9) = ref%Lorentz_Coeff       
+
+        Do i = 1, n_active_scalars
+            ra_constants(12+(i-1)*2) = -1.0d0
+        Enddo 
 
     End Subroutine Polytropic_Reference
 


### PR DESCRIPTION
Adds loops to Constant_Reference(), Polytropic_ReferenceND(), and Polytropic_Reference() to initialize the previously zeroed-out active-scalar buoyancy constants. 