### PR TITLE
Fix equation coefficients custom diffusions

### DIFF
--- a/src/Physics/PDE_Coefficients.F90
+++ b/src/Physics/PDE_Coefficients.F90
@@ -1592,9 +1592,11 @@ Contains
         ra_functions(:,5) = kappa(:)/kappa_top
         ra_functions(:,12) = dlnkappa(:)
 
-        ra_constants(7) = eta_top
-        ra_functions(:,7) = eta(:)/eta_top
-        ra_functions(:,13) = dlneta(:)
+        If (magnetism) Then 
+            ra_constants(7) = eta_top
+            ra_functions(:,7) = eta(:)/eta_top
+            ra_functions(:,13) = dlneta(:)
+        Endif ! if no magnetism, all of the above are already zero
 
         Do i = 1, n_active_scalars
             ra_constants(11+(i-1)*2) = kappa_chi_a_top(i)

--- a/src/Physics/PDE_Coefficients.F90
+++ b/src/Physics/PDE_Coefficients.F90
@@ -1396,6 +1396,8 @@ Contains
 
         Call Compute_Diffusion_Coefs()
 
+        Call Set_Diffusivity_Equation_Coefficients()
+
     End Subroutine Initialize_Transport_Coefficients
 
     Subroutine Allocate_Transport_Coefficients()
@@ -1458,8 +1460,6 @@ Contains
                 EndIf
 
         End Select
-
-        Call Set_Diffusivity_Equation_Coefficients()
 
     End Subroutine Initialize_Diffusivity
 


### PR DESCRIPTION
This pull request "safeguards" the diffusion coefficients part of the equation_coefficients file. It adds the new subroutine Set_Diffusivity_Equation_Coefficients(), called at the end of Initialize_Transport_Coefficients(), to ensure that equation_coefficients always reflects what the code actually solved, at least for the diffusion pieces. 

This should fix the bug mentioned in #433 and guard against similar possible bugs in the future. 