### PR TITLE
fixed bug in initializing aspect_ratio (non-dimensional anelastic)

### DIFF
--- a/src/Physics/PDE_Coefficients.F90
+++ b/src/Physics/PDE_Coefficients.F90
@@ -432,7 +432,7 @@ Contains
         Endif
 
         If (aspect_ratio .lt. 0) Then
-            aspect_ratio = rmax/rmin
+            aspect_ratio = rmin/rmax
         Endif
         Allocate(dtmparr(1:N_R), gravity(1:N_R))
         dtmparr(:) = 0.0d0


### PR DESCRIPTION
In reference_type = 3 (non-dimensional anelastic), the aspect_ratio (if it was unspecified, i.e., needing to be calculated from rmin and rmax) was incorrectly initialized as rmax/rmin, the reciprocal of what it's supposed to be. 