### PR TITLE
Safeguard equation_coefficients file to reflect the actual code

### DIFF
--- a/src/Physics/PDE_Coefficients.F90
+++ b/src/Physics/PDE_Coefficients.F90
@@ -1537,8 +1537,7 @@ Contains
         ! Set the equation coefficients (apart from the ones having to do with diffusivities / heating)
         ! for proper output to the equation_coefficients file    
         
-        ! All of these have a reference-type-independent correspondence to the "ref" object
-        ! except for the following buoyancy constants
+        ! The buoyancy constants are set dependent on each reference type
         If (reference_type .eq. 1) Then
             ra_constants(2) = Rayleigh_Number/Prandtl_Number
             Do i = 1, n_active_scalars
@@ -1554,9 +1553,9 @@ Contains
             Do i = 1, n_active_scalars
                 ra_constants(12+(i-1)*2) = -chi_a_Modified_Rayleigh_Number(i)
             Enddo
-        Endif ! if reference_type .eq. 4, the buoyancy constants "are what they are"
+        Endif ! if reference_type .eq. 4, the buoyancy constants have been set directly already
 
-        ! All the following have universal correspondence to the "ref" object  
+        ! All other constants have universal correspondence to the "ref" object  
         ra_constants(1) = ref%Coriolis_Coeff
         ra_constants(3) = ref%dpdr_w_term(1)/ref%density(1)
         ra_constants(4) = ref%Lorentz_Coeff


### PR DESCRIPTION
This pull requests adds a new subroutine,

Set_Reference_Equation_Coefficients()

to the PDE_Coefficients module, which is called at the end of the Initialize_Reference() subroutine. The subroutine sets ra_constants and ra_functions (except ones having to do with diffusion, heating, and buoyancy) directly from the "ref" object and is independent of reference_type. This reduces code bloat (previously there were several repeated lines at the end of each ...Reference() subroutine specifying ra_constants/ra_functions in the exact same way), should ensure that the equation_coefficients file always reflects the equations the code actually solved, and should make future reference_type's less error-prone.

This pull request is the natural follow on to #443, which safeguarded the ra_constants/ra_functions having to do with the diffusions. 