### PR TITLE
Add a link to the INCITE dataset.

### DIFF
--- a/doc/source/accessing_and_sharing_data.rst
+++ b/doc/source/accessing_and_sharing_data.rst
@@ -10,6 +10,14 @@ Rayleigh model configurations and checkpoint data of several publications can be
 - https://osf.io/qbt32/
 - https://doi.org/10.5281/zenodo.7117668
 
+A large number of Rayleigh simulations were generated as part of the INCITE project
+"Frontiers in Planetary and Stellar Magnetism Through High Performance Computing"
+supported by the Department of Energy and the Computational Infrastructure for Geodynamics.
+Results and publications of this project can be found here:
+
+- https://geodynamics.org/groups/dynamo/frontiers
+- https://incite.readthedocs.io/en/latest/
+
 Sharing Your Rayleigh Data
 --------------------------
 


### PR DESCRIPTION
Add the INCITE dataset to the list of accessible Rayleigh data. We are in the process of finishing up the website allowing access to that data. A probably final version (not yet merged) can be seen here: https://incite--13.org.readthedocs.build/en/13/.