### PR TITLE
New general anelastic non-dimensional subroutine (reference_type = 5)

### DIFF
--- a/src/Physics/PDE_Coefficients.F90
+++ b/src/Physics/PDE_Coefficients.F90
@@ -514,7 +514,7 @@ Contains
     Subroutine Polytropic_ReferenceND_General()
         Implicit None
         Integer :: i
-        Real*8 :: c0, c1, poly_n_ad, numer, denom1, denom2, norm, tol
+        Real*8 :: c0, c1, poly_n_ad, norm, tol
         Real*8, Allocatable :: gravity(:), flux_nonrad(:), partial_heating(:), nsquared(:), &
             & zeta(:), dzeta(:), d2zeta(:), dlnzeta(:), d2lnzeta(:)
         Character*12 :: dstring
@@ -748,11 +748,12 @@ Contains
             norm = four_pi*norm/shell_volume
             nsquared = nsquared/norm
 
-            Dissipation_Number = (poly_n + 1.0d0)/(poly_n_ad + 1.0d0)
-            numer = 3.0d0*aspect_ratio*(1.0d0 - aspect_ratio)**2 * (1 - exp(-poly_Nrho/poly_n))
-            denom1 = (3.0d0*aspect_ratio/2.0d0) * (1.0 - aspect_ratio**2) * (1.0d0 - exp(-poly_Nrho/poly_n))
-            denom2 = -(1.0d0 - aspect_ratio**3)*(aspect_ratio - exp(-poly_Nrho/poly_n))
-            Dissipation_Number = Dissipation_Number * numer / (denom1 + denom2)
+            Call Integrate_in_radius(nsquared,norm)
+            norm = four_pi*norm/shell_volume
+            nsquared = nsquared/norm
+
+            ! ref%temperature(N_R) is now T_inner/volav(T); gravity(N_R) = g_inner/volav(g)
+            Dissipation_Number = Dissipation_Number*ref%temperature(N_R)/gravity(N_R)
         Endif 
 
         ! This was all assuming the H in Dissipation_Number was the shell_depth. 

--- a/src/Physics/PDE_Coefficients.F90
+++ b/src/Physics/PDE_Coefficients.F90
@@ -541,18 +541,28 @@ Contains
         ! Determine desired time-scale
         If (ND_Time_Rot) ND_Time_Visc = .false.
 
-        ! Determine how user wants to specify Ra and B_visc.
+        ! Determine how user wants to specify Ra, Chi_A_Ra, and B_visc.
         ! (The modified versions or not).
         If (rotation) Then
             If (Modified_Rayleigh_Number .lt. 0) Then !User set Ra, not Ra*
                 Modified_Rayleigh_Number = Rayleigh_Number*Ekman_Number**2/Prandtl_Number
-            Else ! User specified Ra*; that takes precedence over Ra
+            Else ! User set Ra*; that takes precedence over Ra
                 Rayleigh_Number = Modified_Rayleigh_Number*Prandtl_Number/Ekman_Number**2
             Endif
 
+            Do i = 1, n_active_scalars
+                If (Chi_A_Modified_Rayleigh_Number(i) .lt. 0) Then
+                    !User set Chi_A_Ra(i), not Chi_A_Ra(i)*
+                    Chi_A_Modified_Rayleigh_Number(i) = Chi_A_Rayleigh_Number(i)*Ekman_Number**2/Prandtl_Number
+                Else 
+                    ! User set Chi_A_Ra(i)*; that takes precedence over Chi_A_Ra(i)
+                    Chi_A_Rayleigh_Number(i) = Chi_A_Modified_Rayleigh_Number(i)*Prandtl_Number/Ekman_Number**2
+                Endif
+            Enddo
+
             If (Buoyancy_Number_Rot .lt. 0) Then !User set B_visc, not B_rot
                 Buoyancy_Number_Rot = Buoyancy_Number_Visc*Ekman_Number**2
-            Else ! User B_rot; that takes precedence over B_visc
+            Else ! User set B_rot; that takes precedence over B_visc
                 Buoyancy_Number_Visc = Buoyancy_Number_Rot/Ekman_Number**2
             Endif
         Endif

--- a/src/Physics/PDE_Coefficients.F90
+++ b/src/Physics/PDE_Coefficients.F90
@@ -608,9 +608,8 @@ Contains
             If (my_rank .eq. 0) Then
                 Call stdout%print("WARNING: You specified an adiabatic polytrope,")
                 Call stdout%print("but a nonzero Buoyancy Number.")
-                Call stdout%print("Rayleigh is setting the Buoyancy Number to zero.")
+                Call stdout%print("These choices may be physically inconsistent.")
             Endif
-            Buoyancy_Number_Visc = 0.0d0
         Endif
 
         If ((.not. Adiabatic_Polytrope) .and. (Buoyancy_Number_Visc .lt. tol) ) Then
@@ -619,7 +618,6 @@ Contains
                 Call stdout%print("but a Buoyancy Number of zero.")
                 Call stdout%print("These choices may be physically inconsistent.")
             Endif
-            Buoyancy_Number_Visc = 0.0d0
         Endif
 
         ! Print rest of information about the reference state

--- a/src/Physics/PDE_Coefficients.F90
+++ b/src/Physics/PDE_Coefficients.F90
@@ -651,6 +651,8 @@ Contains
             Write(dstring,dofmt)Rayleigh_Number
             Call stdout%print(" ---- Rayleigh Number          : "//trim(dstring))
             If (rotation) Then
+                Write(dstring,dofmt)Convective_Rossby_Number
+                Call stdout%print("          (Conv. Rossby Number : "//trim(dstring)//")")
                 Write(dstring,dofmt)Modified_Rayleigh_Number
                 Call stdout%print("          (Mod. Rayleigh Number: "//trim(dstring)//")")
             Endif
@@ -665,6 +667,8 @@ Contains
                 Write(dstring,dofmt)Buoyancy_Number_Visc
                 Call stdout%print(" ---- Visc. Buoyancy Number    : "//trim(dstring))
                 If (rotation) Then
+                    Write(dstring,dofmt)Sigma_Parameter
+                    Call stdout%print("          (Sigma               : "//trim(dstring)//")")
                     Write(dstring,dofmt)Buoyancy_Number_Rot
                     Call stdout%print("          (Rot. Buoyancy Number: "//trim(dstring)//")")
                 Endif

--- a/src/Physics/PDE_Coefficients.F90
+++ b/src/Physics/PDE_Coefficients.F90
@@ -702,10 +702,14 @@ Contains
 
         gravity = (rmin**2)*OneOverRSquared
 
-        denom1 = (1.0d0 - exp(-poly_Nrho/poly_n))/(1.d0 - Aspect_Ratio)
-        denom2 = -(Aspect_Ratio - exp(-poly_Nrho/poly_n))/(Aspect_Ratio*Shell_Depth)
-        nsquared = (rmin/radius)**3 / (denom1 + denom2*radius)
+        ref%dsdr = (1.0d0/Specific_Heat_Ratio)*(ref%dlnT - (Specific_Heat_Ratio - 1.0d0) * ref%dlnrho)
+        ! This is (1/c_p) dS/dr (where "S" is dimensional background S)
+        ! That's fine up to a multiplicative constant which we determine below
 
+        nsquared = gravity*ref%dsdr ! N^2 (non-dimensional) up to multiplicative constant
+        nsquared = nsquared/nsquared(N_R) ! N^2 (non-dimensional) now correct if ND_Inner_Radius .eq. .True.
+
+        ! calculate "basal" dissipation number explicitly
         Dissipation_Number = (poly_n + 1.0d0)/(poly_n_ad + 1.0d0) * (1.0d0/aspect_ratio) * &
             & (1.0d0 - exp(-poly_Nrho/poly_n) )
      
@@ -720,7 +724,7 @@ Contains
             ND_Volume_Average = .false.
         Endif
 
-        ! Now possibly adjust rho, T, and g to account for where non-dimensionalization occurs
+        ! Now possibly adjust profiles to account for where non-dimensionalization occurs
         If (ND_Outer_Radius) Then
             Dissipation_Number = Dissipation_Number * gravity(1) / ref%temperature(1)
             ref%density = ref%density/ref%density(1)

--- a/src/Physics/PDE_Coefficients.F90
+++ b/src/Physics/PDE_Coefficients.F90
@@ -582,14 +582,16 @@ Contains
         ! / advect_reference_state
         If ((.not. Adiabatic_Polytrope) .and. (.not. advect_reference_state) ) Then
             If (my_rank .eq. 0) Then
-                Call stdout%print("WARNING: You specified a non-adiabatic polytrope but did not set advect_reference_state = .true.")
+                Call stdout%print("WARNING: You specified a non-adiabatic polytrope,")
+                Call stdout%print("but did not set advect_reference_state = .true.")
                 Call stdout%print("These choices may be physically inconsistent.")
             Endif
         Endif
  
         If (Adiabatic_Polytrope .and. (Buoyancy_Number_Visc .gt. tol) ) Then
             If (my_rank .eq. 0) Then
-                Call stdout%print("WARNING: You specified an adiabatic polytrope but a nonzero Buoyancy Number")
+                Call stdout%print("WARNING: You specified an adiabatic polytrope,")
+                Call stdout%print("but a nonzero Buoyancy Number.")
                 Call stdout%print("Rayleigh is setting the Buoyancy Number to zero.")
             Endif
             Buoyancy_Number_Visc = 0.0d0
@@ -597,7 +599,8 @@ Contains
 
         If ((.not. Adiabatic_Polytrope) .and. (Buoyancy_Number_Visc .lt. tol) ) Then
             If (my_rank .eq. 0) Then
-                Call stdout%print("WARNING: You specified a non-adiabatic polytrope but a Buoyancy Number of zero")
+                Call stdout%print("WARNING: You specified a non-adiabatic polytrope,")
+                Call stdout%print("but a Buoyancy Number of zero.")
                 Call stdout%print("These choices may be physically inconsistent.")
             Endif
             Buoyancy_Number_Visc = 0.0d0

--- a/src/Physics/PDE_Coefficients.F90
+++ b/src/Physics/PDE_Coefficients.F90
@@ -604,7 +604,7 @@ Contains
             Endif
         Endif
  
-        If (Adiabatic_Polytrope .and. (abs(Buoyancy_Number_Visc) .gt. tol) ) Then
+        If (Adiabatic_Polytrope .and. (abs(Buoyancy_Number_Visc/Rayleigh_Number) .gt. tol) ) Then
             If (my_rank .eq. 0) Then
                 Call stdout%print("WARNING: You specified an adiabatic polytrope,")
                 Call stdout%print("but a nonzero Buoyancy Number.")
@@ -612,7 +612,7 @@ Contains
             Endif
         Endif
 
-        If ((.not. Adiabatic_Polytrope) .and. (abs(Buoyancy_Number_Visc) .lt. tol) ) Then
+        If ((.not. Adiabatic_Polytrope) .and. (abs(Buoyancy_Number_Visc/Rayleigh_Number) .lt. tol) ) Then
             If (my_rank .eq. 0) Then
                 Call stdout%print("WARNING: You specified a non-adiabatic polytrope,")
                 Call stdout%print("but a Buoyancy Number of zero.")

--- a/src/Physics/PDE_Coefficients.F90
+++ b/src/Physics/PDE_Coefficients.F90
@@ -571,10 +571,14 @@ Contains
                 Buoyancy_Number_Visc = Buoyancy_Number_Rot/Ekman_Number**2
             Elseif (Buoyancy_Number_Rot .gt. 0) Then ! User set B_rot, not B_visc
                 Buoyancy_Number_Visc = Buoyancy_Number_Rot/Ekman_Number**2
-                Sigma_Parameter = sqrt(Buoyancy_Number_Rot*Prandtl_Number)
+                If (Buoyancy_Number_Visc .ge. 0) Then ! don't take square roots of negative numbers
+                    Sigma_Parameter = sqrt(Buoyancy_Number_Rot*Prandtl_Number)
+                Endif
             Else !User set B_visc, not something else
                 Buoyancy_Number_Rot = Buoyancy_Number_Visc*Ekman_Number**2
-                Sigma_Parameter = sqrt(Buoyancy_Number_Rot*Prandtl_Number)
+                If (Buoyancy_Number_Visc .ge. 0) Then ! don't take square roots of negative numbers
+                    Sigma_Parameter = sqrt(Buoyancy_Number_Rot*Prandtl_Number)
+                Endif
             Endif
         Endif
 
@@ -667,8 +671,10 @@ Contains
                 Write(dstring,dofmt)Buoyancy_Number_Visc
                 Call stdout%print(" ---- Visc. Buoyancy Number    : "//trim(dstring))
                 If (rotation) Then
-                    Write(dstring,dofmt)Sigma_Parameter
-                    Call stdout%print("          (Sigma               : "//trim(dstring)//")")
+                    If (Buoyancy_Number_Visc .ge. 0) Then ! don't take square roots of negative numbers
+                        Write(dstring,dofmt)Sigma_Parameter
+                        Call stdout%print("          (Sigma               : "//trim(dstring)//")")
+                    Endif
                     Write(dstring,dofmt)Buoyancy_Number_Rot
                     Call stdout%print("          (Rot. Buoyancy Number: "//trim(dstring)//")")
                 Endif

--- a/src/Physics/PDE_Coefficients.F90
+++ b/src/Physics/PDE_Coefficients.F90
@@ -745,7 +745,7 @@ Contains
 
         ! Now non-dimensionalize the time by the viscous diffusion time 
 
-        ref%Coriolis_Coeff = 2.0d0/Ekman_Number
+        ref%Coriolis_Coeff = 1.0d0/Ekman_Number
 
         ref%Buoyancy_Coeff(:) = (Rayleigh_Number/Prandtl_Number)*ref%density(:)*gravity(:)
         Do i = 1, n_active_scalars

--- a/src/Physics/PDE_Coefficients.F90
+++ b/src/Physics/PDE_Coefficients.F90
@@ -1504,11 +1504,13 @@ Contains
         gravity_power           = 0.0d0
         Dissipation_Number      = 0.0d0
         Modified_Rayleigh_Number = 0.0d0
+        Convective_Rossby_Number = -1.0d0
 
         ! Nondimensional variables for the active/passive scalar fields
         chi_a_rayleigh_number(1:n_scalar_max)          = 0.0d0
         chi_a_prandtl_number(1:n_scalar_max)           = 1.0d0
         chi_a_modified_rayleigh_number(1:n_scalar_max) = 0.0d0
+        chi_a_convective_rossby_number(1:n_scalar_max) = -1.0d0
         chi_p_prandtl_number(1:n_scalar_max)           = 1.0d0
 
         ! Dimensional anelastic variables (reference_type = 2)
@@ -1538,7 +1540,8 @@ Contains
 
         Specific_Heat_Ratio = 5.0d0/3.0d0 ! Probably 5/3 or 7/5
         Buoyancy_Number_Visc = 0.0d0
-        Buoyancy_Number_Rot = 0.0d0
+        Buoyancy_Number_Rot = -1.0d0
+        Sigma_Parameter = -1.0d0
         Length_Scale = -1.0d0
 
         ! Minimum time step based on rotation rate

--- a/src/Physics/PDE_Coefficients.F90
+++ b/src/Physics/PDE_Coefficients.F90
@@ -604,7 +604,7 @@ Contains
             Endif
         Endif
  
-        If (Adiabatic_Polytrope .and. (Buoyancy_Number_Visc .gt. tol) ) Then
+        If (Adiabatic_Polytrope .and. (abs(Buoyancy_Number_Visc) .gt. tol) ) Then
             If (my_rank .eq. 0) Then
                 Call stdout%print("WARNING: You specified an adiabatic polytrope,")
                 Call stdout%print("but a nonzero Buoyancy Number.")
@@ -612,7 +612,7 @@ Contains
             Endif
         Endif
 
-        If ((.not. Adiabatic_Polytrope) .and. (Buoyancy_Number_Visc .lt. tol) ) Then
+        If ((.not. Adiabatic_Polytrope) .and. (abs(Buoyancy_Number_Visc) .lt. tol) ) Then
             If (my_rank .eq. 0) Then
                 Call stdout%print("WARNING: You specified a non-adiabatic polytrope,")
                 Call stdout%print("but a Buoyancy Number of zero.")


### PR DESCRIPTION
Implements to subroutine

Polytropic_Reference_ND_General()

in PDE_Coefficients. Note that my other pull request (#447) is included here. This new functionality allows user to specify simulation using Prandtl number, Rayleigh number (flux or otherwise), Ekman  number, magnetic Prandtl number, and four number characterizing the polytrop ice: specific-heat ratio (default 5/3), poly tropic index, number of density scale heights, and shell aspect ratio. 

User can choose between non-dimensionalizing the reference state using the profile values at the inner radius, outer radius, or volume-averaged over the shell (default). 

User can non-dimensionalize time using either the rotation rate (time = 1/Omega_0) or viscous diffusion time. 

User can non-dimensionalize the length scale using an arbitrary value, with default being the shell depth. 