### PR TITLE
Fix geodynamics/rayleigh docker image for apptainer

### DIFF
--- a/doc/source/User_Guide/getting_started.rst
+++ b/doc/source/User_Guide/getting_started.rst
@@ -117,6 +117,7 @@ Docker Container
 ~~~~~~~~~~~~~~~
 
 Docker provides a standardized way to build, distribute and run containerized environments on Linux, macOS, and Windows. To get started you should install Docker on your system following the instructions from `here <https://www.docker.com/get-started>`_. On Linux you can likely also install it from a distribution package (e.g., ``docker-io`` on Debian/Ubuntu). `Podman <https://podman.io/>`_ is an alternative runtime that can run Docker containers and can be used as a drop-in replacement for Docker.
+Singularity/Apptainer are other available alternatives that are more commonly used on HPC systems.
 
 Launching the container
 ^^^^^^^^^^^^^^^^^^^^^^^
@@ -130,6 +131,8 @@ This command will create a terminal inside the container and drop you in a direc
 that contains a pre-compiled version of Rayleigh. You can run input examples or
 tests by executing `rayleigh.opt` or `rayleigh.dbg` and look at the output files, but
 all files will be deleted when you `exit` the container.
+
+.. note:: If you use Apptainer/Singularity instead of docker you can keep the model output files, because Apptainer by default mounts the current directory into the container. The command to run Rayleigh inside the container is ``mpirun -np X apptainer exec geodynamics/rayleigh:latest rayleigh.opt``` (assuming you have a Rayleigh input file in the current directory).
 
 We also provide a container with a development environment for Rayleigh that allows you to change the code, build the
 documentation and the code, and to keep model outputs.

--- a/doc/source/User_Guide/getting_started.rst
+++ b/doc/source/User_Guide/getting_started.rst
@@ -120,7 +120,20 @@ Docker provides a standardized way to build, distribute and run containerized en
 
 Launching the container
 ^^^^^^^^^^^^^^^^^^^^^^^
-You can download our pre-built container from Docker Hub and launch it using the command from the main Rayleigh directory. The following command is for GNU/Linux and macOS users.
+You can launch our pre-built container that is hosted on Docker Hub from a terminal.
+This container is set up to get used to Rayleigh not to run productive models with it.
+
+.. code-block:: bash
+    docker run -it --rm geodynamics/rayleigh:latest bash
+
+This command will create a terminal inside the container and drop you in a directory
+that contains a pre-compiled version of Rayleigh. You can run input examples or
+tests by executing `rayleigh.opt` or `rayleigh.dbg` and look at the output files, but
+all files will be deleted when you `exit` the container.
+
+We also provide a container with a development environment for Rayleigh that allows you to change the code, build the
+documentation and the code, and to keep model outputs.
+The following command is for GNU/Linux and macOS users.
 
 .. code-block:: bash
 
@@ -136,7 +149,7 @@ Windows users should run the script ``docker-devel.bat`` instead.
 
 Configuration and Compilation
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. note:: All these commands are run inside the Docker container and assume you have a copy of Rayleigh at ``$HOME/path/to/Rayleigh`` (which corresponds to ``/root/path/to/Rayleigh`` inside the container).
+.. note:: All these commands are run inside the Docker container and assume you have a copy of Rayleigh at ``$HOME/path/to/Rayleigh`` (which corresponds to ``/work/path/to/Rayleigh`` inside the container).
 
 Building the documentation
 

--- a/docker/rayleigh/Dockerfile
+++ b/docker/rayleigh/Dockerfile
@@ -20,6 +20,7 @@ RUN ./configure \
 ENV PATH="${RAYLEIGH_DIR}/bin:${PATH}"
 ENV PYTHONPATH="${RAYLEIGH_DIR}/post_processing${PYTHONPATH:+:$PYTHONPATH}"
 
-# Allow running OpenMPI as root
+# Allow running OpenMPI as root and avoid warning messages
 ENV OMPI_ALLOW_RUN_AS_ROOT=1
 ENV OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
+ENV OMPI_MCA_btl_vader_single_copy_mechanism=none

--- a/docker/rayleigh/Dockerfile
+++ b/docker/rayleigh/Dockerfile
@@ -1,18 +1,14 @@
 FROM geodynamics/rayleigh-buildenv-jammy:latest
 
+# expose the port for Jupyter
 EXPOSE 8888
 
-RUN useradd \
-  --create-home \
-  rayleigh_user
+# define Rayleigh directory
+ENV RAYLEIGH_DIR /opt/Rayleigh
 
-USER rayleigh_user
+RUN git clone 'https://github.com/geodynamics/Rayleigh.git' ${RAYLEIGH_DIR}
 
-WORKDIR /home/rayleigh_user
-
-RUN git clone 'https://github.com/geodynamics/Rayleigh.git'
-
-WORKDIR /home/rayleigh_user/Rayleigh
+WORKDIR ${RAYLEIGH_DIR}
 
 RUN ./configure \
     -debian-mkl \
@@ -20,8 +16,10 @@ RUN ./configure \
   && make install \
   && make clean
 
-ENV RAYLEIGH_DIR /home/rayleigh_user/Rayleigh
-
+# Add Rayleigh to the path
 ENV PATH="${RAYLEIGH_DIR}/bin:${PATH}"
-
 ENV PYTHONPATH="${RAYLEIGH_DIR}/post_processing${PYTHONPATH:+:$PYTHONPATH}"
+
+# Allow running OpenMPI as root
+ENV OMPI_ALLOW_RUN_AS_ROOT=1
+ENV OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1


### PR DESCRIPTION
Our current docker container `geodynamics/rayleigh` includes a user with limited permissions and a home directory that is only readable by that user. This is a problem if the container is run using `singularity` or `apptainer`, because these container systems automatically set the user identity inside the container to the user on the outside. This means the Rayleigh installation in the current container is not usable when using apptainer or singularity. A common solution to this problem is to have the docker container default to the root user.
This way the two use cases (docker / apptainer) both work:
- for docker the user id switched to root inside the container and allows everything, including to install new software if necessary (=better than the current container)
- for apptainer/singularity the user id will be taken from the host system, but because rayleigh is installed in a generally readable location they can execute it normally. In addition, because apptainer/singularity automatically mount the current directory into the container the user is also allowed to write in this directory.

@tukss and @cianwilson I have already rebuild and updated the geodynamics/rayleigh container on docker hub. Could you try to execute that container using Singularity or Apptainer on the systems you have available? I tried on my laptop and one other system and it seems to work.

```
apptainer pull docker://geodynamics/rayleigh
# This should always work
apptainer exec rayleigh_latest.sif mpirun -n 4 rayleigh.opt
# this should only work if MPI inside and outside of container are compatible
mpirun -n 4 apptainer exec rayleigh_latest.sif rayleigh.opt```
```