### PR TITLE
add support for podman

### DIFF
--- a/doc/source/User_Guide/getting_started.rst
+++ b/doc/source/User_Guide/getting_started.rst
@@ -116,7 +116,7 @@ At this point, you can run "make install," and run the code using mpirun as you 
 Docker Container
 ~~~~~~~~~~~~~~~
 
-Docker provides a standardized way to build, distribute and run containerized environments on Linux, macOS, and Windows. To get started you should install Docker on your system following the instructions from `here <https://www.docker.com/get-started>`_. On Linux you can likely also install it from a distribution package (e.g., ``docker-io`` on Debian/Ubuntu).
+Docker provides a standardized way to build, distribute and run containerized environments on Linux, macOS, and Windows. To get started you should install Docker on your system following the instructions from `here <https://www.docker.com/get-started>`_. On Linux you can likely also install it from a distribution package (e.g., ``docker-io`` on Debian/Ubuntu). `Podman <https://podman.io/>`_ is an alternative runtime that can run Docker containers and can be used as a drop-in replacement for Docker.
 
 Launching the container
 ^^^^^^^^^^^^^^^^^^^^^^^

--- a/docker-devel
+++ b/docker-devel
@@ -1,3 +1,37 @@
 #!/bin/sh
 
-docker run -it --rm -v $HOME:/work -e HOSTUID=$(id -u) -e HOSTGID=$(id -g) -e HOSTUSER=$(id -n -u) geodynamics/rayleigh-devel-jammy:latest
+USE_PODMAN=0
+
+USAGE="Launches a Rayleigh development container\n
+Options:\n
+  -p   Use podman instead of docker to run the container.
+"
+
+while getopts ph o
+do
+  case $o in
+    p) USE_PODMAN=1;;
+    h) echo "$USAGE"; exit 1;;
+  esac
+done
+shift `expr $OPTIND - 1`
+
+HAS_DOCKER=$(command -v docker > /dev/null && echo 1 || echo 0)
+HAS_PODMAN=$(command -v podman > /dev/null && echo 1 || echo 0)
+
+if [ $HAS_DOCKER -eq 0 -a $HAS_PODMAN -ne 0 ]
+then
+  echo "docker not installed. Falling back to podman."
+  USE_PODMAN=1
+fi
+
+if [ $USE_PODMAN -ne 0 ]
+then
+  CMD=podman
+  prefix=docker://
+else
+  CMD=docker
+  prefix=
+fi
+
+"$CMD" run -it --rm -v "$HOME":/work -e HOSTUID="$(id -u)" -e HOSTGID="$(id -g)" -e HOSTUSER="$(id -n -u)" "$prefix"geodynamics/rayleigh-devel-jammy:latest


### PR DESCRIPTION
This makes the docker-devel script aware of podman and automatically selects it as a fallback. The bat file is not updated as there is no podman on Windows.