### PR TITLE
Update physics_math_overview.rst

### DIFF
--- a/doc/source/User_Guide/physics_math_overview.rst
+++ b/doc/source/User_Guide/physics_math_overview.rst
@@ -473,7 +473,7 @@ where *W* and *Z* are referred to as the poloidal and toroidal stream functions 
 .. math::
    :label: vrstream
    
-       \mathrm{f_1}v_r = - \frac{1}{r\mathrm{sin}\theta}\frac{\partial}{\partial\theta}\left(\mathrm{sin}\theta\frac{\partial W}{\partial\theta} \right)-\frac{1}{r^2\mathrm{sin}^2\theta}\frac{\partial^2 Z}{\partial\phi^2},   
+       \mathrm{f_1}v_r = - \frac{1}{r^2\mathrm{sin}\theta}\frac{\partial}{\partial\theta}\left(\mathrm{sin}\theta\frac{\partial W}{\partial\theta} \right)-\frac{1}{r^2\mathrm{sin}^2\theta}\frac{\partial^2 W}{\partial\phi^2},   
 
 .. math::
    :label: vtstream
@@ -513,7 +513,7 @@ where *C* and *A* are the poloidal and toroidal flux functions respectively.  Si
 .. math::
    :label: Brstream
    
-       B_r = - \frac{1}{r\mathrm{sin}\theta}\frac{\partial}{\partial\theta}\left(\mathrm{sin}\theta\frac{\partial C}{\partial\theta} \right)-\frac{1}{r^2\mathrm{sin}^2\theta}\frac{\partial^2 A}{\partial\phi^2},   
+       B_r = - \frac{1}{r^2\mathrm{sin}\theta}\frac{\partial}{\partial\theta}\left(\mathrm{sin}\theta\frac{\partial C}{\partial\theta} \right)-\frac{1}{r^2\mathrm{sin}^2\theta}\frac{\partial^2 C}{\partial\phi^2},   
 
 .. math::
    :label: Btstream


### PR DESCRIPTION
There are two typos in equation (16) which expresses the radial velocity component in terms of the streamfunctions: 1) The first term should be proportional to 1/r^2, not 1/r 2) The second term should involve the W streamfunction instead of the Z streamfunction.

There are two completely equivalent errors in Equation (22) which expresses the radial component of the magnetic field in terms of the fluxfunctions.