### PR TITLE
Implementation of Finite-Difference formulation

### DIFF
--- a/input_examples/main_input_mhd_jones_FD
+++ b/input_examples/main_input_mhd_jones_FD
@@ -1,0 +1,64 @@
+&problemsize_namelist
+ n_r = 128
+ n_theta = 192
+ nprow = -1
+ npcol = -1
+ rmin = 2.45d9
+ rmax = 7.0d9
+/
+&numerical_controls_namelist
+chebyshev = false
+/
+&physical_controls_namelist
+ rotation  = .true.
+ magnetism = .true.
+ benchmark_mode = 4
+ benchmark_integration_interval = 100
+ benchmark_report_interval = 10000
+ advect_reference_state = .false.
+/
+&temporal_controls_namelist
+ max_time_step = 200.0d0
+ max_iterations = 5000000
+ checkpoint_interval = 100000
+ cflmin = 0.4d0
+ cflmax = 0.6d0
+/
+&io_controls_namelist
+/
+&output_namelist
+/
+
+&Boundary_Conditions_Namelist
+strict_L_Conservation = .true.
+T_Top    = 0.0d0
+T_Bottom = 774268.3d0
+fix_tvar_top = .true.
+fix_tvar_bottom = .true.
+/
+&Initial_Conditions_Namelist
+init_type = 7
+magnetic_init_type = 7
+mag_amp = 1.0d0
+temp_amp = 1.0d1
+temp_w = 0.01d4
+conductive_profile =.true.
+restart_iter = 0
+/
+&Test_Namelist
+/
+&Reference_Namelist
+reference_type = 2
+heating_type = 0
+poly_n = 2.0d0
+poly_Nrho = 3.0d0
+poly_mass = 1.9D30
+poly_rho_i = 1.1d0
+pressure_specific_heat = 1.0509d8
+angular_velocity = 1.76d-4
+/
+&Transport_Namelist
+nu_top    = 7.28728d12
+kappa_top = 7.28728d12
+eta_top = 1.457456d11
+/

--- a/src/Makefile.fdeps
+++ b/src/Makefile.fdeps
@@ -45,7 +45,7 @@ Initial_Conditions.o : Initial_Conditions.F90 Load_Balance.o BufferedOutput.o Ma
 Input.o : Input.F90 MPI_LAYER.o Ra_MPI_Base.o Checkpointing.o Parallel_Framework.o PDE_Coefficients.o TestSuite.o Initial_Conditions.o BoundaryConditions.o Spherical_IO.o Controls.o ProblemSize.o 
 Legendre_Polynomials.o : Legendre_Polynomials.F90 
 Legendre_Transforms.o : Legendre_Transforms.F90 Structures.o Legendre_Polynomials.o 
-Linear_Solve.o : Linear_Solve.F90 Chebyshev_Polynomials.o Finite_Difference.o 
+Linear_Solve.o : Linear_Solve.F90 ProblemSize.o Chebyshev_Polynomials.o Finite_Difference.o 
 Linear_Terms_Cart.o : Linear_Terms_Cart.F90 ClockInfo.o Timers.o BoundaryConditions.o Fields.o Linear_Solve.o ProblemSize.o Controls.o Load_Balance.o 
 Load_Balance.o : Load_Balance.F90 MPI_LAYER.o 
 MPI_LAYER.o : MPI_LAYER.F90 All_to_All.o Ra_MPI_Base.o 
@@ -56,7 +56,7 @@ Math_Utility.o : Math_Utility.F90
 PDE_Coefficients.o : PDE_Coefficients.F90 General_MPI.o Math_Utility.o Math_Constants.o Controls.o ProblemSize.o 
 Parallel_Framework.o : Parallel_Framework.F90 BufferedOutput.o Structures.o Load_Balance.o General_MPI.o MPI_LAYER.o 
 Parallel_IO.o : Parallel_IO.F90 General_MPI.o Spherical_Buffer.o Legendre_Transforms.o Fourier_Transform.o MPI_LAYER.o ISendReceive.o Structures.o Parallel_Framework.o Ra_MPI_Base.o 
-ProblemSize.o : ProblemSize.F90 Timers.o BufferedOutput.o Math_Constants.o Chebyshev_Polynomials.o Controls.o Spectral_Derivatives.o Legendre_Polynomials.o Parallel_Framework.o 
+ProblemSize.o : ProblemSize.F90 Timers.o BufferedOutput.o Math_Constants.o Finite_Difference.o Chebyshev_Polynomials.o Controls.o Spectral_Derivatives.o Legendre_Polynomials.o Parallel_Framework.o 
 Ra_MPI_Base.o : Ra_MPI_Base.F90 
 Ra_Precision.o : Ra_Precision.F90 
 Run_Param_Header.dbg.o : Run_Param_Header.dbg.F 

--- a/src/Makefile.fdeps
+++ b/src/Makefile.fdeps
@@ -45,7 +45,7 @@ Initial_Conditions.o : Initial_Conditions.F90 Load_Balance.o BufferedOutput.o Ma
 Input.o : Input.F90 MPI_LAYER.o Ra_MPI_Base.o Checkpointing.o Parallel_Framework.o PDE_Coefficients.o TestSuite.o Initial_Conditions.o BoundaryConditions.o Spherical_IO.o Controls.o ProblemSize.o 
 Legendre_Polynomials.o : Legendre_Polynomials.F90 
 Legendre_Transforms.o : Legendre_Transforms.F90 Structures.o Legendre_Polynomials.o 
-Linear_Solve.o : Linear_Solve.F90 Chebyshev_Polynomials.o Finite_Difference.o
+Linear_Solve.o : Linear_Solve.F90 Chebyshev_Polynomials.o Finite_Difference.o 
 Linear_Terms_Cart.o : Linear_Terms_Cart.F90 ClockInfo.o Timers.o BoundaryConditions.o Fields.o Linear_Solve.o ProblemSize.o Controls.o Load_Balance.o 
 Load_Balance.o : Load_Balance.F90 MPI_LAYER.o 
 MPI_LAYER.o : MPI_LAYER.F90 All_to_All.o Ra_MPI_Base.o 
@@ -56,7 +56,7 @@ Math_Utility.o : Math_Utility.F90
 PDE_Coefficients.o : PDE_Coefficients.F90 General_MPI.o Math_Utility.o Math_Constants.o Controls.o ProblemSize.o 
 Parallel_Framework.o : Parallel_Framework.F90 BufferedOutput.o Structures.o Load_Balance.o General_MPI.o MPI_LAYER.o 
 Parallel_IO.o : Parallel_IO.F90 General_MPI.o Spherical_Buffer.o Legendre_Transforms.o Fourier_Transform.o MPI_LAYER.o ISendReceive.o Structures.o Parallel_Framework.o Ra_MPI_Base.o 
-ProblemSize.o : ProblemSize.F90 Timers.o BufferedOutput.o Math_Constants.o Finite_Difference.o Chebyshev_Polynomials.o Controls.o Spectral_Derivatives.o Legendre_Polynomials.o Parallel_Framework.o
+ProblemSize.o : ProblemSize.F90 Timers.o BufferedOutput.o Math_Constants.o Finite_Difference.o Chebyshev_Polynomials.o Controls.o Spectral_Derivatives.o Legendre_Polynomials.o Parallel_Framework.o 
 Ra_MPI_Base.o : Ra_MPI_Base.F90 
 Ra_Precision.o : Ra_Precision.F90 
 Run_Param_Header.dbg.o : Run_Param_Header.dbg.F 

--- a/src/Makefile.fdeps
+++ b/src/Makefile.fdeps
@@ -45,7 +45,7 @@ Initial_Conditions.o : Initial_Conditions.F90 Load_Balance.o BufferedOutput.o Ma
 Input.o : Input.F90 MPI_LAYER.o Ra_MPI_Base.o Checkpointing.o Parallel_Framework.o PDE_Coefficients.o TestSuite.o Initial_Conditions.o BoundaryConditions.o Spherical_IO.o Controls.o ProblemSize.o 
 Legendre_Polynomials.o : Legendre_Polynomials.F90 
 Legendre_Transforms.o : Legendre_Transforms.F90 Structures.o Legendre_Polynomials.o 
-Linear_Solve.o : Linear_Solve.F90 Chebyshev_Polynomials.o Finite_Difference.o 
+Linear_Solve.o : Linear_Solve.F90 Chebyshev_Polynomials.o Finite_Difference.o
 Linear_Terms_Cart.o : Linear_Terms_Cart.F90 ClockInfo.o Timers.o BoundaryConditions.o Fields.o Linear_Solve.o ProblemSize.o Controls.o Load_Balance.o 
 Load_Balance.o : Load_Balance.F90 MPI_LAYER.o 
 MPI_LAYER.o : MPI_LAYER.F90 All_to_All.o Ra_MPI_Base.o 
@@ -56,7 +56,7 @@ Math_Utility.o : Math_Utility.F90
 PDE_Coefficients.o : PDE_Coefficients.F90 General_MPI.o Math_Utility.o Math_Constants.o Controls.o ProblemSize.o 
 Parallel_Framework.o : Parallel_Framework.F90 BufferedOutput.o Structures.o Load_Balance.o General_MPI.o MPI_LAYER.o 
 Parallel_IO.o : Parallel_IO.F90 General_MPI.o Spherical_Buffer.o Legendre_Transforms.o Fourier_Transform.o MPI_LAYER.o ISendReceive.o Structures.o Parallel_Framework.o Ra_MPI_Base.o 
-ProblemSize.o : ProblemSize.F90 Timers.o BufferedOutput.o Math_Constants.o Chebyshev_Polynomials.o Controls.o Spectral_Derivatives.o Legendre_Polynomials.o Parallel_Framework.o 
+ProblemSize.o : ProblemSize.F90 Timers.o BufferedOutput.o Math_Constants.o Finite_Difference.o Chebyshev_Polynomials.o Controls.o Spectral_Derivatives.o Legendre_Polynomials.o Parallel_Framework.o
 Ra_MPI_Base.o : Ra_MPI_Base.F90 
 Ra_Precision.o : Ra_Precision.F90 
 Run_Param_Header.dbg.o : Run_Param_Header.dbg.F 

--- a/src/Makefile.fdeps
+++ b/src/Makefile.fdeps
@@ -45,7 +45,7 @@ Initial_Conditions.o : Initial_Conditions.F90 Load_Balance.o BufferedOutput.o Ma
 Input.o : Input.F90 MPI_LAYER.o Ra_MPI_Base.o Checkpointing.o Parallel_Framework.o PDE_Coefficients.o TestSuite.o Initial_Conditions.o BoundaryConditions.o Spherical_IO.o Controls.o ProblemSize.o 
 Legendre_Polynomials.o : Legendre_Polynomials.F90 
 Legendre_Transforms.o : Legendre_Transforms.F90 Structures.o Legendre_Polynomials.o 
-Linear_Solve.o : Linear_Solve.F90 ProblemSize.o Chebyshev_Polynomials.o Finite_Difference.o 
+Linear_Solve.o : Linear_Solve.F90 Chebyshev_Polynomials.o Finite_Difference.o 
 Linear_Terms_Cart.o : Linear_Terms_Cart.F90 ClockInfo.o Timers.o BoundaryConditions.o Fields.o Linear_Solve.o ProblemSize.o Controls.o Load_Balance.o 
 Load_Balance.o : Load_Balance.F90 MPI_LAYER.o 
 MPI_LAYER.o : MPI_LAYER.F90 All_to_All.o Ra_MPI_Base.o 
@@ -56,7 +56,7 @@ Math_Utility.o : Math_Utility.F90
 PDE_Coefficients.o : PDE_Coefficients.F90 General_MPI.o Math_Utility.o Math_Constants.o Controls.o ProblemSize.o 
 Parallel_Framework.o : Parallel_Framework.F90 BufferedOutput.o Structures.o Load_Balance.o General_MPI.o MPI_LAYER.o 
 Parallel_IO.o : Parallel_IO.F90 General_MPI.o Spherical_Buffer.o Legendre_Transforms.o Fourier_Transform.o MPI_LAYER.o ISendReceive.o Structures.o Parallel_Framework.o Ra_MPI_Base.o 
-ProblemSize.o : ProblemSize.F90 Timers.o BufferedOutput.o Math_Constants.o Finite_Difference.o Chebyshev_Polynomials.o Controls.o Spectral_Derivatives.o Legendre_Polynomials.o Parallel_Framework.o 
+ProblemSize.o : ProblemSize.F90 Timers.o BufferedOutput.o Math_Constants.o Chebyshev_Polynomials.o Controls.o Spectral_Derivatives.o Legendre_Polynomials.o Parallel_Framework.o 
 Ra_MPI_Base.o : Ra_MPI_Base.F90 
 Ra_Precision.o : Ra_Precision.F90 
 Run_Param_Header.dbg.o : Run_Param_Header.dbg.F 

--- a/src/Math_Layer/Linear_Solve.F90
+++ b/src/Math_Layer/Linear_Solve.F90
@@ -874,11 +874,14 @@ Module Linear_Solve
         Integer, Intent(In) :: eqind, varind, mode, row, dorder
         Integer :: colblock, rowblock
         real*8, Pointer, Dimension(:,:) :: mpointer
-        mpointer => equation_set(mode,eqind)%mpointer
-        colblock = equation_set(mode,eqind)%colblock(varind)
-        rowblock = equation_set(mode,eqind)%rowblock
 
-        Call Cheby_Continuity(row,rowblock,colblock,dorder,mpointer)
+        If (chebyshev) then
+                mpointer => equation_set(mode,eqind)%mpointer
+                colblock = equation_set(mode,eqind)%colblock(varind)
+                rowblock = equation_set(mode,eqind)%rowblock
+        
+                Call Cheby_Continuity(row,rowblock,colblock,dorder,mpointer)
+        Endif
 
     End Subroutine FEContinuity
     Subroutine Clear_Row(eqind, mode,row)

--- a/src/Math_Layer/Linear_Solve.F90
+++ b/src/Math_Layer/Linear_Solve.F90
@@ -21,6 +21,7 @@
 Module Linear_Solve
     Use Finite_Difference
     Use Chebyshev_Polynomials, Only : Cheby_Grid
+    Use ProblemSize, Only : my_rank
     !==========================================================================
     ! Generalized Implicit Time-stepping
     ! Currently assumes that implicit time stepping can be done with 1 dimension (only)
@@ -442,6 +443,14 @@ Module Linear_Solve
                         !Call LU_Solve_Sparse(j,k)
                         Call Equation_set(j,k)%LU_Solve_Sparse()
                     Else
+                        if (my_rank .eq. 0) Then
+                        print*,k,j, n_equations, n_modes
+                        if (k .eq. 4 .and. j .eq. 2) then
+                        open(1, file = 'data1.dat', status = 'new')
+                        write(1,*) Equation_set(j,k)%LHS(size(Equation_set(j,k)%LHS,1),:)
+                        close(1)
+                        endif
+                        endif
                         Call lu_solve_full(Equation_set(j,k)%LHS , Equation_Set(j,k)%rhs_pointer , Equation_Set(j,k)%Pivot)
                     Endif
                 Endif
@@ -1035,7 +1044,7 @@ Module Linear_Solve
           Real*8,Intent(inout) :: rhs(:,:,:)
           Integer, Intent(in) :: pvt(:)
           Integer, Optional :: na, nb
-          Integer :: ma, mb, lda, ku, kl,info
+          Integer :: ma, mb, lda, ku, kl,info, i, j
 
           If (Present(na)) Then
              ma = na
@@ -1057,17 +1066,29 @@ Module Linear_Solve
           ku = kl
         !  Call dgbtrs('N', ma, kl, ku, mb, mat, lda, pvt, rhs, Size(rhs,3), info)
 
+          If (my_rank .eq. 0) Then
+          open(1, file = 'data1.dat', status = 'new') 
+          print*,lda,ma 
+          do, i=1,lda
+          write(1,*) mat(i,:)
+          enddo
+          !do i=1,100  
+          !write(1,*) mat   
+          !end do  
+          close(1) 
+          endif
           Call dgbtrs('N', ma, kl, ku, mb, mat, lda, pvt, rhs, Size(rhs,1), info)
 
 
     End Subroutine LU_Solve_Band
 
     Subroutine LU_Solve_full(mat, rhs, pvt, na, nb)
-        Real*8,intent(in) :: mat(:,:)
+        Real*8,intent(inout) :: mat(:,:)
         Real*8,Intent(inout) :: rhs(:,:,:)
+        Real*8 :: diag
         Integer, Intent(in) :: pvt(:)
         Integer, Optional :: na, nb
-        Integer :: ma, mb, info
+        Integer :: ma, mb, info,i,j
 
         If (Present(na)) Then
             Write(6,*)'na specified: ', na, Size(rhs,1)
@@ -1082,10 +1103,44 @@ Module Linear_Solve
         Else
             mb = Size(rhs)/Size(rhs,1)
         End If
-
+          !If (magnetism) Then
+         !precond = mat
+          Do i = 1, ma
+             diag = mat(i,i)
+             if (my_rank .eq. 0) then
+             print*,i,ma,diag
+             !if (diag .eq. 0.0) then
+             !open(1, file = 'data1.dat', status = 'new')
+             !print*,size(mat,1),size(mat,2)
+             !do, j=1,ma
+             !write(1,*) mat(j,:)
+             !enddo
+             !close(1)
+             !endif
+             if (i .eq. ma) Then
+             print*,"End"
+             endif
+             endif
+             mat(i,:)=mat(i,:)/diag
+             rhs(i,:,:) = rhs(i,:,:)/diag
+          enddo
+          
+          !EndIf
+          !If (my_rank .eq. 0) Then
+          !open(1, file = 'data1.dat', status = 'new')
+          !print*,size(mat,1),size(mat,2)
+          !do, i=1,ma
+          !write(1,*) mat(i,:)
+          !enddo
+          !do i=1,100  
+          !write(1,*) mat   
+          !end do  
+          !close(1)
+          !endif
         Call dgetrs('N', ma, mb, mat, Size(mat,1), pvt, rhs, Size(rhs,1), info)
-
-
+     
+         
+      
         !If(Present(nb)) Then
         If (info .ne. 0) Then
             Write(6,*)'Problem is solve!  info is ', info
@@ -1098,12 +1153,12 @@ Module Linear_Solve
             Integer :: link,i,nupper
             If (equation_set(mode,equ)%solvefor) Then
                 If (equ .eq. 1) Then
-                    nupper = 3*cpgrid%max_npoly
+                    nupper = 3*ndim1!cpgrid%max_npoly
                     !Call Band_Load_Single(mode,equ,11)
                      Call Band_Load_Single(mode,equ,nupper)
 
                 Else
-                    nupper = cpgrid%max_npoly
+                    nupper = ndim1!cpgrid%max_npoly
                     Call Band_Load_Single(mode,equ,nupper) ! 3
                 Endif
 

--- a/src/Math_Layer/Linear_Solve.F90
+++ b/src/Math_Layer/Linear_Solve.F90
@@ -879,7 +879,7 @@ Module Linear_Solve
                 mpointer => equation_set(mode,eqind)%mpointer
                 colblock = equation_set(mode,eqind)%colblock(varind)
                 rowblock = equation_set(mode,eqind)%rowblock
-        
+
                 Call Cheby_Continuity(row,rowblock,colblock,dorder,mpointer)
         Endif
 
@@ -1082,8 +1082,10 @@ Module Linear_Solve
         Else
             mb = Size(rhs)/Size(rhs,1)
         End If
-       Call dgetrs('N', ma, mb, mat, Size(mat,1), pvt, rhs, Size(rhs,1), info)
-      
+
+        Call dgetrs('N', ma, mb, mat, Size(mat,1), pvt, rhs, Size(rhs,1), info)
+
+
         !If(Present(nb)) Then
         If (info .ne. 0) Then
             Write(6,*)'Problem is solve!  info is ', info

--- a/src/Math_Layer/Linear_Solve.F90
+++ b/src/Math_Layer/Linear_Solve.F90
@@ -21,7 +21,7 @@
 Module Linear_Solve
     Use Finite_Difference
     Use Chebyshev_Polynomials, Only : Cheby_Grid
-    Use ProblemSize, Only : my_rank
+    !Use ProblemSize, Only : my_rank
     !==========================================================================
     ! Generalized Implicit Time-stepping
     ! Currently assumes that implicit time stepping can be done with 1 dimension (only)
@@ -443,14 +443,14 @@ Module Linear_Solve
                         !Call LU_Solve_Sparse(j,k)
                         Call Equation_set(j,k)%LU_Solve_Sparse()
                     Else
-                        if (my_rank .eq. 0) Then
-                        print*,k,j, n_equations, n_modes
-                        if (k .eq. 4 .and. j .eq. 2) then
-                        open(1, file = 'data1.dat', status = 'new')
-                        write(1,*) Equation_set(j,k)%LHS(size(Equation_set(j,k)%LHS,1),:)
-                        close(1)
-                        endif
-                        endif
+                        !if (my_rank .eq. 0) Then
+                        !print*,k,j, n_equations, n_modes
+                        !if (k .eq. 4 .and. j .eq. 2) then
+                        !open(1, file = 'data1.dat', status = 'new')
+                        !write(1,*) Equation_set(j,k)%LHS(size(Equation_set(j,k)%LHS,1),:)
+                        !close(1)
+                        !endif
+                        !endif
                         Call lu_solve_full(Equation_set(j,k)%LHS , Equation_Set(j,k)%rhs_pointer , Equation_Set(j,k)%Pivot)
                     Endif
                 Endif
@@ -1066,17 +1066,17 @@ Module Linear_Solve
           ku = kl
         !  Call dgbtrs('N', ma, kl, ku, mb, mat, lda, pvt, rhs, Size(rhs,3), info)
 
-          If (my_rank .eq. 0) Then
-          open(1, file = 'data1.dat', status = 'new') 
-          print*,lda,ma 
-          do, i=1,lda
-          write(1,*) mat(i,:)
-          enddo
+          !If (my_rank .eq. 0) Then
+          !open(1, file = 'data1.dat', status = 'new') 
+          !print*,lda,ma 
+          !do, i=1,lda
+          !write(1,*) mat(i,:)
+          !enddo
           !do i=1,100  
           !write(1,*) mat   
           !end do  
-          close(1) 
-          endif
+          !close(1) 
+          !endif
           Call dgbtrs('N', ma, kl, ku, mb, mat, lda, pvt, rhs, Size(rhs,1), info)
 
 
@@ -1105,10 +1105,10 @@ Module Linear_Solve
         End If
           !If (magnetism) Then
          !precond = mat
-          Do i = 1, ma
-             diag = mat(i,i)
-             if (my_rank .eq. 0) then
-             print*,i,ma,diag
+          !Do i = 1, ma
+             !diag = mat(i,i)
+             !if (my_rank .eq. 0) then
+             !print*,i,ma,diag
              !if (diag .eq. 0.0) then
              !open(1, file = 'data1.dat', status = 'new')
              !print*,size(mat,1),size(mat,2)
@@ -1117,13 +1117,13 @@ Module Linear_Solve
              !enddo
              !close(1)
              !endif
-             if (i .eq. ma) Then
-             print*,"End"
-             endif
-             endif
-             mat(i,:)=mat(i,:)/diag
-             rhs(i,:,:) = rhs(i,:,:)/diag
-          enddo
+             !if (i .eq. ma) Then
+             !print*,"End"
+             !endif
+             !endif
+             !mat(i,:)=mat(i,:)/diag
+             !rhs(i,:,:) = rhs(i,:,:)/diag
+          !enddo
           
           !EndIf
           !If (my_rank .eq. 0) Then
@@ -1153,12 +1153,12 @@ Module Linear_Solve
             Integer :: link,i,nupper
             If (equation_set(mode,equ)%solvefor) Then
                 If (equ .eq. 1) Then
-                    nupper = 3*ndim1!cpgrid%max_npoly
+                    nupper = 3*cpgrid%max_npoly
                     !Call Band_Load_Single(mode,equ,11)
                      Call Band_Load_Single(mode,equ,nupper)
 
                 Else
-                    nupper = ndim1!cpgrid%max_npoly
+                    nupper = cpgrid%max_npoly
                     Call Band_Load_Single(mode,equ,nupper) ! 3
                 Endif
 

--- a/src/Math_Layer/Linear_Solve.F90
+++ b/src/Math_Layer/Linear_Solve.F90
@@ -21,7 +21,6 @@
 Module Linear_Solve
     Use Finite_Difference
     Use Chebyshev_Polynomials, Only : Cheby_Grid
-    !Use ProblemSize, Only : my_rank
     !==========================================================================
     ! Generalized Implicit Time-stepping
     ! Currently assumes that implicit time stepping can be done with 1 dimension (only)
@@ -1064,12 +1063,11 @@ Module Linear_Solve
     End Subroutine LU_Solve_Band
 
     Subroutine LU_Solve_full(mat, rhs, pvt, na, nb)
-        Real*8,intent(inout) :: mat(:,:)
+        Real*8,intent(in) :: mat(:,:)
         Real*8,Intent(inout) :: rhs(:,:,:)
-        Real*8 :: diag
         Integer, Intent(in) :: pvt(:)
         Integer, Optional :: na, nb
-        Integer :: ma, mb, info,i,j
+        Integer :: ma, mb, info
 
         If (Present(na)) Then
             Write(6,*)'na specified: ', na, Size(rhs,1)
@@ -1084,43 +1082,7 @@ Module Linear_Solve
         Else
             mb = Size(rhs)/Size(rhs,1)
         End If
-          !If (magnetism) Then
-         !precond = mat
-          !Do i = 1, ma
-             !diag = mat(i,i)
-             !if (my_rank .eq. 0) then
-             !print*,i,ma,diag
-             !if (diag .eq. 0.0) then
-             !open(1, file = 'data1.dat', status = 'new')
-             !print*,size(mat,1),size(mat,2)
-             !do, j=1,ma
-             !write(1,*) mat(j,:)
-             !enddo
-             !close(1)
-             !endif
-             !if (i .eq. ma) Then
-             !print*,"End"
-             !endif
-             !endif
-             !mat(i,:)=mat(i,:)/diag
-             !rhs(i,:,:) = rhs(i,:,:)/diag
-          !enddo
-          
-          !EndIf
-          !If (my_rank .eq. 0) Then
-          !open(1, file = 'data1.dat', status = 'new')
-          !print*,size(mat,1),size(mat,2)
-          !do, i=1,ma
-          !write(1,*) mat(i,:)
-          !enddo
-          !do i=1,100  
-          !write(1,*) mat   
-          !end do  
-          !close(1)
-          !endif
-        Call dgetrs('N', ma, mb, mat, Size(mat,1), pvt, rhs, Size(rhs,1), info)
-     
-         
+       Call dgetrs('N', ma, mb, mat, Size(mat,1), pvt, rhs, Size(rhs,1), info)
       
         !If(Present(nb)) Then
         If (info .ne. 0) Then

--- a/src/Math_Layer/Linear_Solve.F90
+++ b/src/Math_Layer/Linear_Solve.F90
@@ -443,14 +443,6 @@ Module Linear_Solve
                         !Call LU_Solve_Sparse(j,k)
                         Call Equation_set(j,k)%LU_Solve_Sparse()
                     Else
-                        !if (my_rank .eq. 0) Then
-                        !print*,k,j, n_equations, n_modes
-                        !if (k .eq. 4 .and. j .eq. 2) then
-                        !open(1, file = 'data1.dat', status = 'new')
-                        !write(1,*) Equation_set(j,k)%LHS(size(Equation_set(j,k)%LHS,1),:)
-                        !close(1)
-                        !endif
-                        !endif
                         Call lu_solve_full(Equation_set(j,k)%LHS , Equation_Set(j,k)%rhs_pointer , Equation_Set(j,k)%Pivot)
                     Endif
                 Endif
@@ -1044,7 +1036,7 @@ Module Linear_Solve
           Real*8,Intent(inout) :: rhs(:,:,:)
           Integer, Intent(in) :: pvt(:)
           Integer, Optional :: na, nb
-          Integer :: ma, mb, lda, ku, kl,info, i, j
+          Integer :: ma, mb, lda, ku, kl,info
 
           If (Present(na)) Then
              ma = na
@@ -1066,17 +1058,6 @@ Module Linear_Solve
           ku = kl
         !  Call dgbtrs('N', ma, kl, ku, mb, mat, lda, pvt, rhs, Size(rhs,3), info)
 
-          !If (my_rank .eq. 0) Then
-          !open(1, file = 'data1.dat', status = 'new') 
-          !print*,lda,ma 
-          !do, i=1,lda
-          !write(1,*) mat(i,:)
-          !enddo
-          !do i=1,100  
-          !write(1,*) mat   
-          !end do  
-          !close(1) 
-          !endif
           Call dgbtrs('N', ma, kl, ku, mb, mat, lda, pvt, rhs, Size(rhs,1), info)
 
 

--- a/src/Physics/Controls.F90
+++ b/src/Physics/Controls.F90
@@ -36,7 +36,7 @@ Module Controls
     ! Numerical Controls
     ! Flats that control details of the parallelization/data layout and
     ! how the equations are solved (not what equations are solved).
-    Logical :: chebyshev = .false.           ! Set to false to use finite-differences (chebyshev polynomials are used by default)
+    Logical :: chebyshev = .true.           ! Set to false to use finite-differences (chebyshev polynomials are used by default)
     Logical :: bandsolve = .false.          ! Set to true to use band solves with the finite-differences
     Logical :: static_transpose = .false.   ! When true, transpose buffers for sending/receiving are never de-allocated for spherical buffer objects
     Logical :: static_config = .false.      ! When true, configuration buffers (p3a, s1b, etc.) ar enever de-allocated for spherical buffer objects

--- a/src/Physics/Controls.F90
+++ b/src/Physics/Controls.F90
@@ -36,7 +36,7 @@ Module Controls
     ! Numerical Controls
     ! Flats that control details of the parallelization/data layout and
     ! how the equations are solved (not what equations are solved).
-    Logical :: chebyshev = .true.           ! Set to false to use finite-differences (chebyshev polynomials are used by default)
+    Logical :: chebyshev = .false.           ! Set to false to use finite-differences (chebyshev polynomials are used by default)
     Logical :: bandsolve = .false.          ! Set to true to use band solves with the finite-differences
     Logical :: static_transpose = .false.   ! When true, transpose buffers for sending/receiving are never de-allocated for spherical buffer objects
     Logical :: static_config = .false.      ! When true, configuration buffers (p3a, s1b, etc.) ar enever de-allocated for spherical buffer objects
@@ -151,7 +151,7 @@ Contains
     Subroutine Initialize_Controls()
         Implicit None
         character*120 :: ofilename
-        chebyshev = .true.   ! finite-difference is not currently supported
+        !chebyshev = .true.   ! finite-difference is not currently supported
         Allocate(global_msgs(1:nglobal_msgs))
         global_msgs = 0.0d0
 

--- a/src/Physics/Controls.F90
+++ b/src/Physics/Controls.F90
@@ -151,7 +151,6 @@ Contains
     Subroutine Initialize_Controls()
         Implicit None
         character*120 :: ofilename
-        !chebyshev = .true.   ! finite-difference is not currently supported
         Allocate(global_msgs(1:nglobal_msgs))
         global_msgs = 0.0d0
 

--- a/src/Physics/Input.F90
+++ b/src/Physics/Input.F90
@@ -20,7 +20,7 @@
 
 Module Input
     Use ProblemSize,  Only : problemsize_namelist, nprow, npcol, n_r,n_theta, npout, global_rank, &
-                             ncpu_global, aspect_ratio, l_max
+                             ncpu_global, aspect_ratio, l_max, dr_input
     Use Controls,     Only : temporal_controls_namelist, numerical_controls_namelist, &
                              physical_controls_namelist, max_iterations, pad_alltoall, &
                              multi_run_mode, nruns, rundirs, my_path, run_cpus, &

--- a/src/Physics/ProblemSize.F90
+++ b/src/Physics/ProblemSize.F90
@@ -377,7 +377,7 @@ Contains
             Do i = 2,bounds_count
                 domain_bounds(i) = domain_bounds(i-1)+rdelta
             Enddo
-         Else
+        Else
             ! Case (c)
             n_r = 0
             Do i = 1, cheby_count

--- a/src/Physics/ProblemSize.F90
+++ b/src/Physics/ProblemSize.F90
@@ -77,7 +77,7 @@ Module ProblemSize
     Integer :: ndomains = 1
     Integer :: n_uniform_domains =1
     Real*8  :: domain_bounds(1:nsubmax+1)=-1.0d0
-    Real*8  :: dr_input(4096) = 1.0d0
+    Real*8  :: dr_input(4096) = 0.0d0
     Logical :: uniform_bounds = .false.
     Type(Cheby_Grid), Target :: gridcp
 
@@ -520,14 +520,20 @@ Contains
             Enddo
         Else
             grid_type = 1
-            !if (my_rank .eq. 0) Then
-            !print*,"FINITE DIFF"
-            !endif
             Radius(N_R) = rmin ! Follow ASH convention of reversed radius
-            Delta_R(N_R) = dr_input(N_R)
             uniform_dr = 1.0d0/(N_R-1.0d0)*(rmax-rmin)
+            If (dr_input(N_R) .eq. 0.0) Then
+                Delta_r(N_R) = uniform_dr
+            Else If (dr_input(N_R) .gt. 0.0) Then
+                Delta_r(N_R) = dr_input(N_R)
+            Endif 
+
             Do r=N_R-1,1,-1
-                    Delta_r(r) = uniform_dr!dr_input(r)!uniform_dr
+                    If (dr_input(r) .eq. 0.0) Then
+                        Delta_r(r) = uniform_dr
+                    Else If (dr_input(r) .gt. 0.0) Then
+                        Delta_r(r) = dr_input(r)
+                    Endif 
                     Radius(r) = Delta_r(r) + Radius(r+1)
             Enddo
         Endif

--- a/src/Physics/ProblemSize.F90
+++ b/src/Physics/ProblemSize.F90
@@ -106,7 +106,11 @@ Contains
 
         If (my_rank .eq. 0) Then
             call stdout%print(" ")
-            call stdout%print(" -- Initalizing Grid...")
+            If (chebyshev) Then
+                call stdout%print(" -- Initializing Chebyshev Grid...")
+            Else
+                call stdout%print(" -- Initializing Finite-Difference Grid...")
+            EndIf
         Endif
 
         Call Report_Grid_Parameters()     ! Print some grid-related info to the screen
@@ -569,7 +573,11 @@ Contains
             Write(dstring,dofmt)rmax
             Call stdout%print(" ---- R_MAX               : "//trim(dstring))
             Write(istr,'(i6)')ndomains
-            call stdout%print(" ---- Chebyshev Domains   : "//trim(istr))
+            If (chebyshev) Then
+                call stdout%print(" ---- Chebyshev Domains   : "//trim(istr))
+            Else
+                call stdout%print(" ---- Finite Difference Domains   : "//trim(istr))
+            Endif
 
             Do i = 1, ndomains
                 call stdout%print(" ")

--- a/src/Physics/ProblemSize.F90
+++ b/src/Physics/ProblemSize.F90
@@ -520,13 +520,15 @@ Contains
             Enddo
         Else
             grid_type = 1
+            !if (my_rank .eq. 0) Then
             !print*,"FINITE DIFF"
+            !endif
             Radius(N_R) = rmin ! Follow ASH convention of reversed radius
             Delta_R(N_R) = dr_input(N_R)
             uniform_dr = 1.0d0/(N_R-1.0d0)*(rmax-rmin)
             Do r=N_R-1,1,-1
                     Delta_r(r) = uniform_dr!dr_input(r)!uniform_dr
-                    Radius(r) = dr_input(r) + Radius(r+1)
+                    Radius(r) = Delta_r(r) + Radius(r+1)
             Enddo
         Endif
 

--- a/src/Physics/ProblemSize.F90
+++ b/src/Physics/ProblemSize.F90
@@ -523,9 +523,9 @@ Contains
             !print*,"FINITE DIFF"
             Radius(N_R) = rmin ! Follow ASH convention of reversed radius
             Delta_R(N_R) = dr_input(N_R)
-            !uniform_dr = 1.0d0/(N_R-1.0d0)*(rmax-rmin)
+            uniform_dr = 1.0d0/(N_R-1.0d0)*(rmax-rmin)
             Do r=N_R-1,1,-1
-                    Delta_r(r) = dr_input(r)!uniform_dr
+                    Delta_r(r) = uniform_dr!dr_input(r)!uniform_dr
                     Radius(r) = dr_input(r) + Radius(r+1)
             Enddo
         Endif

--- a/src/Physics/ProblemSize.F90
+++ b/src/Physics/ProblemSize.F90
@@ -530,14 +530,14 @@ Contains
                 Delta_r(N_R) = uniform_dr
             Else If (dr_input(N_R) .gt. 0.0) Then
                 Delta_r(N_R) = dr_input(N_R)
-            Endif 
+            Endif
 
             Do r=N_R-1,1,-1
                     If (dr_input(r) .eq. 0.0) Then
                         Delta_r(r) = uniform_dr
                     Else If (dr_input(r) .gt. 0.0) Then
                         Delta_r(r) = dr_input(r)
-                    Endif 
+                    Endif
                     Radius(r) = Delta_r(r) + Radius(r+1)
             Enddo
         Endif

--- a/src/Physics/Run_Parameters.F90
+++ b/src/Physics/Run_Parameters.F90
@@ -36,7 +36,7 @@ Contains
                            temporal_controls_namelist, io_controls_namelist
         Use Parallel_Framework, Only: pfi
         Use ProblemSize, Only : my_rank, problemsize_namelist, nprow, npcol, &
-                              n_r, n_theta, l_max, rmin, rmax, &
+                              n_r, n_theta, l_max, dr_input, rmin, rmax, &
                               ndomains, ncheby, dealias_by, domain_bounds
         Use Spherical_IO, Only : output_namelist
         Use BoundaryConditions, Only : boundary_conditions_namelist

--- a/src/Physics/Sphere_Driver.F90
+++ b/src/Physics/Sphere_Driver.F90
@@ -22,7 +22,7 @@ Module Sphere_Driver
     Use ClockInfo
     Use Sphere_Hybrid_Space,   Only : rlm_spacea, rlm_spaceb, hybrid_init
     Use Sphere_Physical_Space, Only : physical_space, ohmic_heating_coeff
-    Use Sphere_Spectral_Space, Only : post_solve, advancetime, ctemp
+    Use Sphere_Spectral_Space, Only : post_solve, advancetime, ctemp, post_solve_FD
     Use Diagnostics_Interface, Only : Reboot_Diagnostics
     Use Spherical_IO, Only : time_to_output
     Use Checkpointing
@@ -158,9 +158,12 @@ Contains
             global_msgs(4) = simulation_time
             If (terminate_file_exists) global_msgs(5) = 1.0d0
 
-            Call Post_Solve() ! Linear Solve Configuration
-
-
+            If (chebyshev) Then
+                Call Post_Solve() ! Linear Solve Configuration
+            Else
+                Call Post_Solve_FD()
+            Endif
+           
             If (my_rank .eq. 0 .and. mod(iteration,statusline_interval) .eq. 0) Then
                 Write(istr,int_out_fmt)iteration
                 Write(dtstr,sci_note_fmt)deltat
@@ -179,6 +182,7 @@ Contains
             Call rlm_spaceb()
 
             Call AdvanceTime()
+
 
 
             ! Disabling this for the time being.  It needs to be brought up-to-date with the

--- a/src/Physics/Sphere_Driver.F90
+++ b/src/Physics/Sphere_Driver.F90
@@ -184,7 +184,6 @@ Contains
             Call AdvanceTime()
 
 
-
             ! Disabling this for the time being.  It needs to be brought up-to-date with the
             ! rest of the code.
             !Call Reboot_Diagnostics(iteration)

--- a/src/Physics/Sphere_Driver.F90
+++ b/src/Physics/Sphere_Driver.F90
@@ -163,7 +163,7 @@ Contains
             Else
                 Call Post_Solve_FD()
             Endif
-           
+
             If (my_rank .eq. 0 .and. mod(iteration,statusline_interval) .eq. 0) Then
                 Write(istr,int_out_fmt)iteration
                 Write(dtstr,sci_note_fmt)deltat

--- a/src/Physics/Sphere_Linear_Terms.F90
+++ b/src/Physics/Sphere_Linear_Terms.F90
@@ -57,7 +57,7 @@ Contains
                         Lconservation_weights( nm+(2*gridcp%npoly(m))/3+1:nm+gridcp%npoly(m) ) = 0.0d0  ! De-Alias
                         nm = nm + gridcp%npoly(m)
                     Enddo
-                Else 
+                Else
                     Lconservation_weights = radial_integral_weights
                 Endif
             Endif

--- a/src/Physics/Sphere_Linear_Terms.F90
+++ b/src/Physics/Sphere_Linear_Terms.F90
@@ -43,20 +43,23 @@ Contains
             Call Initialize_Linear_System()
 
             If (strict_L_conservation) Then
-
-                Allocate(Lconservation_weights(1:N_R))
-                Lconservation_weights(1:N_R) = 0.0d0
-                nm = 0
-                Do m = 1, gridcp%domain_count
-                    Do n = 1, gridcp%npoly(m)
-                        Do r = 1, gridcp%npoly(m)
-                            T = gridcp%dcheby(m)%data(r,n,0)
-                            Lconservation_weights(n+nm) = Lconservation_weights(n+nm) + radial_integral_weights(r+nm) * T
+                If (chebyshev) Then
+                    Allocate(Lconservation_weights(1:N_R))
+                    Lconservation_weights(1:N_R) = 0.0d0
+                    nm = 0
+                    Do m = 1, gridcp%domain_count
+                        Do n = 1, gridcp%npoly(m)
+                            Do r = 1, gridcp%npoly(m)
+                                T = gridcp%dcheby(m)%data(r,n,0)
+                                Lconservation_weights(n+nm) = Lconservation_weights(n+nm) + radial_integral_weights(r+nm) * T
+                            Enddo
                         Enddo
+                        Lconservation_weights( nm+(2*gridcp%npoly(m))/3+1:nm+gridcp%npoly(m) ) = 0.0d0  ! De-Alias
+                        nm = nm + gridcp%npoly(m)
                     Enddo
-                    Lconservation_weights( nm+(2*gridcp%npoly(m))/3+1:nm+gridcp%npoly(m) ) = 0.0d0  ! De-Alias
-                    nm = nm + gridcp%npoly(m)
-                Enddo
+                Else 
+                    Lconservation_weights = radial_integral_weights
+                Endif
             Endif
         Endif
     End Subroutine Linear_Init

--- a/src/Physics/Sphere_Linear_Terms.F90
+++ b/src/Physics/Sphere_Linear_Terms.F90
@@ -492,7 +492,6 @@ Contains
                 Endif
             Endif
 
-
             If (bandsolve) Then
                 Call Band_Arrange(weq,lp)
                 Call Band_Arrange(zeq,lp)

--- a/src/Physics/Sphere_Linear_Terms.F90
+++ b/src/Physics/Sphere_Linear_Terms.F90
@@ -495,6 +495,7 @@ Contains
                 Endif
             Endif
 
+
             If (bandsolve) Then
                 Call Band_Arrange(weq,lp)
                 Call Band_Arrange(zeq,lp)

--- a/src/Physics/Sphere_Physical_Space.F90
+++ b/src/Physics/Sphere_Physical_Space.F90
@@ -52,6 +52,7 @@ Contains
         Call StopWatch(dphi_time)%increment()
 
 
+
         ! Next perform the FFT
         Call StopWatch(fft_time)%startclock()
         Call fft_to_physical(wsp%p3a,rsc = .true.)
@@ -137,6 +138,7 @@ Contains
         Call Momentum_Advection_Radial()
         Call Momentum_Advection_Theta()
         Call Momentum_Advection_Phi()
+
 
         If (magnetism) Then
             Call Compute_Ohmic_Heating()

--- a/src/Physics/Sphere_Physical_Space.F90
+++ b/src/Physics/Sphere_Physical_Space.F90
@@ -52,7 +52,6 @@ Contains
         Call StopWatch(dphi_time)%increment()
 
 
-
         ! Next perform the FFT
         Call StopWatch(fft_time)%startclock()
         Call fft_to_physical(wsp%p3a,rsc = .true.)
@@ -138,7 +137,6 @@ Contains
         Call Momentum_Advection_Radial()
         Call Momentum_Advection_Theta()
         Call Momentum_Advection_Phi()
-
 
         If (magnetism) Then
             Call Compute_Ohmic_Heating()

--- a/src/Physics/Sphere_Spectral_Space.F90
+++ b/src/Physics/Sphere_Spectral_Space.F90
@@ -51,7 +51,7 @@ Contains
                 Write(otstring,t_ofmt)old_deltat
                 Write(tstring,t_ofmt)deltat
                 Call stdout%print(' Timestep has changed from '//Trim(otstring)//' to '//Trim(tstring)//'.')
-        Call stdout%partial_flush()  ! Make SURE that a changing timestep is recorded ...
+                Call stdout%partial_flush()  ! Make SURE that a changing timestep is recorded ...
                          ! ... even at the expense of additional file I/O for redirected stdout
             Endif
             Call StopWatch(seteq_time)%startclock()

--- a/src/Physics/Sphere_Spectral_Space.F90
+++ b/src/Physics/Sphere_Spectral_Space.F90
@@ -470,7 +470,6 @@ Subroutine Post_Solve_FD()
         Else
             ctemp%nf1a = 1
             Call ctemp%construct('p1a')
-            Call ctemp%construct('p1b')
             ctemp%p1a(:,:,:,:) = 0.0d0
             Do m = 1, my_num_lm
                 Do i = 1, 2
@@ -485,7 +484,6 @@ Subroutine Post_Solve_FD()
                 Enddo
             Enddo
             Call ctemp%deconstruct('p1a')
-            Call ctemp%deconstruct('p1b')
         Endif
 
     End Subroutine Finalize_EMF

--- a/src/Physics/Sphere_Spectral_Space.F90
+++ b/src/Physics/Sphere_Spectral_Space.F90
@@ -470,6 +470,7 @@ Subroutine Post_Solve_FD()
         Else
             ctemp%nf1a = 1
             Call ctemp%construct('p1a')
+            Call ctemp%construct('p1b')
             ctemp%p1a(:,:,:,:) = 0.0d0
             Do m = 1, my_num_lm
                 Do i = 1, 2
@@ -484,6 +485,7 @@ Subroutine Post_Solve_FD()
                 Enddo
             Enddo
             Call ctemp%deconstruct('p1a')
+            Call ctemp%deconstruct('p1b')
         Endif
 
     End Subroutine Finalize_EMF

--- a/src/Physics/Sphere_Spectral_Space.F90
+++ b/src/Physics/Sphere_Spectral_Space.F90
@@ -34,7 +34,146 @@ Module Sphere_Spectral_Space
     Type(SphericalBuffer) :: ctemp ! workspace
 Contains
 
+Subroutine Post_Solve_FD()	
+		Implicit None
+		Integer :: m, i
+		Character*12 :: tstring, otstring
+		! wsp%p1b is assumed to be allocated
+		Call StopWatch(psolve_time)%startclock()
+		Call wsp%construct('p1a')
+		wsp%config = 'p1a'
 
+		old_deltat = deltat
+		If (new_timestep) Then
+			deltat = new_deltat
+			new_timestep = .false.
+			If (my_rank .eq. 0) Then
+				Write(otstring,t_ofmt)old_deltat
+				Write(tstring,t_ofmt)deltat
+				Call stdout%print(' Timestep has changed from '//Trim(otstring)//' to '//Trim(tstring)//'.')
+                Call stdout%partial_flush()  ! Make SURE that a changing timestep is recorded ...
+                                             ! ... even at the expense of additional file I/O for redirected stdout
+			Endif
+			Call StopWatch(seteq_time)%startclock()
+			Call Reset_Linear_Equations()
+			Call StopWatch(seteq_time)%increment()
+		Endif
+		if (euler_step) then
+				!Euler Step
+				new_ab_factor = deltat
+				old_ab_factor = 0.0d0
+                euler_step = .false.
+		else
+				new_ab_factor = 0.5d0*deltat*(2 + deltat/old_deltat)
+				old_ab_factor = -0.5d0*deltat**2/old_deltat
+		endif
+		wsp%p1b = wsp%p1b*old_ab_factor	
+
+		!Copy each variable out of the RHS into the top part of the buffer
+
+		Call Get_All_RHS(wsp%p1a)
+
+
+		! Now take radial derivatives.  We can automate this further later.
+
+
+		!///////////////////////////////////////////////////////////////////////////	
+		!Load the W derivatives into the appropriate RHS's
+		Call d_by_dx(wvar,d3wdr3,wsp%p1a,3)		! d3wdr3 will be overwritten by dwdr shortly
+		Call Add_Derivative(peq,wvar,3,wsp%p1b,wsp%p1a,d3wdr3)
+
+		Call d_by_dx(wvar,dwdr   ,wsp%p1a,1)		
+		Call d_by_dx(wvar,d2wdr2 ,wsp%p1a,2)    
+
+		Call Add_Derivative(peq,wvar,0,wsp%p1b,wsp%p1a,wvar)	
+		Call Add_Derivative(peq,wvar,1,wsp%p1b,wsp%p1a,dwdr)
+        Call Add_Derivative(peq,wvar,2,wsp%p1b,wsp%p1a,d2wdr2)
+
+		Call Add_Derivative(weq,wvar,0,wsp%p1b,wsp%p1a,wvar)
+	    Call Add_Derivative(weq,wvar,1,wsp%p1b,wsp%p1a,dwdr)
+		Call Add_Derivative(weq,wvar,2,wsp%p1b,wsp%p1a,d2wdr2)
+
+		If (deriv_cluge) Then
+			Call d_by_dx(dwdr,d2wdr2,wsp%p1a,1)	! cluge like in ASH  --- seems unnecessary though.  take out once all else works
+		Endif
+		!//////////////////////////////
+		!  P Terms
+		Call d_by_dx(pvar,dpdr1,wsp%p1a,1)	! dpdr will be overwritten by d2tdr2 shortly
+		Call Add_Derivative(weq,pvar,1,wsp%p1b,wsp%p1a,dpdr1)
+
+        If (output_iteration) Then
+            ! Grab dpdr
+            Call cobuffer%construct('p1a')
+            cobuffer%p1a(:,:,:,dpdr_cb) = wsp%p1a(:,:,:,dpdr1)
+        Endif
+
+		Call Add_Derivative(peq,pvar,0,wsp%p1b,wsp%p1a,pvar)
+
+		!///////////////////////////////
+		! T Terms
+		Call d_by_dx(tvar,d2tdr2,wsp%p1a,2)	! d2tdr2 will be overwritten by dtdr shortly
+		Call Add_Derivative(teq,tvar,2,wsp%p1b,wsp%p1a,d2tdr2)
+
+		Call d_by_dx(tvar,dtdr,wsp%p1a,1)
+		Call Add_Derivative(teq,tvar,1,wsp%p1b,wsp%p1a,dtdr)	
+
+		Call Add_Derivative(teq,tvar,0, wsp%p1b,wsp%p1a,tvar)	
+		Call Add_Derivative(weq,tvar,0, wsp%p1b,wsp%p1a,tvar)	! gravity
+
+
+
+
+		!///////////////////////////////
+		!  Z Terms
+		Call d_by_dx(zvar,d2zdr2,wsp%p1a,2)		! 2nd derivative will be overwritten with dzdr
+		Call Add_Derivative(zeq,zvar,2,wsp%p1b,wsp%p1a,d2zdr2)	
+
+		Call d_by_dx(zvar,dzdr,wsp%p1a,1)	
+
+		Call Add_Derivative(zeq,zvar,0,wsp%p1b,wsp%p1a,zvar)	
+        Call Add_Derivative(zeq,zvar,1,wsp%p1b,wsp%p1a,dzdr)
+
+		If (magnetism) Then
+			!//////////////
+			! A-terms (Toroidal magnetic field)
+			Call d_by_dx(avar,d2adr2,wsp%p1a,2)		! 2nd derivative will be overwritten with dadr
+			Call Add_Derivative(aeq,avar,2,wsp%p1b,wsp%p1a,d2adr2)
+			Call d_by_dx(avar,dadr,wsp%p1a,1)	
+
+			Call Add_Derivative(aeq,avar,0,wsp%p1b,wsp%p1a,avar)
+
+			!///////////////////
+			! C-terms (Poloidal magnetic field)
+			Call d_by_dx(cvar,d2cdr2,wsp%p1a,2)		
+			Call Add_Derivative(ceq,cvar,2,wsp%p1b,wsp%p1a,d2cdr2)
+			Call d_by_dx(cvar,dcdr,wsp%p1a,1)	
+			Call Add_Derivative(ceq,cvar,0,wsp%p1b,wsp%p1a,cvar)
+
+		Endif
+
+		!Load the old ab array into the RHS
+
+		Call Set_All_RHS(wsp%p1b)	! RHS now holds old_AB+CN factors
+
+		Call wsp%deconstruct('p1b')
+		Call StopWatch(psolve_time)%increment()
+
+		Call StopWatch(ctranspose_time)%startclock()
+
+
+        If (output_iteration) Then
+            !Convert p/rho to p
+            ! We already took d/dr(p/rho), so we'll fix that later
+		    Do m = 1, my_num_lm
+			    Do i = 1, 2
+				    wsp%p1a(:,i,m,pvar) = wsp%p1a(:,i,m,pvar)*ref%density(:)
+			    Enddo
+		    Enddo
+            Call cobuffer%reform()
+        Endif
+        Call wsp%reform()
+		Call StopWatch(ctranspose_time)%increment()
+	End Subroutine Post_Solve_FD
 
     Subroutine Post_Solve()
         Implicit None

--- a/tests/unit_tests/SHT/expected_output.out
+++ b/tests/unit_tests/SHT/expected_output.out
@@ -9,7 +9,7 @@
  -- MPI initialized.
 
 
- -- Initalizing Grid...
+ -- Initializing Chebyshev Grid...
  ---- Specified parameters ----
  ---- N_R                 :     48
  ---- N_THETA             :     64


### PR DESCRIPTION
Added all the necessary changes required to run the benchmarks on uniform FD grids when `dr_input` is not specified. When `dr_input` is specified using Fortran-based syntax in the main_input file, Rayleigh can be run with a non-uniform grid. Currently, when the `chebyshev` flag is set to false, finite-difference is activated.  