### PR TITLE
Push to ghcr and build for Apple Silicon

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -23,8 +23,18 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Login to DockerHub
         uses: docker/login-action@v2
@@ -32,15 +42,18 @@ jobs:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_LOGIN }}
 
-      - name: Build and push Docker image for master
+      - name: Build and push Docker image for main
         if: contains(github.event_name, 'push')
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v4
         with:
           context: ./docker/rayleigh/
           cache-from: type=registry,ref=geodynamics/rayleigh-buildenv-jammy
           cache-to: type=inline
+          platforms: linux/amd64,linux/arm64
           push: true
-          tags: geodynamics/rayleigh:latest
+          tags: |
+            ghcr.io/${{ github.repository }}:latest
+            ${{ github.repository }}:latest
 
       - name: Build and push Docker image for release
         if: contains(github.event_name, 'release')
@@ -49,6 +62,8 @@ jobs:
           context: ./docker/rayleigh/
           cache-from: type=registry,ref=geodynamics/rayleigh-buildenv-jammy
           cache-to: type=inline
+          platforms: linux/amd64,linux/arm64
           push: true
-          tags: geodynamics/rayleigh:${{github.ref_name}}
-
+          tags: |
+            ghcr.io/${{ github.repository }}:${{github.ref_name}}
+            ${{ github.repository }}:${{github.ref_name}}


### PR DESCRIPTION
This PR makes two changes to building the rayleigh docker container:
1. It builds a multi architecture image for amd64 (all usual systems) and arm64 (closer to current Apple systems). Using docker will automatically download the best image for the current system.
2. It pushes the image not just to docker hub, but also to Github Container Registry (ghcr.io). This just provides the image in another location. Docker Hub has been a bit unreliable in the past and we are adding GHCR as back up for CIG packages.