### PR TITLE
Report the diff between expected and actual test report

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,7 +22,7 @@ jobs:
     container: geodynamics/rayleigh-buildenv-jammy
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
     - name: Build documentation
       # First make sure notebooks do not contain output, then build doc
       run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -78,7 +78,7 @@ jobs:
       uses: actions/upload-artifact@v2
       with:
           name: changes-unit-tests.diff
-          path: $GITHUB_WORKSPACE/tests/unit_tests/SHT/changes.diff
+          path: tests/unit_tests/SHT/changes.diff
 
   conda:
     name: conda-build
@@ -95,7 +95,7 @@ jobs:
         shell: bash -l {0}
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: conda-incubator/setup-miniconda@v2
       with:
         activate-environment: radev

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -60,6 +60,12 @@ jobs:
         git diff > changes.diff
         git diff --exit-code --name-only
 
+    - name: archive results
+      uses: actions/upload-artifact@v2
+      with:
+          name: changes-tests.diff
+          path: changes.diff
+
     - name: Unit Tests
       run: |
         cd "$GITHUB_WORKSPACE"/tests/unit_tests/SHT
@@ -67,6 +73,12 @@ jobs:
 
         git diff > changes.diff
         git diff --exit-code --name-only
+
+    - name: archive results
+      uses: actions/upload-artifact@v2
+      with:
+          name: changes-unit-tests.diff
+          path: $GITHUB_WORKSPACE/tests/unit_tests/SHT/changes.diff
 
   conda:
     name: conda-build


### PR DESCRIPTION
I noticed that our CI does store the diff between expected and actual test results, but it never uploads them to the github page. This change makes it so that users can download the diff file to investigate exactly what went wrong in the test.