### PR TITLE
Updated scipy to version 1.10 (from 1.6).

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -13,7 +13,7 @@ dependencies:
   - git=2.30
   - matplotlib=3.4
   - jupyter=1.0
-  - scipy=1.6
+  - scipy=1.10
   - sphinx=4.0
   - sphinxcontrib-bibtex=2.2
   - nbsphinx=0.8

--- a/environment_doc.yml
+++ b/environment_doc.yml
@@ -10,7 +10,7 @@ dependencies:
   - python=3.9
   - matplotlib=3.4
   - jupyter=1.0
-  - scipy=1.6
+  - scipy=1.10
   - sphinx=4.0
   - sphinxcontrib-bibtex=2.2
   - nbsphinx=0.8


### PR DESCRIPTION
This PR updates the version of scipy specified by the conda environment files.   The FFT interface has changed since 1.6 and was creating conflicts with an upcoming PR.