### PR TITLE
put c_8 into mm and pp enth_flux, dt_by_dp

### DIFF
--- a/src/Diagnostics/Diagnostics_Thermal_Equation.F90
+++ b/src/Diagnostics/Diagnostics_Thermal_Equation.F90
@@ -641,7 +641,7 @@ Contains
             Do t = my_theta%min, my_theta%max
                 Do r = my_r%min, my_r%max
                     dt_by_ds = ref%temperature(r)/pressure_specific_heat
-                    dt_by_dp = 1.0d0/pressure_specific_heat/ref%density(r)
+                    dt_by_dp = 1.0d0/pressure_specific_heat/ref%density(r)*ra_constants(8)
                     Do k = 1, n_phi
                         tmp1(PSI) = pressure_specific_heat*ref%density(r) * &
                             (dt_by_ds*fbuffer(PSI,tvar) + dt_by_dp*fbuffer(PSI,pvar))
@@ -677,7 +677,7 @@ Contains
             Do t = my_theta%min, my_theta%max
                 Do r = my_r%min, my_r%max
                     dt_by_ds = ref%temperature(r)/pressure_specific_heat
-                    dt_by_dp = 1.0d0/pressure_specific_heat/ref%density(r)
+                    dt_by_dp = 1.0d0/pressure_specific_heat/ref%density(r)*ra_constants(8)
                     Do k = 1, n_phi
                         tmp1(PSI) = pressure_specific_heat*ref%density(r) * &
                             (dt_by_ds*m0_values(PSI2,tvar) + dt_by_dp*m0_values(PSI2,pvar))
@@ -713,7 +713,7 @@ Contains
             Do t = my_theta%min, my_theta%max
                 Do r = my_r%min, my_r%max
                     dt_by_ds = ref%temperature(r)/pressure_specific_heat
-                    dt_by_dp = 1.0d0/pressure_specific_heat/ref%density(r)
+                    dt_by_dp = 1.0d0/pressure_specific_heat/ref%density(r)*ra_constants(8)
                     Do k = 1, n_phi
                         tmp1(PSI) = pressure_specific_heat*ref%density(r) * &
                             (dt_by_ds*fbuffer(PSI,tvar) + dt_by_dp*fbuffer(PSI,pvar))
@@ -749,7 +749,7 @@ Contains
             Do t = my_theta%min, my_theta%max
                 Do r = my_r%min, my_r%max
                     dt_by_ds = ref%temperature(r)/pressure_specific_heat
-                    dt_by_dp = 1.0d0/pressure_specific_heat/ref%density(r)
+                    dt_by_dp = 1.0d0/pressure_specific_heat/ref%density(r)*ra_constants(8)
                     Do k = 1, n_phi
                         tmp1(PSI) = pressure_specific_heat*ref%density(r) * &
                             (dt_by_ds*m0_values(PSI2,tvar) + dt_by_dp*m0_values(PSI2,pvar))


### PR DESCRIPTION
I believe the current calculation of enthalpy flux is inconsistent between the total flux and Reynolds decomposition (there is a missing c_8 in definition of dt_by_dp). I think it only affects non-dimensional cases, not the dimensional one (since they're c_8 = 1). This pull request should fix things. 