### PR TITLE
Adding CI Test for Finite-Difference Scheme (uniform grid)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,7 +42,12 @@ jobs:
         make install
     - name: Test
       run: |
+        #Primary test (Chebyshev Mode)
         cd "$GITHUB_WORKSPACE"/tests/c2001_case0
+        mpirun -np 4 ../../bin/rayleigh.dbg
+
+        # Finite-difference test (uniform grid)
+        cd "$GITHUB_WORKSPACE"/tests/c2001_case0_FD_uniform
         mpirun -np 4 ../../bin/rayleigh.dbg
 
         # Generic input test

--- a/tests/c2001_case0_FD_uniform/Benchmark_Reports/00000400
+++ b/tests/c2001_case0_FD_uniform/Benchmark_Reports/00000400
@@ -1,0 +1,20 @@
+ ///////////////////////////////////////////////////////////////////////////
+               RAYLEIGH ACCURACY BENCHMARK SUMMARY               
+  
+   Benchmark:  Christensen et al. 2001  (Non-MHD, Case 0)
+  
+   Radial Resolution      N_R =           48
+   Angular Resolution N_theta =           64
+  
+   Averaging Interval (Viscous Diffusion Times) :       0.030000
+  
+   Beginning Iteration :          100
+   Ending Iteration    :          400
+   Number of Samples   :            4
+ ----------------------------------------------------------------------------
+   Observable      |    Measured    | Suggested   | % Difference |  Std. Dev.
+ ----------------------------------------------------------------------------
+   Kinetic Energy  :     28.301141     58.348000    -51.495953     13.514207
+   Temperature     :      0.341681      0.428120    -20.190460      0.027911
+   Vphi            :     -6.129535    -10.157100    -39.652707      2.190392
+   Drift Frequency :     11.914373      0.182400   6432.002964      3.873469

--- a/tests/c2001_case0_FD_uniform/main_input
+++ b/tests/c2001_case0_FD_uniform/main_input
@@ -1,0 +1,66 @@
+! This is a smaller and faster version of the
+! input_examples/benchmark_diagnostics_input model. The output of the model is
+! not yet in steady-state, but only used as a regression test. Whenever
+! something changes the functionality of tthe code, it will hopefully affect
+! the results of this benchmark.
+
+&problemsize_namelist
+ n_r = 48
+ n_theta = 64
+ nprow = 2
+ npcol = 2
+ aspect_ratio = 0.35d0
+ shell_depth = 1.0d0
+/
+&numerical_controls_namelist
+ chebyshev=.false.
+/
+&physical_controls_namelist
+ benchmark_mode = 1
+ benchmark_integration_interval = 100
+ benchmark_report_interval = 400
+ rotation  = .True.
+ magnetism = .false.
+ viscous_heating = .false.
+ ohmic_heating = .false.
+/
+&temporal_controls_namelist
+ max_time_step = 1.0d-4
+ max_iterations = 400
+ checkpoint_interval = 100000
+ cflmin = 0.4d0
+ cflmax = 0.6d0
+/
+&io_controls_namelist
+/
+&output_namelist
+/
+
+&Boundary_Conditions_Namelist
+no_slip_boundaries = .true.
+strict_L_Conservation = .false.
+dtdr_bottom = 0.0d0
+T_Top    = 0.0d0
+T_Bottom = 1.0d0
+fix_tvar_top = .true.
+fix_tvar_bottom = .true.
+/
+&Initial_Conditions_Namelist
+init_type = 1    ! Benchmark init
+temp_amp = 1.0d1
+temp_w = 0.01d4
+restart_iter = -1
+/
+&Test_Namelist
+/
+&Reference_Namelist
+Ekman_Number = 1.0d-3
+Rayleigh_Number = 1.0d5
+Prandtl_Number = 1.0d0
+Magnetic_Prandtl_Number = 5.0d0
+reference_type = 1
+heating_type = 0      ! No heating
+gravity_power = 1.0d0  ! g ~ radius
+/
+&Transport_Namelist
+/


### PR DESCRIPTION
This adds an initial test for the new FD functionality when applied to a uniform grid.  It is otherwise the same test and input file used for Chebyshev mode.