### PR TITLE
Initial conditions using checkpoint files added to user supplied files

### DIFF
--- a/src/Math_Layer/Linear_Solve.F90
+++ b/src/Math_Layer/Linear_Solve.F90
@@ -641,6 +641,29 @@ Module Linear_Solve
         Endif
     End Subroutine Set_RHS
 
+    Subroutine Get_RHS(eqid,get_from)
+        ! Set the RHS of equation eqid to the value of set_to
+        Implicit None
+        Real*8, Intent(InOut) :: get_from(:,:,:)
+        Integer, Intent(In) :: eqid
+        Integer :: istart,iend, ind
+
+
+        If (n_modes .gt. 0) Then
+            !Primary equation object always has the full, allocated rhs.
+            ind = eqid
+            if (.not. equation_set(1,eqid)%primary) then
+                ind = equation_set(1,eqid)%links(1)
+            endif
+            ! Individual RHS's inhabit row ranges defined by rowblock and ndim1
+            istart = equation_set(1,eqid)%rowblock+1
+            iend = istart+ndim1-1
+
+
+            get_from(1:ndim1,:,:)=equation_set(1,ind)%rhs(istart:iend,:,:)
+        Endif
+    End Subroutine Get_RHS
+
     Subroutine Zero_RHS(eqid)
         ! Set the RHS of equation eqid to zero
         ! This is useful for when we want to remove explicity time-dependence

--- a/src/Physics/Initial_Conditions.F90
+++ b/src/Physics/Initial_Conditions.F90
@@ -113,7 +113,6 @@ Contains
         ! The equation set RHS's stays allocated throughout - it is effectively how we save the AB terms.
         Call Allocate_RHS(zero_rhs=.true.)
 
-
         !////////////////////////////////////////
         ! Read in checkpoint files as appropriate
         If (init_type .eq. -1) Then
@@ -127,36 +126,23 @@ Contains
             Endif
         Endif
         
+        ! Take care of IC's that require reading from a checkpoint (if init_type and magnetic_init_type = -1)
+        ! If (init_type or/and magnetic_init_type = -2), read the checkpoint and add a user defined field to it for IC
         If ( (init_type .lt. 0) .or. ( magnetism .and. (magnetic_init_type .lt. 0) ) ) Then
             Call restart_from_checkpoint(restart_iter)
-             print*,'Init type < 0; Restarting from Checkpoint'
-            ! Bhishek
             If (init_type .eq. -2) Then
-               ! Add entropy perturbation
-               print*,'Adding Entropy perturbation file'
+                If (my_rank .eq. 0) Then
+                    Call stdout%print(" ---- Hydro Init Type    : ADD USER FILE TO CHECKPOINT ")
+                Endif
                Call add_to_field(tvar, t_init_file)
             Endif
             If (magnetic_init_type .eq. -2) Then
-               print*,'Adding poloidal and toroidal componets to a checkpoint'
+                If (my_rank .eq. 0) Then
+                    Call stdout%print(" ---- Magnetic Init Type : ADD USER FILE TO CHECKPOINT ")
+                Endif
                Call add_to_field(cvar, c_init_file)
                Call add_to_field(avar, a_init_file)
             Endif
-            ! Bhishek
-        Endif
-
-        !NICK
-        If (init_type .eq. -2) Then
-            print*, 'Init type -2; Restart with checkpoint'
-            !Call restart_from_checkpoint(restart_iter)
-            ! Add entropy perturbation
-            print*,'Init type -2; Adding Entropy perturbation file'
-            Call add_to_field(tvar, t_init_file)
-        Endif
-
-        If (magnetic_init_type .eq. -2) Then
-            ! Add A and C perturbations
-            Call add_to_field(cvar, c_init_file)
-            Call add_to_field(avar, a_init_file)
         Endif
 
         !////////////////////////////////////
@@ -659,17 +645,12 @@ Contains
         Integer :: fcount(3,2)
         Type(SphericalBuffer) :: tempfield, tempfield2
         fcount(:,:) = 1
-        print*,'Success 1'
         call tempfield%init(field_count = fcount, config = 'p1b')
-        print*,'Success 2'
         call tempfield%construct('p1b')
-        print*,'Success 3'
         call tempfield2%init(field_count = fcount, config = 'p1b')
         call tempfield2%construct('p1b')
-        print*,'Success 4'
 
         call get_rhs(field_index,tempfield2%p1b(:,:,:,1))
-        print*,'Success 5'
 
         if (trim(field_file) .ne. '__nothing__') then
             call read_input(field_file, 1, tempfield)


### PR DESCRIPTION
The default initial conditions type in Rayleigh allow reading from a checkpoint file (init_type = -1 for thermal and velocity fields, magnetic_init_type = -2 for magnetic fields). Modifications made in this request allow for new IC's:

1.  init_type = -2 reads checkpoint file as well as a user-supplied entropy profile. The sum total of these two is the new IC. 
2. magnetic_init_type = -2 reads checkpoint file and user-supplied profiles of toroidal and poloidal field components. The sum total of checkpoint file and user-supplied profiles is the new IC. 

An additional subroutine Get_RHS is added to src/Math_Layer/Linear_Solve.F90. 