### PR TITLE
ref%dsdr should now be scalable by constant c_11

### DIFF
--- a/doc/source/User_Guide/physics_math_overview.rst
+++ b/doc/source/User_Guide/physics_math_overview.rst
@@ -147,7 +147,7 @@ respectively. The evolution of :math:`\Theta` is described by
 .. math::
    :label: theta_evol
 
-   \mathrm{f}_1(r)\,\mathrm{f}_4(r)\left[\frac{\partial \Theta}{\partial t}  + \boldsymbol{v}\cdot\boldsymbol{\nabla}\Theta + \mathrm{f}_{14}(r)v_r\right] =\
+   \mathrm{f}_1(r)\,\mathrm{f}_4(r)\left[\frac{\partial \Theta}{\partial t}  + \boldsymbol{v}\cdot\boldsymbol{\nabla}\Theta + c_{11}\,\mathrm{f}_{14}(r)v_r\right] =\
        c_6\,\boldsymbol{\nabla}\cdot\left[\mathrm{f}_1(r)\,\mathrm{f}_4(r)\,\mathrm{f}_5(r)\,\boldsymbol{\nabla}\Theta \right] \\
         +\ c_{10}\,\mathrm{f}_6(r)
         + c_8\,\Phi(r,\theta,\phi)
@@ -235,7 +235,8 @@ assigning the following to the functions :math:`\mathrm{f}_i(r)` and the constan
    \mathrm{f}_7(r) &\rightarrow \tilde{\eta}(r)\; &c_7 &\rightarrow \frac{1}{Pm} \\
     &\vdots &c_8&\rightarrow 0\\ 
     &\vdots &c_9&\rightarrow 0 \\
-    \mathrm{f}_{14}(r)&\rightarrow 0\; &c_{10}&\rightarrow 0.\end{aligned}
+    &\vdots &c_{10}&\rightarrow 0 \\
+    \mathrm{f}_{14}(r)&\rightarrow 0\; &c_{11}&\rightarrow 0.\end{aligned}
 
 Here the tildes denote nondimensional radial profiles, e.g., :math:`\tilde{\nu}(r) = \nu(r)/\nu_o`. 
 
@@ -296,7 +297,8 @@ When run in dimensional, anelastic mode (cgs units; **reference_type=2**
        \mathrm{f}_7(r) &\rightarrow \eta(r)\; &c_7 &\rightarrow 1 \\
        &\vdots &c_8&\rightarrow 1\\ 
        &\vdots &c_9&\rightarrow \frac{1}{4\pi} \\
-       \mathrm{f}_{14}(r)&\rightarrow \frac{d\hat{S}}{dr }&c_{10}&\rightarrow L_*.\end{aligned}
+       &\vdots &c_{10}&\rightarrow L_* \\
+       \mathrm{f}_{14}(r)&\rightarrow \frac{d\hat{S}}{dr }&c_{11}&\rightarrow 1.\end{aligned}
 
 Here :math:`\hat{\rho}(r)`, :math:`\hat{T}(r)`, and :math:`d\hat{S}/dr` are the spherically symmetric, time-independent reference-state
 density, temperature, and entropy gradient, respectively. The thermal variables satisfy the
@@ -392,7 +394,8 @@ choices result in the functions :math:`\mathrm{f}_i` and the constants
        \mathrm{f}_7(r) &\rightarrow \tilde{\eta}(r) \; &c_7 &\rightarrow \frac{\mathrm{E}}{\mathrm{Pm}} \\
        &\vdots &c_8&\rightarrow \frac{\mathrm{E}\,\mathrm{Di}}{\mathrm{Ra}^*}\\ 
        &\vdots &c_9&\rightarrow  \frac{\mathrm{E}^2\,\mathrm{Di}}{\mathrm{Pm}^2\mathrm{Ra}^*}\\
-       \mathrm{f}_{14}(r)&\rightarrow \frac{d\tilde{S}}{dr }&c_{10}&\rightarrow L_*.\end{aligned}
+       &\vdots &c_{10}&\rightarrow L_* \\
+       \mathrm{f}_{14}(r)&\rightarrow 0&c_{11}&\rightarrow 0.\end{aligned}
 
 As in the Boussinesq case, the nondimensional diffusivities are defined according to, e.g., :math:`\tilde{\nu}(r) \equiv \nu(r)/\nu_o`. The nondimensional heating :math:`\tilde{Q}(r)` is defined such that its volume integral equals the nondimensional **luminosity** or **heating_integral** set in the *main_input* file. As in the dimensional anelastic case, the volume integral of :math:`\mathrm{f}_6(r)` equals unity, and :math:`\mathrm{c}_{10} = L_*`. The unit for luminosity in this nondimensionalization (to get a dimensional luminosity from the nondimensional :math:`L_*`) is :math:`\rho_oL^3T_o\Delta s\Omega_0`. 
 
@@ -428,7 +431,7 @@ We thus arrive at the following nondimensionalized equations:
         + \mathrm{E}\boldsymbol{\nabla}\cdot\boldsymbol{\mathcal{D}}\\
        %
        %
-       \tilde{\rho}(r)\,\tilde{T}(r)\left[\frac{\partial \Theta}{\partial t} + \boldsymbol{v}\cdot\boldsymbol{\nabla}\Theta + v_r\frac{d\hat{S}}{dr}\right] =\;
+       \tilde{\rho}(r)\,\tilde{T}(r)\left[\frac{\partial \Theta}{\partial t} + \boldsymbol{v}\cdot\boldsymbol{\nabla}\Theta\right] =\;
        &\frac{\mathrm{E}}{\mathrm{Pr}}\boldsymbol{\nabla}\cdot\left[\tilde{\kappa}(r)\tilde{\rho}(r)\,\tilde{T}(r)\,\boldsymbol{\nabla}\Theta \right] % diffusion
        + \tilde{Q}(r)   % Internal heating
        \\

--- a/src/Physics/PDE_Coefficients.F90
+++ b/src/Physics/PDE_Coefficients.F90
@@ -254,7 +254,7 @@ Contains
     Subroutine Allocate_Reference_State
         Implicit None
 
-        n_ra_constants = 10 + 2*(n_active_scalars + n_passive_scalars)
+        n_ra_constants = 11 + 2*(n_active_scalars + n_passive_scalars)
         n_ra_functions = 14 + 2*(n_active_scalars + n_passive_scalars)
 
         Allocate(ref%density(1:N_R))
@@ -1196,7 +1196,7 @@ Contains
         ref%Lorentz_Coeff = ra_constants(4)
         ref%ohmic_amp(:) = ra_constants(9)/(ref%density(:)*ref%temperature(:))
 
-        ref%dsdr(:)     = ra_functions(:,14)
+        ref%dsdr(:)     = ra_constants(11)*ra_functions(:,14)
 
     End Subroutine Get_Custom_Reference
 
@@ -1680,12 +1680,12 @@ Contains
         do i = 1, n_active_scalars
           Call Initialize_Diffusivity(kappa_chi_a(i,:),dlnkappa_chi_a(i,:),&
                                       kappa_chi_a_top(i),kappa_chi_a_type(i),kappa_chi_a_power(i),&
-                                      11+(i-1)*2,15+(i-1)*2,16+(i-1)*2)
+                                      12+(i-1)*2,15+(i-1)*2,16+(i-1)*2)
         end do
         do i = 1, n_passive_scalars
           Call Initialize_Diffusivity(kappa_chi_p(i,:),dlnkappa_chi_p(i,:),&
                                       kappa_chi_p_top(i),kappa_chi_p_type(i),kappa_chi_p_power(i),&
-                                      11+(n_active_scalars+i-1)*2,15+(n_active_scalars+i-1)*2,16+(n_active_scalars+i-1)*2)
+                                      12+(n_active_scalars+i-1)*2,15+(n_active_scalars+i-1)*2,16+(n_active_scalars+i-1)*2)
         end do
 
         If (viscous_heating) Then
@@ -1723,7 +1723,7 @@ Contains
               If (kappa_chi_a_type(i+1) .eq. 3) Then
                   temp_functions(:,15+i*2) = ra_functions(:,15+i*2)
                   temp_functions(:,16+i*2) = ra_functions(:,16+i*2)
-                  temp_constants(11+i*2)   = ra_constants(11+i*2)
+                  temp_constants(12+i*2)   = ra_constants(12+i*2)
               Endif
             end do
 
@@ -1731,7 +1731,7 @@ Contains
               If (kappa_chi_p_type(i+1) .eq. 3) Then
                   temp_functions(:,15+(n_active_scalars+i)*2) = ra_functions(:,15+(n_active_scalars+i)*2)
                   temp_functions(:,16+(n_active_scalars+i)*2) = ra_functions(:,16+(n_active_scalars+i)*2)
-                  temp_constants(11+(n_active_scalars+i)*2)   = ra_constants(11+(n_active_scalars+i)*2)
+                  temp_constants(12+(n_active_scalars+i)*2)   = ra_constants(12+(n_active_scalars+i)*2)
               Endif
             end do
 
@@ -1964,6 +1964,15 @@ Contains
         ra_constants(4) = ref%Lorentz_Coeff
         ra_constants(8) = ref%viscous_amp(1)*ref%temperature(1)/2.0d0
         ra_constants(9) = ref%ohmic_amp(1)*ref%density(1)*ref%temperature(1)
+        Select Case(reference_type)
+            Case(1,2)
+                ra_constants(11) = 0.0d0
+            Case(3)
+                ra_constants(11) = 1.0d0
+            Case(5)
+                ra_constants(11) = Prandtl_Number*Buoyancy_Number_Visc/Rayleigh_Number
+        End Select
+
 
         ra_functions(:,1) = ref%density
         ra_functions(:,4) = ref%temperature
@@ -2034,13 +2043,13 @@ Contains
         Endif ! if no magnetism, all of the above are already zero
 
         Do i = 1, n_active_scalars
-            ra_constants(11+(i-1)*2) = kappa_chi_a_norm(i)
+            ra_constants(12+(i-1)*2) = kappa_chi_a_norm(i)
             ra_functions(:,15+(i-1)*2) = kappa_chi_a(i,:)/kappa_chi_a_norm(i)
             ra_functions(:,16+(i-1)*2) = dlnkappa_chi_a(i,:)
         Enddo
 
         Do i = 1, n_passive_scalars
-            ra_constants(11+(n_active_scalars+i-1)*2) = kappa_chi_p_norm(i)
+            ra_constants(12+(n_active_scalars+i-1)*2) = kappa_chi_p_norm(i)
             ra_functions(:,15+(n_active_scalars+i-1)*2) = kappa_chi_p(i,:)/kappa_chi_p_norm(i)
             ra_functions(:,16+(n_active_scalars+i-1)*2) = dlnkappa_chi_p(i,:)
         Enddo

--- a/src/Physics/PDE_Coefficients.F90
+++ b/src/Physics/PDE_Coefficients.F90
@@ -1249,7 +1249,6 @@ Contains
 
         cset(:) = 0
         input_constants(:) = 0.0d0
-        ra_constants(11) = 1.0d0 ! this should be 1 by default (not 0)
 
         
         ref_file = Trim(my_path)//filename
@@ -1281,11 +1280,17 @@ Contains
             Read(15) eqversion
             If (eqversion .eq. 1) Then
                 !Read(15) cset(1:n_ra_constants-1) ! c_11 didn't exist yet
-                Read(15) cset(1:10) ! equation_coefficients couldn't write the custom active/passive scalar constants yet
+                Read(15) cset(1:10) ! equation_coefficients couldn't write the custom active/passive scalar constants yet, and c_11 didn't exist yet
+                Read(15) fset(1:n_ra_functions)                
                 Read(15) input_constants(1:10)
+                cset(11) = 1 ! treat this as if c_11 = 1 was specified in the custom reference file
+                input_constants(11) = 1.0d0 
+                If (my_rank .eq. 0) Call stdout%print('got here')
             Else
                 Read(15) cset(1:n_ra_constants)
+                Read(15) fset(1:n_ra_functions) 
                 Read(15) input_constants(1:n_ra_constants)
+                Call stdout%print('actualy got here')
             Endif
             
             ! Cset(i) is 1 if a constant(i) was set; it is 0 otherwise.


### PR DESCRIPTION
All terms in the PDEs have constants out front that can scale the terms, except for the reference entropy advection term f_14. This pull request would insert a new constant (c_11) that can scale ref%dsdr in the custom framework and takes on an appropriate value for the other reference_type's. 