### PR TITLE
Provide support for the mpi_f08 module

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,6 +18,9 @@ env:
 jobs:
   test:
     name: linux-jammy-container-build
+    strategy:
+      matrix:
+        mpi: ["", --mpi-f08, --mpi-f77 --FFLAGS=-fallow-argument-mismatch]
     runs-on: [ubuntu-latest]
     container: geodynamics/rayleigh-buildenv-jammy
 
@@ -35,7 +38,7 @@ jobs:
     - name: Build Rayleigh
       # Now build Rayleigh itself
       run: |
-        ./configure -debian-mkl --FFLAGS_DBG='-O0 -g -fbounds-check -ffpe-trap=invalid,zero,overflow -fbacktrace -ffixed-line-length-132 -Wall'
+        ./configure -debian-mkl ${{ matrix.mpi }} --FFLAGS_DBG='-O0 -g -fbounds-check -ffpe-trap=invalid,zero,overflow -fbacktrace -ffixed-line-length-132 -Wall'
 
         make fdeps && git diff --exit-code
         make -j

--- a/configure
+++ b/configure
@@ -221,6 +221,12 @@ function displayhelp {
     echo "      match the one used to compile MPI."
     echo ""
 
+    echo "  --mpi-f08 ; -mpi-f08:"
+    echo "      Set this flag to use the newer Fortran 2008 MPI module."
+    echo "      This needs to be supported by the MPI install."
+    echo "      It may help with compiler errors due to type mismatches."
+    echo ""
+
     echo "  --prefix=<RAYLEIGH PREFIX>: "
     echo "      Specifies the directory in which to place Rayleigh's executables"
     echo "      when "make install" is run.  By default, executables are placed in"
@@ -429,6 +435,10 @@ do
       USEMPIF77="TRUE";
       ;;
 
+    --mpi-f08 | -mpi-f08 )
+      USEMPIF08="TRUE";
+      ;;
+
     --with-lapack=*)
       LPROOT=`expr "x$option" : "x-*with-lapack=\(.*\)"`;
       ;;
@@ -548,6 +558,12 @@ else
   then
           OPT_FLAGS="$OPT_FLAGS -DUSE_MPI_F77_BINDINGS"
           DBG_FLAGS="$DBG_FLAGS -DUSE_MPI_F77_BINDINGS"
+  fi
+
+  if [ "$USEMPIF08" == "TRUE" ]
+  then
+          OPT_FLAGS="$OPT_FLAGS -DUSE_MPI_F08_BINDINGS"
+          DBG_FLAGS="$DBG_FLAGS -DUSE_MPI_F08_BINDINGS"
   fi
 
   if [ $FVERSION == "INTEL" ]

--- a/src/IO/Parallel_IO.F90
+++ b/src/IO/Parallel_IO.F90
@@ -1588,7 +1588,7 @@ Contains
                             bdisp = self%buffer_disp(j)
                             Call MPI_File_Seek( funit, fdisp, MPI_SEEK_SET, ierr) 
                             Call MPI_FILE_WRITE(funit, self%buffer(bdisp), & 
-                                self%buffsize, MPI_DOUBLE_PRECISION, MPI_STATUS_IGNORE, ierr)
+                                self%buffsize, MPI_REAL8, MPI_STATUS_IGNORE, ierr)
                         Endif
 
                     Endif
@@ -1604,7 +1604,7 @@ Contains
                             bdisp = 1+self%buffsize*self%nvals*(j-1)
                             Call MPI_File_Seek( funit, fdisp, MPI_SEEK_SET, ierr) 
                             Call MPI_FILE_WRITE(funit, self%buffer(bdisp), & 
-                                self%buffsize*self%nvals, MPI_DOUBLE_PRECISION, MPI_STATUS_IGNORE, ierr)
+                                self%buffsize*self%nvals, MPI_REAL8, MPI_STATUS_IGNORE, ierr)
                         Enddo
                     Endif
                 Endif
@@ -1619,7 +1619,7 @@ Contains
                     Call MPI_File_Seek(funit,tdisp,MPI_SEEK_SET,ierr)
 
                     Call MPI_FILE_WRITE(funit, self%time(j), 1, & 
-                           MPI_DOUBLE_PRECISION, MPI_STATUS_IGNORE, ierr)
+                           MPI_REAL8, MPI_STATUS_IGNORE, ierr)
 
                     Call MPI_FILE_WRITE(funit, self%iter(j), 1, & 
                            MPI_INTEGER, MPI_STATUS_IGNORE, ierr)
@@ -1686,7 +1686,7 @@ Contains
                     fdisp = self%file_disp_in(j)+hdisp
                     Call MPI_File_Seek( funit, fdisp, MPI_SEEK_SET, ierr) 
                     Call MPI_FILE_READ(funit, self%buffer(1), & 
-                        self%in_buffer_size, MPI_DOUBLE_PRECISION, MPI_STATUS_IGNORE, ierr)
+                        self%in_buffer_size, MPI_REAL8, MPI_STATUS_IGNORE, ierr)
                 Endif
                 Call self%distribute_data(j)
             Enddo

--- a/src/IO/Parallel_IO.F90
+++ b/src/IO/Parallel_IO.F90
@@ -1543,7 +1543,6 @@ Contains
         Logical :: error
         Integer(kind=MPI_OFFSET_KIND), Intent(In), Optional :: disp
         Integer(kind=MPI_OFFSET_KIND) :: hdisp, tdisp, fdisp, bdisp
-        Integer :: mstatus(MPI_STATUS_SIZE)
 
         ! A baseline displacement within the file can be passed to this routine.
         ! Can be due to header and/or multiple prior records.
@@ -1589,7 +1588,7 @@ Contains
                             bdisp = self%buffer_disp(j)
                             Call MPI_File_Seek( funit, fdisp, MPI_SEEK_SET, ierr) 
                             Call MPI_FILE_WRITE(funit, self%buffer(bdisp), & 
-                                self%buffsize, MPI_DOUBLE_PRECISION, mstatus, ierr)
+                                self%buffsize, MPI_DOUBLE_PRECISION, MPI_STATUS_IGNORE, ierr)
                         Endif
 
                     Endif
@@ -1605,7 +1604,7 @@ Contains
                             bdisp = 1+self%buffsize*self%nvals*(j-1)
                             Call MPI_File_Seek( funit, fdisp, MPI_SEEK_SET, ierr) 
                             Call MPI_FILE_WRITE(funit, self%buffer(bdisp), & 
-                                self%buffsize*self%nvals, MPI_DOUBLE_PRECISION, mstatus, ierr)
+                                self%buffsize*self%nvals, MPI_DOUBLE_PRECISION, MPI_STATUS_IGNORE, ierr)
                         Enddo
                     Endif
                 Endif
@@ -1620,10 +1619,10 @@ Contains
                     Call MPI_File_Seek(funit,tdisp,MPI_SEEK_SET,ierr)
 
                     Call MPI_FILE_WRITE(funit, self%time(j), 1, & 
-                           MPI_DOUBLE_PRECISION, mstatus, ierr)
+                           MPI_DOUBLE_PRECISION, MPI_STATUS_IGNORE, ierr)
 
                     Call MPI_FILE_WRITE(funit, self%iter(j), 1, & 
-                           MPI_INTEGER, mstatus, ierr)
+                           MPI_INTEGER, MPI_STATUS_IGNORE, ierr)
                 Enddo
             Endif    
 
@@ -1647,7 +1646,6 @@ Contains
         Logical :: error
         Integer(kind=MPI_OFFSET_KIND), Intent(In), Optional :: disp
         Integer(kind=MPI_OFFSET_KIND) :: hdisp, fdisp
-        Integer :: mstatus(MPI_STATUS_SIZE)
 
         ! Read data (Checkpoints/Generic I/O)
 
@@ -1688,7 +1686,7 @@ Contains
                     fdisp = self%file_disp_in(j)+hdisp
                     Call MPI_File_Seek( funit, fdisp, MPI_SEEK_SET, ierr) 
                     Call MPI_FILE_READ(funit, self%buffer(1), & 
-                        self%in_buffer_size, MPI_DOUBLE_PRECISION, mstatus, ierr)
+                        self%in_buffer_size, MPI_DOUBLE_PRECISION, MPI_STATUS_IGNORE, ierr)
                 Endif
                 Call self%distribute_data(j)
             Enddo

--- a/src/IO/Parallel_IO.F90
+++ b/src/IO/Parallel_IO.F90
@@ -1249,7 +1249,11 @@ Contains
         Implicit None
         Class(io_buffer) :: self
         Integer :: p, n, nn, rstart, rend,  nrirq, nsirq
+#ifdef USE_MPI_F08_BINDINGS
+        Type(MPI_Request), Allocatable :: rirqs(:), sirqs(:)
+#else
         Integer, Allocatable :: rirqs(:), sirqs(:)
+#endif
         Integer :: inds(4)
         Integer :: my_nm
 
@@ -1360,7 +1364,11 @@ Contains
         Class(io_buffer) :: self
         Integer, Intent(In) :: cache_ind
         Integer :: p, n, nn, rstart, rend,  nrirq, nsirq
+#ifdef USE_MPI_F08_BINDINGS
+        Type(MPI_Request), Allocatable :: rirqs(:), sirqs(:)
+#else
         Integer, Allocatable :: rirqs(:), sirqs(:)
+#endif
         Integer :: inds(4)
         Integer :: ncache
 
@@ -1537,9 +1545,15 @@ Contains
     Subroutine Write_Data(self,disp,file_unit,filename)
         Implicit None
         Class(io_buffer) :: self
-        Integer, Intent(In), Optional :: file_unit
         Character*120, Intent(In), Optional :: filename
-        Integer :: funit, ierr, j
+        Integer :: ierr, j
+#ifdef USE_MPI_F08_BINDINGS
+        Type(MPI_File), Intent(In), Optional :: file_unit
+        Type(MPI_File) :: funit
+#else
+        Integer, Intent(In), Optional :: file_unit
+        Integer :: funit
+#endif
         Logical :: error
         Integer(kind=MPI_OFFSET_KIND), Intent(In), Optional :: disp
         Integer(kind=MPI_OFFSET_KIND) :: hdisp, tdisp, fdisp, bdisp
@@ -1640,9 +1654,15 @@ Contains
     Subroutine Read_Data(self,disp,file_unit,filename)
         Implicit None
         Class(io_buffer) :: self
-        Integer, Intent(In), Optional :: file_unit
         Character*120, Intent(In), Optional :: filename
-        Integer :: funit, ierr, j
+        Integer :: ierr, j
+#ifdef USE_MPI_F08_BINDINGS
+        Type(MPI_File), Intent(In), Optional :: file_unit
+        Type(MPI_File) :: funit
+#else
+        Integer, Intent(In), Optional :: file_unit
+        Integer :: funit
+#endif
         Logical :: error
         Integer(kind=MPI_OFFSET_KIND), Intent(In), Optional :: disp
         Integer(kind=MPI_OFFSET_KIND) :: hdisp, fdisp

--- a/src/IO/Spherical_IO.F90
+++ b/src/IO/Spherical_IO.F90
@@ -84,7 +84,7 @@ Module Spherical_IO
         Integer :: nq, nlevels ! Number of nonzero elements of values and levels
         Integer :: my_nlevels  ! Number of nonzero elements of levels that are in process
 
-        Integer :: file_unit = 15
+        Integer :: file_unit
         Character*120 :: file_prefix = 'None'
 
         Integer, Allocatable :: oqvals(:)   ! Array of size nq used by I/O process to record output ordering of diagnostics
@@ -1504,7 +1504,6 @@ Contains
         self%nq = 0
         self%nlevels = 0
         self%my_nlevels = 0
-        self%file_unit = 15
         self%file_prefix = 'None'
         If (Allocated(self%oqvals))  DeAllocate(self%oqvals)
 

--- a/src/IO/Spherical_IO.F90
+++ b/src/IO/Spherical_IO.F90
@@ -84,7 +84,11 @@ Module Spherical_IO
         Integer :: nq, nlevels ! Number of nonzero elements of values and levels
         Integer :: my_nlevels  ! Number of nonzero elements of levels that are in process
 
+#ifdef USE_MPI_F08_BINDINGS
+        Type(MPI_File) :: file_unit
+#else
         Integer :: file_unit
+#endif
         Character*120 :: file_prefix = 'None'
 
         Integer, Allocatable :: oqvals(:)   ! Array of size nq used by I/O process to record output ordering of diagnostics
@@ -137,7 +141,12 @@ Module Spherical_IO
         Real*8, Allocatable :: r_vals(:), theta_vals(:), phi_vals(:)
 
         !Communicatory Info for parallel writing (if used)
-        Integer :: ocomm, orank, onp
+#ifdef USE_MPI_F08_BINDINGS
+        Type(MPI_Comm) :: ocomm
+#else
+        Integer :: ocomm
+#endif
+        Integer :: orank, onp
         Logical :: master = .false.
         !%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
@@ -686,7 +695,12 @@ Contains
     Subroutine Write_Header_Data(self)
         Implicit None
         Class(DiagnosticInfo) :: self
-        Integer :: ierr, bsize, btype, i, funit, nbuff, ii,di
+        Integer :: ierr, bsize, btype, i, nbuff, ii,di
+#ifdef USE_MPI_F08_BINDINGS
+        Type(MPI_File) :: funit
+#else
+        Integer :: funit
+#endif
         funit = self%file_unit
         nbuff = self%nheader
         di = 1
@@ -727,7 +741,12 @@ Contains
         Class(DiagnosticInfo) :: self
         INTEGER(kind=MPI_OFFSET_KIND) :: new_disp, full_disp
         Logical :: responsible, output_rank
-        Integer :: orank, funit, error, ncache
+        Integer :: orank, error, ncache
+#ifdef USE_MPI_F08_BINDINGS
+        Type(MPI_File) :: funit
+#else
+        Integer :: funit
+#endif
 
         If ((self%nq > 0) .and. (Mod(this_iter,self%frequency) .eq. 0 )) Then
 
@@ -1148,7 +1167,12 @@ Contains
         Character*120 :: iterstring
         Character*120 :: filename
         Integer :: modcheck, imod, ibelong, icomp
-        Integer :: buffsize, funit
+        Integer :: buffsize
+#ifdef USE_MPI_F08_BINDINGS
+        Type(MPI_File) :: funit
+#else
+        Integer :: funit
+#endif
         integer(kind=MPI_OFFSET_KIND) :: disp
         Logical :: create_file
         Logical :: file_exists

--- a/src/IO/Spherical_IO.F90
+++ b/src/IO/Spherical_IO.F90
@@ -696,7 +696,7 @@ Contains
             btype = self%buff_types(i)
             If (btype .eq. 1) Then
                 CALL MPI_FILE_WRITE(funit, self%rvals(di)%data(1), bsize, &
-                                    MPI_DOUBLE_PRECISION, MPI_STATUS_IGNORE, ierr) 
+                                    MPI_REAL8, MPI_STATUS_IGNORE, ierr) 
                 di = di+1
             Else
                 CALL MPI_FILE_WRITE(funit, self%ivals(ii)%data(1), bsize, &

--- a/src/IO/Spherical_IO.F90
+++ b/src/IO/Spherical_IO.F90
@@ -686,7 +686,6 @@ Contains
     Subroutine Write_Header_Data(self)
         Implicit None
         Class(DiagnosticInfo) :: self
-        Integer :: mstatus(MPI_STATUS_SIZE)
         Integer :: ierr, bsize, btype, i, funit, nbuff, ii,di
         funit = self%file_unit
         nbuff = self%nheader
@@ -697,11 +696,11 @@ Contains
             btype = self%buff_types(i)
             If (btype .eq. 1) Then
                 CALL MPI_FILE_WRITE(funit, self%rvals(di)%data(1), bsize, &
-                                    MPI_DOUBLE_PRECISION, mstatus, ierr) 
+                                    MPI_DOUBLE_PRECISION, MPI_STATUS_IGNORE, ierr) 
                 di = di+1
             Else
                 CALL MPI_FILE_WRITE(funit, self%ivals(ii)%data(1), bsize, &
-                                    MPI_INTEGER, mstatus, ierr) 
+                                    MPI_INTEGER, MPI_STATUS_IGNORE, ierr) 
                 ii = ii+1
             Endif
         Enddo
@@ -1150,7 +1149,6 @@ Contains
         Character*120 :: filename
         Integer :: modcheck, imod, ibelong, icomp
         Integer :: buffsize, funit
-        Integer :: mstatus(MPI_STATUS_SIZE)
         integer(kind=MPI_OFFSET_KIND) :: disp
         Logical :: create_file
         Logical :: file_exists
@@ -1228,17 +1226,17 @@ Contains
 
                     buffsize = 1
                     Call MPI_FILE_WRITE(self%file_unit, endian_tag, buffsize, &
-                        & MPI_INTEGER, mstatus, ierr)
+                        & MPI_INTEGER, MPI_STATUS_IGNORE, ierr)
 
                     buffsize = 1
                     Call MPI_FILE_WRITE(self%file_unit, self%Output_Version, & 
-                        buffsize, MPI_INTEGER, mstatus, ierr)
+                        buffsize, MPI_INTEGER, MPI_STATUS_IGNORE, ierr)
 
                     ! We write zero initially --
                     ! update nrec only after the data is actually written.
                     buffsize = 1
                     Call MPI_FILE_WRITE(self%file_unit, integer_zero, &
-                        & buffsize, MPI_INTEGER, mstatus, ierr) 
+                        & buffsize, MPI_INTEGER, MPI_STATUS_IGNORE, ierr) 
                     
                 Endif
                 
@@ -1252,7 +1250,7 @@ Contains
                     disp = 8
                     Call MPI_File_Seek(self%file_unit,disp,MPI_SEEK_SET,ierr)
                     Call MPI_FILE_READ(self%file_unit, self%current_rec, 1, &
-                        & MPI_INTEGER, mstatus, ierr)
+                        & MPI_INTEGER, MPI_STATUS_IGNORE, ierr)
 
                 Endif
 
@@ -1270,7 +1268,6 @@ Contains
         USE RA_MPI_BASE
         Implicit None
         integer :: ierr, buffsize
-        Integer :: mstatus(MPI_STATUS_SIZE)
         integer(kind=MPI_OFFSET_KIND) :: disp
         !Parallel File Close
         !Peforms the same task as closefile, but using MPI-IO
@@ -1288,7 +1285,7 @@ Contains
             buffsize = 1
 
             call MPI_FILE_WRITE(self%file_unit,self%current_rec , buffsize, MPI_INTEGER, & 
-                mstatus, ierr) 
+                MPI_STATUS_IGNORE, ierr) 
             If (ierr .ne. 0) Write(6,*)'Error writing to header.  Error code: ', ierr, myid, self%file_prefix
         Endif
         Call MPI_FILE_CLOSE(self%file_unit, ierr)

--- a/src/Parallel_Framework/All_to_All.F90
+++ b/src/Parallel_Framework/All_to_All.F90
@@ -119,8 +119,8 @@ Contains
         Type(communicator), Intent(in) :: grp
         Integer :: MPI_err
 
-        call MPI_ALLTOALLv(send_buf, send_count, send_displ, MPI_DOUBLE_PRECISION, recv_buf, &
-            & recv_count, recv_displ, MPI_DOUBLE_PRECISION, grp%comm, MPI_err)
+        call MPI_ALLTOALLv(send_buf, send_count, send_displ, MPI_REAL8, recv_buf, &
+            & recv_count, recv_displ, MPI_REAL8, grp%comm, MPI_err)
     End Subroutine D_Transpose_v_1D
 
     !////////////////////////////////////////////////////////////////////////////////////
@@ -154,11 +154,11 @@ Contains
         Integer :: MPI_err
         Logical, Intent(in) :: normal
         If (normal) Then
-            call MPI_ALLTOALL(send_buf, send_count(1), MPI_DOUBLE_PRECISION, recv_buf, &
-                & recv_count(1), MPI_DOUBLE_PRECISION, grp%comm, MPI_err)
+            call MPI_ALLTOALL(send_buf, send_count(1), MPI_REAL8, recv_buf, &
+                & recv_count(1), MPI_REAL8, grp%comm, MPI_err)
         Else
-            call MPI_ALLTOALLv(send_buf, send_count, send_displ, MPI_DOUBLE_PRECISION, recv_buf, &
-                & recv_count, recv_displ, MPI_DOUBLE_PRECISION, grp%comm, MPI_err)
+            call MPI_ALLTOALLv(send_buf, send_count, send_displ, MPI_REAL8, recv_buf, &
+                & recv_count, recv_displ, MPI_REAL8, grp%comm, MPI_err)
         Endif
     End Subroutine D_Transpose_choose_1D
 

--- a/src/Parallel_Framework/General_MPI.F90
+++ b/src/Parallel_Framework/General_MPI.F90
@@ -59,8 +59,13 @@ Contains
         Real*8, Intent(In)  :: sendbuf
         Real*8, Intent(Out) :: recvbuf
         Type(communicator), Optional :: grp
-        Integer :: icount,  comm
+        Integer :: icount
         Integer :: MPI_err
+#ifdef USE_MPI_F08_BINDINGS
+        Type(MPI_comm) :: comm
+#else
+        Integer :: comm
+#endif
 
         icount = 1
 
@@ -95,7 +100,12 @@ Contains
         Integer*4, Intent(In)  :: sendbuf
         Integer*4, Intent(Out) :: recvbuf
         Type(communicator), Optional :: grp
-        Integer :: icount,  comm, MPI_err
+        Integer :: icount, MPI_err
+#ifdef USE_MPI_F08_BINDINGS
+        Type(MPI_comm) :: comm
+#else
+        Integer :: comm
+#endif
 
         icount = 1
 
@@ -131,7 +141,12 @@ Contains
         Real*8, Intent(Out) :: recvbuf(:)
         Type(communicator), Optional :: grp
         Integer, Intent(In), Optional :: ddest
-        Integer :: icount,  comm, MPI_err, dest
+        Integer :: icount, MPI_err, dest
+#ifdef USE_MPI_F08_BINDINGS
+        Type(MPI_comm) :: comm
+#else
+        Integer :: comm
+#endif
         If (present(ddest)) then
             dest = ddest
         Else
@@ -169,7 +184,12 @@ Contains
         Real*8 :: sendbuf(1:)
         Real*8, Intent(Out) :: recvbuf(1:)
         Type(communicator), Optional :: grp
-        Integer :: icount,  comm, MPI_err
+        Integer :: icount, MPI_err
+#ifdef USE_MPI_F08_BINDINGS
+        Type(MPI_comm) :: comm
+#else
+        Integer :: comm
+#endif
 
         icount = size(sendbuf)
 
@@ -204,7 +224,12 @@ Contains
         Real*8, Intent(Out) :: recvbuf(:,:,:)
         Type(communicator), Optional  :: grp
         Integer, Intent(In), Optional :: ddest
-        Integer :: icount,  comm, MPI_err, dest
+        Integer :: icount,  MPI_err, dest
+#ifdef USE_MPI_F08_BINDINGS
+        Type(MPI_comm) :: comm
+#else
+        Integer :: comm
+#endif
 
         If (present(ddest)) then
             dest = ddest
@@ -247,7 +272,12 @@ Contains
         Real*8, Intent(Out) :: recvbuf(:,:)
         Type(communicator), Optional  :: grp
         Integer, Intent(In), Optional :: ddest
-        Integer :: icount,  comm, MPI_err, dest
+        Integer :: icount, MPI_err, dest
+#ifdef USE_MPI_F08_BINDINGS
+        Type(MPI_comm) :: comm
+#else
+        Integer :: comm
+#endif
 
         If (present(ddest)) then
             dest = ddest
@@ -287,8 +317,12 @@ Contains
         Real*8, Intent(IN)  :: sendbuf(1:,1:)
         Real*8, Intent(Out) :: recvbuf(1:,1:)
         Type(communicator), Optional :: grp
-        Integer :: icount,  comm, MPI_err
-
+        Integer :: icount, MPI_err
+#ifdef USE_MPI_F08_BINDINGS
+        Type(MPI_comm) :: comm
+#else
+        Integer :: comm
+#endif
 
         icount = size(sendbuf)
 
@@ -320,7 +354,12 @@ Contains
         Real*8, INTENT(INOUT) :: buff(:,:)
         Type(communicator), INTENT(IN), Optional :: grp
         Integer, Intent(In), Optional :: broot
-        Integer :: icount,  comm, MPI_err, root
+        Integer :: icount, MPI_err, root
+#ifdef USE_MPI_F08_BINDINGS
+        Type(MPI_comm) :: comm
+#else
+        Integer :: comm
+#endif
 
         If (present(broot)) then
             root = broot
@@ -357,7 +396,12 @@ Contains
         Integer*4, INTENT(INOUT) :: buff(:)
         Type(communicator), INTENT(IN), Optional :: grp
         Integer, Intent(In), Optional :: broot
-        Integer :: icount,  comm, MPI_err, root
+        Integer :: icount, MPI_err, root
+#ifdef USE_MPI_F08_BINDINGS
+        Type(MPI_comm) :: comm
+#else
+        Integer :: comm
+#endif
 
         If (present(broot)) then
             root = broot

--- a/src/Parallel_Framework/General_MPI.F90
+++ b/src/Parallel_Framework/General_MPI.F90
@@ -71,7 +71,7 @@ Contains
         End If
 
 
-        Call MPI_ALLREDUCE(sendbuf, recvbuf, icount, MPI_DOUBLE_PRECISION, MPI_MAX, comm, MPI_err)
+        Call MPI_ALLREDUCE(sendbuf, recvbuf, icount, MPI_REAL8, MPI_MAX, comm, MPI_err)
 
     End Subroutine Global_Max
 
@@ -146,7 +146,7 @@ Contains
             comm = MPI_COMM_WORLD
         End If
 
-        Call MPI_REDUCE(sendbuf, recvbuf, icount, MPI_DOUBLE_PRECISION, MPI_SUM, dest, comm, MPI_err)
+        Call MPI_REDUCE(sendbuf, recvbuf, icount, MPI_REAL8, MPI_SUM, dest, comm, MPI_err)
 
     End Subroutine DSUM1D
 
@@ -179,7 +179,7 @@ Contains
             comm = MPI_COMM_WORLD
         End If
 
-        Call MPI_ALLREDUCE(sendbuf, recvbuf, icount, MPI_DOUBLE_PRECISION, MPI_SUM, comm, MPI_err)
+        Call MPI_ALLREDUCE(sendbuf, recvbuf, icount, MPI_REAL8, MPI_SUM, comm, MPI_err)
 
     End Subroutine DALLSUM1D
 
@@ -221,7 +221,7 @@ Contains
         End If
 
 
-        Call MPI_REDUCE(sendbuf, recvbuf, icount, MPI_DOUBLE_PRECISION, MPI_SUM, dest, comm, MPI_err)
+        Call MPI_REDUCE(sendbuf, recvbuf, icount, MPI_REAL8, MPI_SUM, dest, comm, MPI_err)
 
     End Subroutine DSUM3D
 
@@ -264,7 +264,7 @@ Contains
         End If
 
 
-        Call MPI_REDUCE(sendbuf, recvbuf, icount, MPI_DOUBLE_PRECISION, MPI_SUM, dest, comm, MPI_err)
+        Call MPI_REDUCE(sendbuf, recvbuf, icount, MPI_REAL8, MPI_SUM, dest, comm, MPI_err)
 
     End Subroutine DSUM2D
 
@@ -299,7 +299,7 @@ Contains
         End If
 
 
-        Call MPI_ALLREDUCE(sendbuf, recvbuf, icount, MPI_DOUBLE_PRECISION, MPI_SUM, comm, MPI_err)
+        Call MPI_ALLREDUCE(sendbuf, recvbuf, icount, MPI_REAL8, MPI_SUM, comm, MPI_err)
 
     End Subroutine DALLSUM2D
 
@@ -336,7 +336,7 @@ Contains
             comm = MPI_COMM_WORLD
         End If
 
-        Call MPI_BCAST(buff, icount, MPI_DOUBLE_PRECISION,  root, comm, MPI_err)
+        Call MPI_BCAST(buff, icount, MPI_REAL8,  root, comm, MPI_err)
 
     End Subroutine BCAST2D
 

--- a/src/Parallel_Framework/ISendReceive.F90
+++ b/src/Parallel_Framework/ISendReceive.F90
@@ -199,7 +199,7 @@ Contains
             ione = 1
         End if
 
-        Call mpi_isend(x(ione), n, MPI_DOUBLE_PRECISION, p, tag2, comm2, irq,mpi_err)
+        Call mpi_isend(x(ione), n, MPI_REAL8, p, tag2, comm2, irq,mpi_err)
 
     End Subroutine D_ISend_1D
 
@@ -245,7 +245,7 @@ Contains
             lstart = 1
         Endif
 
-        Call mpi_isend(x(istart,jstart,kstart,lstart), n, MPI_DOUBLE_PRECISION, p, tag2, comm2, irq,mpi_err)
+        Call mpi_isend(x(istart,jstart,kstart,lstart), n, MPI_REAL8, p, tag2, comm2, irq,mpi_err)
     End Subroutine D_ISend_4D
 
     Subroutine D_IReceive_4D(x, irq,n_elements, source, tag, grp,indstart)
@@ -292,7 +292,7 @@ Contains
             lstart = 1
         Endif
 
-        Call mpi_irecv(x(istart,jstart,kstart,lstart), n, MPI_DOUBLE_PRECISION, p, tag2, comm2, irq, mpi_err)
+        Call mpi_irecv(x(istart,jstart,kstart,lstart), n, MPI_REAL8, p, tag2, comm2, irq, mpi_err)
 
     End Subroutine D_IReceive_4D
 
@@ -340,7 +340,7 @@ Contains
             lstart = 1
             mstart = 1
         Endif
-        Call mpi_isend(x(istart,jstart,kstart,lstart,mstart), n, MPI_DOUBLE_PRECISION, p, tag2, comm2, irq,mpi_err)
+        Call mpi_isend(x(istart,jstart,kstart,lstart,mstart), n, MPI_REAL8, p, tag2, comm2, irq,mpi_err)
 
     End Subroutine D_ISend_5D
 
@@ -390,7 +390,7 @@ Contains
             mstart = 1
         Endif
 
-        Call mpi_irecv(x(istart,jstart,kstart,lstart,mstart), n, MPI_DOUBLE_PRECISION, p, tag2, comm2, irq, mpi_err)
+        Call mpi_irecv(x(istart,jstart,kstart,lstart,mstart), n, MPI_REAL8, p, tag2, comm2, irq, mpi_err)
 
     End Subroutine D_IReceive_5D
 
@@ -474,7 +474,7 @@ Contains
             ione = 1
             jone = 1
         Endif
-        Call mpi_isend(x(ione,jone), n, MPI_DOUBLE_PRECISION, p, tag2, comm2, irq,mpi_err)
+        Call mpi_isend(x(ione,jone), n, MPI_REAL8, p, tag2, comm2, irq,mpi_err)
 
     End Subroutine D_ISend_2D
 
@@ -518,7 +518,7 @@ Contains
             jstart = 1
             kstart = 1
         Endif
-        Call mpi_isend(x(istart,jstart,kstart), n, MPI_DOUBLE_PRECISION, p, tag2, comm2, irq,mpi_err)
+        Call mpi_isend(x(istart,jstart,kstart), n, MPI_REAL8, p, tag2, comm2, irq,mpi_err)
 
     End Subroutine D_ISend_3D
 
@@ -638,7 +638,7 @@ Contains
             ione = 1
         Endif
 
-        Call mpi_irecv(x(ione), n, MPI_DOUBLE_PRECISION, p, tag2, comm2, irq, mpi_err)
+        Call mpi_irecv(x(ione), n, MPI_REAL8, p, tag2, comm2, irq, mpi_err)
 
     End Subroutine D_IReceive_1D
 
@@ -724,7 +724,7 @@ Contains
         Endif
 
 
-        Call mpi_irecv(x(ione,jone), n, MPI_DOUBLE_PRECISION, p, tag2, comm2, irq, mpi_err)
+        Call mpi_irecv(x(ione,jone), n, MPI_REAL8, p, tag2, comm2, irq, mpi_err)
 
     End Subroutine D_IReceive_2D
 
@@ -770,7 +770,7 @@ Contains
             kstart = 1
         Endif
 
-        Call mpi_irecv(x(istart,jstart,kstart), n, MPI_DOUBLE_PRECISION, p, tag2, comm2, irq, mpi_err)
+        Call mpi_irecv(x(istart,jstart,kstart), n, MPI_REAL8, p, tag2, comm2, irq, mpi_err)
 
     End Subroutine D_IReceive_3D
 

--- a/src/Parallel_Framework/ISendReceive.F90
+++ b/src/Parallel_Framework/ISendReceive.F90
@@ -79,8 +79,8 @@ Contains
     !/////////////////////////////////////////////////////////////////////
     Subroutine IWait(irq)
         Implicit None
-        Integer :: irq, status(MPI_STATUS_SIZE), mpi_err
-        Call MPI_WAIT(irq,status,mpi_err)
+        Integer :: irq, mpi_err
+        Call MPI_WAIT(irq,MPI_STATUS_IGNORE,mpi_err)
     End Subroutine IWait
 
     !/////////////////////////////////////////////////////////////////////
@@ -99,10 +99,7 @@ Contains
         Integer :: irq(:)
         Integer, Intent(In) :: n
         Integer :: mpi_err
-        Integer, Allocatable :: istat(:,:)
-        Allocate(istat(MPI_STATUS_SIZE,1:n))
-        Call MPI_WAITALL(n,irq,istat,mpi_err)
-        DeAllocate(istat)
+        Call MPI_WAITALL(n,irq,MPI_STATUSES_IGNORE,mpi_err)
     End Subroutine IWaitAll
 
 

--- a/src/Parallel_Framework/ISendReceive.F90
+++ b/src/Parallel_Framework/ISendReceive.F90
@@ -79,7 +79,12 @@ Contains
     !/////////////////////////////////////////////////////////////////////
     Subroutine IWait(irq)
         Implicit None
-        Integer :: irq, mpi_err
+#ifdef USE_MPI_F08_BINDINGS
+        Type(MPI_Request) :: irq
+#else
+        Integer :: irq
+#endif
+        Integer :: mpi_err
         Call MPI_WAIT(irq,MPI_STATUS_IGNORE,mpi_err)
     End Subroutine IWait
 
@@ -96,7 +101,11 @@ Contains
     !
     !/////////////////////////////////////////////////////////////////////
     Subroutine IWaitAll(n,irq)
+#ifdef USE_MPI_F08_BINDINGS
+        Type(MPI_Request) :: irq(:)
+#else
         Integer :: irq(:)
+#endif
         Integer, Intent(In) :: n
         Integer :: mpi_err
         Call MPI_WAITALL(n,irq,MPI_STATUSES_IGNORE,mpi_err)
@@ -166,8 +175,14 @@ Contains
         Real(8), Intent(In)  :: x(:)
         Integer, Intent(In), Optional :: dest, n_elements, tag,istart
         Type(communicator), Intent(In), Optional :: grp
+        Integer :: p, n, tag2, ione
+#ifdef USE_MPI_F08_BINDINGS
+        Type(MPI_Request), Intent(Out) :: irq
+        Type(MPI_Comm) :: comm2
+#else
         Integer, Intent(Out) :: irq
-        Integer :: p, n, comm2, tag2, ione
+        Integer :: comm2
+#endif
 
         If (Present(n_elements)) Then
             n = n_elements
@@ -207,8 +222,14 @@ Contains
         Real*8, Intent(in)  :: x(1:,1:,1:,1:)
         Integer, Intent(In), Optional :: dest, n_elements, tag,indstart(1:4)
         Type(communicator), Intent(In), optional :: grp
+        Integer :: p, n, tag2, istart, kstart, jstart,lstart
+#ifdef USE_MPI_F08_BINDINGS
+        Type(MPI_Request), Intent(Out) :: irq
+        Type(MPI_Comm) :: comm2
+#else
         Integer, Intent(Out) :: irq
-        Integer :: p, n, comm2, tag2, istart, kstart, jstart,lstart
+        Integer :: comm2
+#endif
 
         If (Present(n_elements)) Then
            n = n_elements
@@ -252,9 +273,15 @@ Contains
         Real*8, Intent(Out)  :: x(1:,1:,1:,1:)
         Integer, Intent(In), Optional :: source, n_elements, tag,indstart(1:4)
         Type(communicator), Intent(In), Optional :: grp
-        Integer :: p, n, comm2, tag2
-        Integer, Intent(Out) :: irq
+        Integer :: p, n, tag2
         Integer :: istart,jstart,kstart,lstart
+#ifdef USE_MPI_F08_BINDINGS
+        Type(MPI_Request), Intent(Out) :: irq
+        Type(MPI_Comm) :: comm2
+#else
+        Integer, Intent(Out) :: irq
+        Integer :: comm2
+#endif
 
         If (Present(n_elements)) Then
            n = n_elements
@@ -300,9 +327,15 @@ Contains
         Real*8, Intent(In)  :: x(1:,1:,1:,1:,1:)
         Integer, Intent(In), Optional :: dest, n_elements, tag,indstart(1:5)
         Type(communicator), optional :: grp
-        Integer, Intent(Out) :: irq
-        Integer :: p, n, comm2, tag2
+        Integer :: p, n, tag2
         Integer :: istart, kstart, jstart,lstart, mstart
+#ifdef USE_MPI_F08_BINDINGS
+        Type(MPI_Request), Intent(Out) :: irq
+        Type(MPI_Comm) :: comm2
+#else
+        Integer, Intent(Out) :: irq
+        Integer :: comm2
+#endif
 
         If (Present(n_elements)) Then
            n = n_elements
@@ -348,9 +381,15 @@ Contains
         Real*8, Intent(Out)  :: x(1:,1:,1:,1:,1:)
         Integer, Intent(In), Optional :: source, n_elements, tag,indstart(1:5)
         Type(communicator), Intent(In), Optional :: grp
-        Integer, Intent(Out) :: irq
-        Integer :: p, n, comm2, tag2
+        Integer :: p, n, tag2
         Integer :: istart,jstart,kstart,lstart,mstart
+#ifdef USE_MPI_F08_BINDINGS
+        Type(MPI_Request), Intent(Out) :: irq
+        Type(MPI_Comm) :: comm2
+#else
+        Integer, Intent(Out) :: irq
+        Integer :: comm2
+#endif
 
         If (Present(n_elements)) Then
            n = n_elements
@@ -398,8 +437,14 @@ Contains
         Complex*16, Intent(In)  :: x(:)
         Integer, Intent(In), Optional :: dest, n_elements, tag,istart
         Type(communicator),Intent(In), Optional :: grp
+        Integer :: p, n, tag2, ione
+#ifdef USE_MPI_F08_BINDINGS
+        Type(MPI_Request), Intent(Out) :: irq
+        Type(MPI_Comm) :: comm2
+#else
         Integer, Intent(Out) :: irq
-        Integer :: p, n, comm2, tag2, ione
+        Integer :: comm2
+#endif
 
         If (Present(n_elements)) Then
             n = n_elements
@@ -439,9 +484,15 @@ Contains
         Real(8), Intent(In)  :: x(1:,1:)
         Type(communicator), Intent(In), optional :: grp
         Integer, Intent(In), Optional :: dest, n_elements, tag, indstart(2)
-        Integer, Intent(Out) :: irq
-        Integer :: p, n, comm2, tag2
+        Integer :: p, n, tag2
         Integer :: ione, jone
+#ifdef USE_MPI_F08_BINDINGS
+        Type(MPI_Request), Intent(Out) :: irq
+        Type(MPI_Comm) :: comm2
+#else
+        Integer, Intent(Out) :: irq
+        Integer :: comm2
+#endif
 
         If (Present(n_elements)) Then
            n = n_elements
@@ -482,9 +533,15 @@ Contains
         Real*8, Intent(in)  :: x(1:,1:,1:)
         Integer, Intent(In), Optional :: dest, n_elements, tag,indstart(1:3)
         Type(communicator), Intent(In), Optional :: grp
-        Integer, Intent(Out) :: irq
-        Integer :: p, n, comm2, tag2
+        Integer :: p, n, tag2
         Integer :: istart, kstart, jstart
+#ifdef USE_MPI_F08_BINDINGS
+        Type(MPI_Request), Intent(Out) :: irq
+        Type(MPI_Comm) :: comm2
+#else
+        Integer, Intent(Out) :: irq
+        Integer :: comm2
+#endif
 
         If (Present(n_elements)) Then
            n = n_elements
@@ -526,8 +583,14 @@ Contains
         Complex*16, Intent(In)  :: x(:,:)
         Integer, Intent(In), Optional :: dest, n_elements, tag
         Type(communicator), Intent(In), Optional :: grp
+        Integer :: p, n, tag2
+#ifdef USE_MPI_F08_BINDINGS
+        Type(MPI_Request), Intent(Out) :: irq
+        Type(MPI_Comm) :: comm2
+#else
         Integer, Intent(Out) :: irq
-        Integer :: p, n, comm2, tag2
+        Integer :: comm2
+#endif
 
         If (Present(n_elements)) Then
            n = n_elements
@@ -561,8 +624,14 @@ Contains
         Complex*16, Intent(In)  :: x(:,:,:)
         Integer, Intent(In), Optional :: dest, n_elements, tag,indstart(1:3)
         Type(communicator), Intent(In), Optional :: grp
+        Integer :: p, n, tag2, istart, kstart, jstart
+#ifdef USE_MPI_F08_BINDINGS
+        Type(MPI_Request), Intent(Out) :: irq
+        Type(MPI_Comm) :: comm2
+#else
         Integer, Intent(Out) :: irq
-        Integer :: p, n, comm2, tag2, istart, kstart, jstart
+        Integer :: comm2
+#endif
 
         If (Present(n_elements)) Then
            n = n_elements
@@ -604,8 +673,14 @@ Contains
         Real(8), Intent(Out)  :: x(:)
         Integer, Intent(In), Optional :: source, n_elements, tag, istart
         Type(communicator), Intent(In), Optional :: grp
+        Integer :: p, n, tag2, ione
+#ifdef USE_MPI_F08_BINDINGS
+        Type(MPI_Request), Intent(Out) :: irq
+        Type(MPI_Comm) :: comm2
+#else
         Integer, Intent(Out) :: irq
-        Integer :: p, n, comm2, tag2, ione
+        Integer :: comm2
+#endif
 
         If (Present(n_elements)) Then
             n = n_elements
@@ -646,8 +721,14 @@ Contains
         Complex*16, Intent(Out)  :: x(:)
         Integer, Intent(In), Optional :: source, n_elements, tag, istart
         Type(communicator), Intent(In), Optional :: grp
+        Integer :: p, n, tag2, ione
+#ifdef USE_MPI_F08_BINDINGS
+        Type(MPI_Request), Intent(Out) :: irq
+        Type(MPI_Comm) :: comm2
+#else
         Integer, Intent(Out) :: irq
-        Integer :: p, n, comm2, tag2, ione
+        Integer :: comm2
+#endif
 
         If (Present(n_elements)) Then
            n = n_elements
@@ -688,8 +769,15 @@ Contains
         Real(8), Intent(Out):: x(1:,1:)
         Integer, Intent(In), Optional :: source, n_elements, tag, indstart(1:2)
         Type(communicator),  Optional :: grp
+        Integer :: p, n, tag2, ione, jone
+#ifdef USE_MPI_F08_BINDINGS
+        Type(MPI_Request), Intent(Out) :: irq
+        Type(MPI_Comm) :: comm2
+#else
         Integer, Intent(Out) :: irq
-        Integer :: p, n, comm2, tag2, ione, jone
+        Integer :: comm2
+#endif
+
 
         If (Present(n_elements)) Then
             n = n_elements
@@ -732,9 +820,15 @@ Contains
         Real*8, Intent(Out)  :: x(1:,1:,1:)
         Integer, Intent(In), Optional :: source, n_elements, tag,indstart(1:3)
         Type(communicator), Intent(In), Optional :: grp
-        Integer, Intent(Out) :: irq
-        Integer :: p, n, comm2, tag2
+        Integer :: p, n, tag2
         Integer :: istart,jstart,kstart
+#ifdef USE_MPI_F08_BINDINGS
+        Type(MPI_Request), Intent(Out) :: irq
+        Type(MPI_Comm) :: comm2
+#else
+        Integer, Intent(Out) :: irq
+        Integer :: comm2
+#endif
 
         If (Present(n_elements)) Then
            n = n_elements
@@ -780,8 +874,15 @@ Contains
         Complex*16, Intent(Out)  :: x(:,:)
         Integer, Intent(In), Optional :: source, n_elements, tag, indstart(1:2)
         Type(communicator), Intent(In), Optional :: grp
+        Integer :: p, n, tag2, istart, jstart
+#ifdef USE_MPI_F08_BINDINGS
+        Type(MPI_Request), Intent(Out) :: irq
+        Type(MPI_Comm) :: comm2
+#else
         Integer, Intent(Out) :: irq
-        Integer :: p, n, comm2, tag2, istart, jstart
+        Integer :: comm2
+#endif
+
 
         If (Present(n_elements)) Then
            n = n_elements
@@ -823,9 +924,15 @@ Contains
         Complex*16, Intent(Out)  :: x(:,:,:)
         Integer, Intent(In), Optional :: source, n_elements, tag,indstart(1:3)
         Type(communicator), Intent(In), Optional :: grp
-        Integer, Intent(Out) :: irq
-        Integer :: p, n, comm2, tag2
+        Integer :: p, n, tag2
         Integer :: istart, jstart, kstart
+#ifdef USE_MPI_F08_BINDINGS
+        Type(MPI_Request), Intent(Out) :: irq
+        Type(MPI_Comm) :: comm2
+#else
+        Integer, Intent(Out) :: irq
+        Integer :: comm2
+#endif
 
         If (Present(n_elements)) Then
            n = n_elements

--- a/src/Parallel_Framework/Parallel_Framework.F90
+++ b/src/Parallel_Framework/Parallel_Framework.F90
@@ -226,7 +226,12 @@ Contains
         Class(Parallel_Interface) :: self
         Integer, Intent(In) :: intarr(:)
         Integer, Intent(In), Optional :: src, comm_option
-        Integer :: arr_size, comm_handle, src_rank, ierr
+        Integer :: arr_size, src_rank, ierr
+#ifdef USE_MPI_F08_BINDINGS
+        Type(MPI_comm) :: comm_handle
+#else
+        Integer :: comm_handle
+#endif
         arr_size = size(intarr)
         If (present(src)) Then
             src_rank = src

--- a/src/Parallel_Framework/Ra_MPI_Base.F90
+++ b/src/Parallel_Framework/Ra_MPI_Base.F90
@@ -21,12 +21,18 @@
 Module Ra_MPI_Base
 #ifdef USE_MPI_F77_BINDINGS
     Include 'mpif.h'
+#elif USE_MPI_F08_BINDINGS
+    Use MPI_F08
 #else
     Use MPI
 #endif
 
     Type communicator
+#ifdef USE_MPI_F08_BINDINGS
+        Type(MPI_Comm) :: comm    ! The mpi handle for this group
+#else
         Integer :: comm    ! The mpi handle for this group
+#endif
         Integer :: np    ! The number of processors in this group
         Integer :: rank ! A processes's local rank within this group
     End Type communicator

--- a/src/Parallel_Framework/SendReceive.F90
+++ b/src/Parallel_Framework/SendReceive.F90
@@ -43,7 +43,13 @@ Contains
     Integer, Optional :: dest, n_elements, tag,indstart(1:5)
      Integer :: istart, kstart, jstart,lstart, mstart
     Type(communicator), optional :: grp
-    Integer :: p, n, comm2, tag2
+    Integer :: p, n, tag2
+#ifdef USE_MPI_F08_BINDINGS
+    Type(MPI_Comm) :: comm2
+#else
+    Integer :: comm2
+#endif
+
 
     If (Present(n_elements)) Then
        n = n_elements
@@ -94,7 +100,13 @@ Contains
     Integer, Optional :: dest, n_elements, tag,indstart(1:4)
      Integer :: istart, kstart, jstart,lstart
     Type(communicator), optional :: grp
-    Integer :: p, n, comm2, tag2
+    Integer :: p, n, tag2
+#ifdef USE_MPI_F08_BINDINGS
+    Type(MPI_Comm) :: comm2
+#else
+    Integer :: comm2
+#endif
+
 
     If (Present(n_elements)) Then
        n = n_elements
@@ -141,7 +153,13 @@ Contains
     Integer, Optional :: dest, n_elements, tag,indstart(1:3)
      Integer ::  istart, kstart, jstart
     Type(communicator), optional :: grp
-    Integer :: p, n, comm2, tag2
+    Integer :: p, n, tag2
+#ifdef USE_MPI_F08_BINDINGS
+    Type(MPI_Comm) :: comm2
+#else
+    Integer :: comm2
+#endif
+
 
     If (Present(n_elements)) Then
        n = n_elements
@@ -186,7 +204,13 @@ Contains
     Integer, Optional :: dest, n_elements, tag,indstart(1:2)
      Integer :: istart, jstart
     Type(communicator), optional :: grp
-    Integer :: p, n, comm2, tag2
+    Integer :: p, n, tag2
+#ifdef USE_MPI_F08_BINDINGS
+    Type(MPI_Comm) :: comm2
+#else
+    Integer :: comm2
+#endif
+
 
     If (Present(n_elements)) Then
        n = n_elements
@@ -229,7 +253,13 @@ Contains
     Integer, Optional :: dest, n_elements, tag,indstart(1)
      Integer :: istart
     Type(communicator), optional :: grp
-    Integer :: p, n, comm2, tag2
+    Integer :: p, n, tag2
+#ifdef USE_MPI_F08_BINDINGS
+    Type(MPI_Comm) :: comm2
+#else
+    Integer :: comm2
+#endif
+
 
     If (Present(n_elements)) Then
        n = n_elements
@@ -270,7 +300,13 @@ Contains
     Integer, Optional :: dest, n_elements, tag,indstart(1:2)
      Integer :: istart, jstart
     Type(communicator), optional :: grp
-    Integer :: p, n, comm2, tag2
+    Integer :: p, n, tag2
+#ifdef USE_MPI_F08_BINDINGS
+    Type(MPI_Comm) :: comm2
+#else
+    Integer :: comm2
+#endif
+
 
     If (Present(n_elements)) Then
        n = n_elements
@@ -313,7 +349,12 @@ Contains
     Integer, Optional :: dest, n_elements, tag,indstart(1)
      Integer :: istart
     Type(communicator), optional :: grp
-    Integer :: p, n, comm2, tag2
+    Integer :: p, n, tag2
+#ifdef USE_MPI_F08_BINDINGS
+    Type(MPI_Comm) :: comm2
+#else
+    Integer :: comm2
+#endif
 
     If (Present(n_elements)) Then
        n = n_elements
@@ -356,7 +397,12 @@ Contains
     Integer, Optional :: source, n_elements, tag,indstart(1:5)
      Integer :: istart,jstart,kstart,lstart, mstart
     Type(communicator), optional :: grp
-    Integer :: p, n, comm2, tag2
+    Integer :: p, n, tag2
+#ifdef USE_MPI_F08_BINDINGS
+    Type(MPI_Comm) :: comm2
+#else
+    Integer :: comm2
+#endif
 
     If (Present(n_elements)) Then
        n = n_elements
@@ -410,7 +456,12 @@ Contains
     Integer, Optional :: source, n_elements, tag,indstart(1:4)
      Integer :: istart,jstart,kstart,lstart
     Type(communicator), optional :: grp
-    Integer :: p, n, comm2, tag2
+    Integer :: p, n, tag2
+#ifdef USE_MPI_F08_BINDINGS
+    Type(MPI_Comm) :: comm2
+#else
+    Integer :: comm2
+#endif
 
     If (Present(n_elements)) Then
        n = n_elements
@@ -460,7 +511,12 @@ Contains
     Integer, Optional :: source, n_elements, tag,indstart(1:3)
      Integer :: istart,jstart,kstart
     Type(communicator), optional :: grp
-    Integer :: p, n, comm2, tag2
+    Integer :: p, n, tag2
+#ifdef USE_MPI_F08_BINDINGS
+    Type(MPI_Comm) :: comm2
+#else
+    Integer :: comm2
+#endif
 
     If (Present(n_elements)) Then
        n = n_elements
@@ -508,7 +564,12 @@ Contains
     Integer, Optional :: source, n_elements, tag,indstart(1:2)
      Integer :: istart,jstart
     Type(communicator), optional :: grp
-    Integer :: p, n, comm2, tag2
+    Integer :: p, n, tag2
+#ifdef USE_MPI_F08_BINDINGS
+    Type(MPI_Comm) :: comm2
+#else
+    Integer :: comm2
+#endif
 
     If (Present(n_elements)) Then
        n = n_elements
@@ -554,7 +615,12 @@ Contains
     Integer, Optional :: source, n_elements, tag,indstart(1)
      Integer :: istart
     Type(communicator), optional :: grp
-    Integer :: p, n, comm2, tag2
+    Integer :: p, n, tag2
+#ifdef USE_MPI_F08_BINDINGS
+    Type(MPI_Comm) :: comm2
+#else
+    Integer :: comm2
+#endif
 
     If (Present(n_elements)) Then
        n = n_elements
@@ -598,7 +664,12 @@ Contains
     Integer, Optional :: source, n_elements, tag,indstart(1:2)
     Integer :: istart,jstart
     Type(communicator), optional :: grp
-    Integer :: p, n, comm2, tag2
+    Integer :: p, n, tag2
+#ifdef USE_MPI_F08_BINDINGS
+    Type(MPI_Comm) :: comm2
+#else
+    Integer :: comm2
+#endif
 
     If (Present(n_elements)) Then
        n = n_elements
@@ -645,7 +716,12 @@ Contains
     Integer, Optional :: source, n_elements, tag,indstart(1)
      Integer :: istart
     Type(communicator), optional :: grp
-    Integer :: p, n, comm2, tag2
+    Integer :: p, n, tag2
+#ifdef USE_MPI_F08_BINDINGS
+    Type(MPI_Comm) :: comm2
+#else
+    Integer :: comm2
+#endif
 
     If (Present(n_elements)) Then
        n = n_elements

--- a/src/Parallel_Framework/SendReceive.F90
+++ b/src/Parallel_Framework/SendReceive.F90
@@ -356,7 +356,7 @@ Contains
     Integer, Optional :: source, n_elements, tag,indstart(1:5)
      Integer :: istart,jstart,kstart,lstart, mstart
     Type(communicator), optional :: grp
-    Integer :: p, n, comm2, tag2, mstatus(MPI_STATUS_SIZE)
+    Integer :: p, n, comm2, tag2
 
     If (Present(n_elements)) Then
        n = n_elements
@@ -397,7 +397,7 @@ Contains
         mstart = 1
     Endif
 
-    Call mpi_recv(x(istart,jstart,kstart,lstart,mstart), n, MPI_DOUBLE_PRECISION, p, tag2, comm2, mstatus, mpi_err)
+    Call mpi_recv(x(istart,jstart,kstart,lstart,mstart), n, MPI_DOUBLE_PRECISION, p, tag2, comm2, MPI_STATUS_IGNORE, mpi_err)
 
 
     End Subroutine D_Receive_5D
@@ -410,7 +410,7 @@ Contains
     Integer, Optional :: source, n_elements, tag,indstart(1:4)
      Integer :: istart,jstart,kstart,lstart
     Type(communicator), optional :: grp
-    Integer :: p, n, comm2, tag2, mstatus(MPI_STATUS_SIZE)
+    Integer :: p, n, comm2, tag2
 
     If (Present(n_elements)) Then
        n = n_elements
@@ -449,7 +449,7 @@ Contains
         lstart = 1
     Endif
 
-    Call mpi_recv(x(istart,jstart,kstart,lstart), n, MPI_DOUBLE_PRECISION, p, tag2, comm2, mstatus, mpi_err)
+    Call mpi_recv(x(istart,jstart,kstart,lstart), n, MPI_DOUBLE_PRECISION, p, tag2, comm2, MPI_STATUS_IGNORE, mpi_err)
 
 
     End Subroutine D_Receive_4D
@@ -460,7 +460,7 @@ Contains
     Integer, Optional :: source, n_elements, tag,indstart(1:3)
      Integer :: istart,jstart,kstart
     Type(communicator), optional :: grp
-    Integer :: p, n, comm2, tag2, mstatus(MPI_STATUS_SIZE)
+    Integer :: p, n, comm2, tag2
 
     If (Present(n_elements)) Then
        n = n_elements
@@ -497,7 +497,7 @@ Contains
         kstart = 1
     Endif
 
-    Call mpi_recv(x(istart,jstart,kstart), n, MPI_DOUBLE_PRECISION, p, tag2, comm2, mstatus, mpi_err)
+    Call mpi_recv(x(istart,jstart,kstart), n, MPI_DOUBLE_PRECISION, p, tag2, comm2, MPI_STATUS_IGNORE, mpi_err)
 
 
     End Subroutine D_Receive_3D
@@ -508,7 +508,7 @@ Contains
     Integer, Optional :: source, n_elements, tag,indstart(1:2)
      Integer :: istart,jstart
     Type(communicator), optional :: grp
-    Integer :: p, n, comm2, tag2, mstatus(MPI_STATUS_SIZE)
+    Integer :: p, n, comm2, tag2
 
     If (Present(n_elements)) Then
        n = n_elements
@@ -543,7 +543,7 @@ Contains
         jstart = 1
     Endif
 
-    Call mpi_recv(x(istart,jstart), n, MPI_DOUBLE_PRECISION, p, tag2, comm2, mstatus, mpi_err)
+    Call mpi_recv(x(istart,jstart), n, MPI_DOUBLE_PRECISION, p, tag2, comm2, MPI_STATUS_IGNORE, mpi_err)
 
 
     End Subroutine D_Receive_2D
@@ -554,7 +554,7 @@ Contains
     Integer, Optional :: source, n_elements, tag,indstart(1)
      Integer :: istart
     Type(communicator), optional :: grp
-    Integer :: p, n, comm2, tag2, mstatus(MPI_STATUS_SIZE)
+    Integer :: p, n, comm2, tag2
 
     If (Present(n_elements)) Then
        n = n_elements
@@ -587,7 +587,7 @@ Contains
         istart = 1
     Endif
 
-    Call mpi_recv(x(istart), n, MPI_DOUBLE_PRECISION, p, tag2, comm2, mstatus, mpi_err)
+    Call mpi_recv(x(istart), n, MPI_DOUBLE_PRECISION, p, tag2, comm2, MPI_STATUS_IGNORE, mpi_err)
 
 
     End Subroutine D_Receive_1D
@@ -598,7 +598,7 @@ Contains
     Integer, Optional :: source, n_elements, tag,indstart(1:2)
     Integer :: istart,jstart
     Type(communicator), optional :: grp
-    Integer :: p, n, comm2, tag2, mstatus(MPI_STATUS_SIZE)
+    Integer :: p, n, comm2, tag2
 
     If (Present(n_elements)) Then
        n = n_elements
@@ -633,7 +633,7 @@ Contains
         jstart = 1
     Endif
 
-    Call mpi_recv(x(istart,jstart), n, MPI_INTEGER, p, tag2, comm2, mstatus, mpi_err)
+    Call mpi_recv(x(istart,jstart), n, MPI_INTEGER, p, tag2, comm2, MPI_STATUS_IGNORE, mpi_err)
 
 
     End Subroutine I_Receive_2D
@@ -645,7 +645,7 @@ Contains
     Integer, Optional :: source, n_elements, tag,indstart(1)
      Integer :: istart
     Type(communicator), optional :: grp
-    Integer :: p, n, comm2, tag2, mstatus(MPI_STATUS_SIZE)
+    Integer :: p, n, comm2, tag2
 
     If (Present(n_elements)) Then
        n = n_elements
@@ -678,7 +678,7 @@ Contains
         istart = 1
     Endif
 
-    Call mpi_recv(x(istart), n, MPI_INTEGER, p, tag2, comm2, mstatus, mpi_err)
+    Call mpi_recv(x(istart), n, MPI_INTEGER, p, tag2, comm2, MPI_STATUS_IGNORE, mpi_err)
 
 
     End Subroutine I_Receive_1D

--- a/src/Parallel_Framework/SendReceive.F90
+++ b/src/Parallel_Framework/SendReceive.F90
@@ -82,7 +82,7 @@ Contains
         lstart = 1
         mstart = 1
     Endif
-    Call mpi_send(x(istart,jstart,kstart,lstart,mstart), n, MPI_DOUBLE_PRECISION, p, tag2, comm2,  mpi_err)
+    Call mpi_send(x(istart,jstart,kstart,lstart,mstart), n, MPI_REAL8, p, tag2, comm2,  mpi_err)
     !write(6,*)'zs ', p
     End Subroutine D_Send_5D
 
@@ -131,7 +131,7 @@ Contains
         kstart = 1
         lstart = 1
     Endif
-    Call mpi_send(x(istart,jstart,kstart,lstart), n, MPI_DOUBLE_PRECISION, p, tag2, comm2,  mpi_err)
+    Call mpi_send(x(istart,jstart,kstart,lstart), n, MPI_REAL8, p, tag2, comm2,  mpi_err)
     !write(6,*)'zs ', p
     End Subroutine D_Send_4D
 
@@ -176,7 +176,7 @@ Contains
         jstart = 1
         kstart = 1
     Endif
-    Call mpi_send(x(istart,jstart,kstart), n, MPI_DOUBLE_PRECISION, p, tag2, comm2,  mpi_err)
+    Call mpi_send(x(istart,jstart,kstart), n, MPI_REAL8, p, tag2, comm2,  mpi_err)
     !write(6,*)'zs ', p
     End Subroutine D_Send_3D
 
@@ -219,7 +219,7 @@ Contains
         istart = 1
         jstart = 1
     Endif
-    Call mpi_send(x(istart,jstart), n, MPI_DOUBLE_PRECISION, p, tag2, comm2,  mpi_err)
+    Call mpi_send(x(istart,jstart), n, MPI_REAL8, p, tag2, comm2,  mpi_err)
 
     End Subroutine D_Send_2D
 
@@ -260,7 +260,7 @@ Contains
     Else
         istart = 1
     Endif
-    Call mpi_send(x(istart), n, MPI_DOUBLE_PRECISION, p, tag2, comm2,  mpi_err)
+    Call mpi_send(x(istart), n, MPI_REAL8, p, tag2, comm2,  mpi_err)
 
     End Subroutine D_Send_1D
 
@@ -397,7 +397,7 @@ Contains
         mstart = 1
     Endif
 
-    Call mpi_recv(x(istart,jstart,kstart,lstart,mstart), n, MPI_DOUBLE_PRECISION, p, tag2, comm2, MPI_STATUS_IGNORE, mpi_err)
+    Call mpi_recv(x(istart,jstart,kstart,lstart,mstart), n, MPI_REAL8, p, tag2, comm2, MPI_STATUS_IGNORE, mpi_err)
 
 
     End Subroutine D_Receive_5D
@@ -449,7 +449,7 @@ Contains
         lstart = 1
     Endif
 
-    Call mpi_recv(x(istart,jstart,kstart,lstart), n, MPI_DOUBLE_PRECISION, p, tag2, comm2, MPI_STATUS_IGNORE, mpi_err)
+    Call mpi_recv(x(istart,jstart,kstart,lstart), n, MPI_REAL8, p, tag2, comm2, MPI_STATUS_IGNORE, mpi_err)
 
 
     End Subroutine D_Receive_4D
@@ -497,7 +497,7 @@ Contains
         kstart = 1
     Endif
 
-    Call mpi_recv(x(istart,jstart,kstart), n, MPI_DOUBLE_PRECISION, p, tag2, comm2, MPI_STATUS_IGNORE, mpi_err)
+    Call mpi_recv(x(istart,jstart,kstart), n, MPI_REAL8, p, tag2, comm2, MPI_STATUS_IGNORE, mpi_err)
 
 
     End Subroutine D_Receive_3D
@@ -543,7 +543,7 @@ Contains
         jstart = 1
     Endif
 
-    Call mpi_recv(x(istart,jstart), n, MPI_DOUBLE_PRECISION, p, tag2, comm2, MPI_STATUS_IGNORE, mpi_err)
+    Call mpi_recv(x(istart,jstart), n, MPI_REAL8, p, tag2, comm2, MPI_STATUS_IGNORE, mpi_err)
 
 
     End Subroutine D_Receive_2D
@@ -587,7 +587,7 @@ Contains
         istart = 1
     Endif
 
-    Call mpi_recv(x(istart), n, MPI_DOUBLE_PRECISION, p, tag2, comm2, MPI_STATUS_IGNORE, mpi_err)
+    Call mpi_recv(x(istart), n, MPI_REAL8, p, tag2, comm2, MPI_STATUS_IGNORE, mpi_err)
 
 
     End Subroutine D_Receive_1D

--- a/src/Physics/Benchmarking.F90
+++ b/src/Physics/Benchmarking.F90
@@ -934,7 +934,11 @@ Contains
         Real*8, Intent(In) :: inbuff(1:,my_r%min:,my_theta%min:,:)
         Real*8, Allocatable :: all_strips(:,:,:)
         Integer :: i,j, indst(3), ndata
+#ifdef USE_MPI_F08_BINDINGS
+        Type(MPI_Request) :: rirqs(1:4), sirqs(1:4)
+#else
         Integer :: rirqs(1:4), sirqs(1:4)
+#endif
 
         Integer, Allocatable :: obs_inds(:)
 

--- a/src/Physics/Checkpointing.F90
+++ b/src/Physics/Checkpointing.F90
@@ -489,14 +489,14 @@ Contains
         Endif
 
         If (my_row_rank .eq. 0) Then
-            Call MPI_Bcast(old_radius,n_r_old, MPI_DOUBLE_PRECISION, 0, pfi%ccomm%comm, ierr)
+            Call MPI_Bcast(old_radius,n_r_old, MPI_REAL8, 0, pfi%ccomm%comm, ierr)
         Endif
-        Call MPI_Bcast(old_radius,n_r_old, MPI_DOUBLE_PRECISION, 0, pfi%rcomm%comm, ierr)
+        Call MPI_Bcast(old_radius,n_r_old, MPI_REAL8, 0, pfi%rcomm%comm, ierr)
 
         If (my_row_rank .eq. 0) Then
-            Call MPI_Bcast(dt_pars,3, MPI_DOUBLE_PRECISION, 0, pfi%ccomm%comm, ierr)
+            Call MPI_Bcast(dt_pars,3, MPI_REAL8, 0, pfi%ccomm%comm, ierr)
         Endif
-        Call MPI_Bcast(dt_pars,3, MPI_DOUBLE_PRECISION, 0, pfi%rcomm%comm, ierr)
+        Call MPI_Bcast(dt_pars,3, MPI_REAL8, 0, pfi%rcomm%comm, ierr)
 
         checkpoint_dt    = dt_pars(1)
         checkpoint_newdt = dt_pars(2)

--- a/src/Physics/Generic_Input.F90
+++ b/src/Physics/Generic_Input.F90
@@ -56,7 +56,7 @@ contains
     real*8, allocatable, dimension(:,:) :: my_lmn_coeffs, lmn_coeffs, col_coeffs, sendarr2
 
     ! set up some sizes of mpi types
-    call MPI_TYPE_GET_EXTENT(MPI_DOUBLE_PRECISION, lb, real_size, ierr)
+    call MPI_TYPE_GET_EXTENT(MPI_REAL8, lb, real_size, ierr)
     call MPI_TYPE_GET_EXTENT(MPI_INTEGER, lb, int_size, ierr)
 
     ! process 0 reads the first few parameters describing the file
@@ -162,12 +162,12 @@ contains
               disp2 = disp1 + (col_lmn_ind1(i)-1)*real_size
               call MPI_FILE_SEEK(funit, disp2, MPI_SEEK_SET, ierr)
               call MPI_FILE_READ(funit, col_coeffs(offset,1), col_lmn_count(i), &
-                                 MPI_DOUBLE_PRECISION, &
+                                 MPI_REAL8, &
                                  MPI_STATUS_IGNORE, ierr)  ! real
               disp2 = disp1 + (n_lmn+col_lmn_ind1(i)-1)*real_size
               call MPI_FILE_SEEK(funit, disp2, MPI_SEEK_SET, ierr)
               call MPI_FILE_READ(funit, col_coeffs(offset,2), col_lmn_count(i), &
-                                 MPI_DOUBLE_PRECISION, &
+                                 MPI_REAL8, &
                                  MPI_STATUS_IGNORE, ierr) ! imaginary
               offset = offset + col_lmn_count(i)
             end if
@@ -348,12 +348,12 @@ contains
               disp2 = disp1 + col_lmn_i*real_size
               call MPI_FILE_SEEK(funit, disp2, MPI_SEEK_SET, ierr)
               call MPI_FILE_READ(funit, col_coeffs(offset,1), col_lmn_n, &
-                                 MPI_DOUBLE_PRECISION, &
+                                 MPI_REAL8, &
                                  MPI_STATUS_IGNORE, ierr)  ! real
               disp2 = disp1 + (n_lmn+col_lmn_i)*real_size
               call MPI_FILE_SEEK(funit, disp2, MPI_SEEK_SET, ierr)
               call MPI_FILE_READ(funit, col_coeffs(offset,2), col_lmn_n, &
-                                 MPI_DOUBLE_PRECISION, &
+                                 MPI_REAL8, &
                                  MPI_STATUS_IGNORE, ierr) ! imaginary
               offset = offset + col_lmn_n
             end if

--- a/src/Physics/Generic_Input.F90
+++ b/src/Physics/Generic_Input.F90
@@ -46,7 +46,12 @@ contains
     integer :: l_endian_tag, version, fmode, n_lmn, l_l_max, l_n_max, k_lm_owner, l_max_n
     integer :: i, j, k, l, m, n, lm, mp, j1, jc, jn, jo, ji, p, col_np, col_mp_min
     integer :: start_count, end_count, my_lmn_count, total_lmn_count, col_lmn_n, col_lmn_i, l_lm_count
-    integer :: offset, ierr, funit
+    integer :: offset, ierr
+#ifdef USE_MPI_F08_BINDINGS
+        Type(MPI_File) :: funit
+#else
+        Integer :: funit
+#endif
     integer(kind=MPI_ADDRESS_KIND) :: lb, int_size, real_size
     integer(kind=MPI_OFFSET_KIND) :: disp1, disp2
     integer, dimension(3) :: pars

--- a/src/Physics/Generic_Input.F90
+++ b/src/Physics/Generic_Input.F90
@@ -50,7 +50,6 @@ contains
     integer(kind=MPI_ADDRESS_KIND) :: lb, int_size, real_size
     integer(kind=MPI_OFFSET_KIND) :: disp1, disp2
     integer, dimension(3) :: pars
-    integer, dimension(MPI_STATUS_SIZE) :: mstatus
     integer, allocatable, dimension(:) :: ls, ms, ns
     integer, allocatable, dimension(:) :: proc_lmn_count, col_lmn_count, col_lmn_ind1, col_coeffs_ind1, sendarri
     integer, allocatable, dimension(:,:) :: my_lmn_inds, lmn_inds, sendarri2
@@ -164,12 +163,12 @@ contains
               call MPI_FILE_SEEK(funit, disp2, MPI_SEEK_SET, ierr)
               call MPI_FILE_READ(funit, col_coeffs(offset,1), col_lmn_count(i), &
                                  MPI_DOUBLE_PRECISION, &
-                                 mstatus, ierr)  ! real
+                                 MPI_STATUS_IGNORE, ierr)  ! real
               disp2 = disp1 + (n_lmn+col_lmn_ind1(i)-1)*real_size
               call MPI_FILE_SEEK(funit, disp2, MPI_SEEK_SET, ierr)
               call MPI_FILE_READ(funit, col_coeffs(offset,2), col_lmn_count(i), &
                                  MPI_DOUBLE_PRECISION, &
-                                 mstatus, ierr) ! imaginary
+                                 MPI_STATUS_IGNORE, ierr) ! imaginary
               offset = offset + col_lmn_count(i)
             end if
           end do
@@ -350,12 +349,12 @@ contains
               call MPI_FILE_SEEK(funit, disp2, MPI_SEEK_SET, ierr)
               call MPI_FILE_READ(funit, col_coeffs(offset,1), col_lmn_n, &
                                  MPI_DOUBLE_PRECISION, &
-                                 mstatus, ierr)  ! real
+                                 MPI_STATUS_IGNORE, ierr)  ! real
               disp2 = disp1 + (n_lmn+col_lmn_i)*real_size
               call MPI_FILE_SEEK(funit, disp2, MPI_SEEK_SET, ierr)
               call MPI_FILE_READ(funit, col_coeffs(offset,2), col_lmn_n, &
                                  MPI_DOUBLE_PRECISION, &
-                                 mstatus, ierr) ! imaginary
+                                 MPI_STATUS_IGNORE, ierr) ! imaginary
               offset = offset + col_lmn_n
             end if
           end do


### PR DESCRIPTION
This PR add the new option `--mpi-f08` to `configure`, which bases all of Rayleigh's MPI calls on the `mpi_f08` module instead of the `mpi` module. The default (`mpi`) is left untouched but the hope is that the new option helps us work around many compiler warnings and errors due to stricter type checking. In the long term we probably have switch to `mpi_f08` as this is what the MPI standard highly recommends and the old `mpi` module might go away at some point.

Ideally we should have the CI build and test all MPI variants. I don't want to replicate all the code in the Github actions though. If anyone knows of a more elegant way of running the same code with different `configure` parameters, I'd appreciate it.

Rationale for adding this:
- `mpi_f08` is the only standard compliant way to use MPI from Fortran. See the discussion in [Section 19.1.1 of the MPI-4.1 standard](https://www.mpi-forum.org/docs/mpi-4.1/mpi41-report.pdf#subsection.19.1.1).
- We have had issues with the F90 module (`mpi`) and the F77 bindings (`mpif.h`), where the compiler inferred the type of the buffer argument on the first call and issued errors when the same routine was subsequently called with a different type. `mpi_f08` uses `Type(*)` buffers to avoid this.

This also includes some other MPI cleanups:
- We have supplied a variable for the status argument of many MPI calls without ever doing anything with it. By passing `MPI_STATUS_IGNORE` instead we make the code simpler and don't force the MPI library to fill a status variable we never use.
- The MPI calls used `MPI_DOUBLE_PRECISION` as the data type, even though all our buffers are declared as `Real*8`. While these are the same in most situations, the latter type of declaration is nonstandard and there is no guarantee this always yields an IEEE 754 `binary64` (double precision) number. MPI provides the `MPI_REAL8` type to have something that's compatible with the `Real*8` declaration in Rayleigh. In the long run we should switch to the standard way of declaring variables using the `kind` parameter.