### PR TITLE
Updated AZ_Avgs class to allow concatenation and time-averaging.

### DIFF
--- a/post_processing/rayleigh_diagnostics.py
+++ b/post_processing/rayleigh_diagnostics.py
@@ -1087,7 +1087,7 @@ class Shell_Avgs:
         fd.close()
 
 class AZ_Avgs:
-    """Rayleigh AZ_Avgs Structure
+    """Rayleigh Azimuthally-Averaged Data Structure
     ----------------------------------
     self.niter                                    : number of time steps
     self.nq                                       : number of diagnostic quantities output
@@ -1102,38 +1102,317 @@ class AZ_Avgs:
     self.time[0:niter-1]                          : The simulation time corresponding to each time step
     self.version                                  : The version code for this particular output (internal use)
     self.lut                                      : Lookup table for the different diagnostics output
+
+    self.time_averaged                 : If True, data has been time averaged.
+                                         In this case, iters and time have dimension 2, and contain the
+                                         initial and final times and iterations of the averaged data.
+
+    Initialization Examples:
+        (1):  Read in a single AZ_Avgs file
+              a = AZ_Avgs('00000001',path='./AZ_Avgs/')
+              
+        (2):  Time-average data from multiple AZ_Avgs files:
+              a = AZ_Avgs(['00000001','00000002'])
+              
+        (2):  Concatenate time-series data from multiple AZ_Avgs files:
+              a = AZ_Avgs(['00000001','00000002'],time_average=False)
+
+        (3):  Time-averaged data from multiple AZ_Avgs files + save data to new AZ_Avgs file:
+              a = AZ_Avgs(['00000001','00000002'],ofile='my_save_file.dat')
+              
+        (4):  Concatenate time-series data from multiple AZ_Avgs files.
+              Extract only quantity codes 401 and 402:
+              a = AZ_Avgs(['00000001','00000002'], qcodes = [401,402], time_average = False)
+
+    Additional Notes:
+        For concatenated or averaged data:
+        
+            - Output files are written in identical format to a standard AZ_Avgs file. They may be
+              read in using the same syntax described above.
+              
+            - To save concatenated or averaged data to a new file after initialization:
+              a.write('filename')  [ where 'a' is the AZ_Avgs object name]
+              
     """
 
-    def __init__(self,filename='none',path='AZ_Avgs/'):
-        """filename  : The reference state file to read.
-           path      : The directory where the file is located (if full path not in filename)
-        """
-        if (filename == 'none'):
-            the_file = path+'00000001'
-        else:
-            the_file = path+filename
-        fd = open(the_file,'rb')
-        # We read an integer to assess which endian the file was written in...
-        bs = check_endian(fd,314,'int32')
-        version = swapread(fd,dtype='int32',count=1,swap=bs)
-        nrec = swapread(fd,dtype='int32',count=1,swap=bs)
-        nr = swapread(fd,dtype='int32',count=1,swap=bs)
-        ntheta = swapread(fd,dtype='int32',count=1,swap=bs)
-        nq = swapread(fd,dtype='int32',count=1,swap=bs)
+    def __init__(self,filename='none',path='AZ_Avgs/', ofile=None, qcodes=[],time_average=True, dt = -1, nfiles=-1):
 
-        self.version = version
-        self.niter = nrec
-        self.nq = nq
-        self.nr = nr
-        self.ntheta = ntheta
+        """
+           Initializer for the AZ_Avgs class.
+           
+           Input parameters:
+               filename     : (a) {string} The AZ_Avgs file to read.
+                            : (b) {list of strings} The AZ_Avgs files whose time-series
+                               data you wish to concatenate or time-average.
+               path         : The directory where the file is located (if full path not in filename)
+               qcodes       : {optional; list of ints} Quantity codes you wish to extract (default is to extract all)
+               ofile        : {optional; string}; default = None Filename to save time-averaged data to, if desired.
+               time_average : {optional; Boolean; default = True} Time-average data from multiple files if a list is provided.
+                              If a list of files is provided and this flag is set to False, data will be concatenated instead. 
+               nfiles    : optional -- number of files to read relative to last file 
+                                       in the list (time-averaging mode only; default is all files)
+               dt        : optional -- maximum time to average over, relative to
+                                       final iteration of last file in the list
+                                       (time-averaging mode only; default is all time)                                  
+        """
+        # Check to see if we are compiling data from multiple files
+        # This is true if (a) ofile is set or (b) filename is a list of files, rather than a single string
+        # if (a) is false, but (b) is true, no output is written, but compiled output is returned        
+        
+        #(a)
+        multiple_files = False
+        mainfile=filename
+        if (ofile != None):
+            multiple_files = True
+            
+        #(b)
+        ltype = type([])        
+        ftype=type(filename)
+        if (ltype == ftype):
+            multiple_files = True
+        else:
+            if (mainfile == 'none'):
+                mainfile = path+'00000001'
+            else:
+                mainfile = path+mainfile             
+        
+        if (multiple_files):
+            mainfile = filename[0]
+        
+        # Read the main file no matter what    
+        self.read_dimensions(mainfile)   
+        self.read_data(qcodes=qcodes)
+        
+        if (multiple_files):
+            if (not time_average):
+                self.compile_multiple_files(filename, qcodes = qcodes,path=path)
+            else:
+                self.time_average_files(filename, qcodes = qcodes,path=path, dt = dt, nfiles = nfiles)
+                
+        if (ofile != None):
+            self.write(ofile)
+            
+            
+    def write(self,outfile):
+        """
+            Writing routine for AZ_Avgs class.
+            
+            Input parameters:
+               outfile  : (a) {string} The AZ_Avgs file to be written.
+
+            Calling Syntax:
+                my_shellavgs.write("my_file.dat")
+                (writes all data contained in my_shellavgs to my_file.dat, in standard AZ_Avgs format)
+
+        """
+
+        numdim = 6
+
+        one_rec = np.dtype([('vals', np.float64, [self.nq, self.nr, self.ntheta]), ('times',np.float64), ('iters', np.int32)  ])   
+
+        fstruct = np.dtype([ ('fdims', np.int32, numdim), ('qvals', np.int32,(self.nq)), ('radius',np.float64,(self.nr)), 
+                             ('costheta',np.float64,(self.ntheta)), ('fdata', one_rec, [self.niter,])  ])
+        
+                        
+        odata = np.zeros((1,),dtype=fstruct)
+        odata['fdims'][0,0]=314
+        odata[0]['fdims'][1]=self.version
+        odata[0]['fdims'][2]=self.niter
+        odata[0]['fdims'][3]=self.nr
+        odata[0]['fdims'][4]=self.ntheta
+        odata[0]['fdims'][5]=self.nq
+
+	                
+        odata[0]['qvals'][:]=self.qv[:]
+        odata[0]['radius'][:]=self.radius[:]
+        odata[0]['costheta'][:]=self.costheta[:]
+        odata[0]['fdata']['times'][:]=self.time[0:self.niter]
+        odata[0]['fdata']['iters'][:]=self.iters[0:self.niter]
+        
+        odata[0]['fdata']['vals'][:,:,:,:]=np.transpose(self.vals[:,:,:,:])
+            
+        fd = open(outfile,'wb')
+        odata.tofile(fd)
+        if (self.time_averaged):
+            self.time[1].tofile(fd)
+            self.iters[1].tofile(fd)
+        fd.close()
+        
+
+    def compile_multiple_files(self,filelist,qcodes=[],path=''):
+        """
+           Time-series concatenation routine for the AZ_Avgs class.
+           
+           Input parameters:
+               filelist  : {list of strings} The AZ_Avgs files to be concatenated.
+               path      : The directory where the files are located (if full path not in filename)
+               qcodes    : {optional; list of ints} Quantity codes you wish to extract (if not all)
+
+           Notes:
+                - This routine is incompatibile with version=1 AZ_Avgs due to lack of 
+                  moments output in that original version.  All other versions are compatible.
+                  
+                - This routine assumes radial resolution does not change across files in filelist.
+
+        """
+
+            
+        nfiles = len(filelist)
+        new_nrec = self.niter*nfiles
+        self.niter = new_nrec
+        self.vals = np.zeros((self.nr,4,self.nq,self.niter),dtype='float64')
+        self.iters = np.zeros(self.niter          ,dtype='int32')
+        self.time  = np.zeros(self.niter          ,dtype='float64')        
+        
+        k = 0
+        for i in range(nfiles):
+
+            a = AZ_Avgs(filelist[i],qcodes=qcodes,path=path)
+
+            #If the iteration count isn't constant throughout a run,
+            #we may need to resize the arrays
+            if (k+a.niter > self.niter):
+                self.niter = k+a.niter
+                self.time.resize((self.niter))
+                self.iters.resize( (self.niter))
+                # Note that using numpy's resize routine gets a little tricky here
+                # due to the striping of the vals array.  Handle this 'manually'
+                # for now
+                vals = np.zeros((self.ntheta,self.nr, self.nq,self.niter),dtype='float64')
+                vals[:,:,:,0:k] = self.vals[:,:,:,0:k]
+                self.vals = vals
+
+            self.time[k:k+a.niter]   = a.time[:]
+            self.iters[k:k+a.niter]  = a.iters[:]
+            self.vals[:,:,:,k:k+a.niter] = a.vals[:,:,:,:]
+            k+=a.niter
+            
+        # Trim off any excess zeros 
+        # (in case last file was incomplete)
+        self.niter = k
+        self.time = self.time[0:self.niter]
+        self.iters = self.iters[0:self.niter]
+        self.vals = self.vals[:,:,:,0:self.niter]
+
+
+    def time_average_files(self,filelist,qcodes=[],path='', dt=-1,nfiles=-1):
+        """
+           Time-series concatenation routine for the Shell_Avgs class.
+           
+           Input parameters:
+               filelist  : {list of strings} The Shell_Avgs files to be time-averaged.
+               path      : The directory where the files are located (if full path not in filename)
+               qcodes    : {optional; list of ints} Quantity codes you wish to extract (if not all)             
+               nfiles    : optional -- number of files to read relative to last file 
+                                       in the list (default is all files)
+               dt        : optional -- maximum time to average over, relative to
+                                       final iteration of last file in the list
+                                       (default is all time)
+           Notes:
+                  
+                - This routine assumes radial resolution does not change across files in filelist.
+                - This routine assumes that each file contains AT LEAST 2 timesteps.
+        """
+        
+        numfiles = len(filelist)
+        flast = -1
+        if (nfiles > 0):
+            flast = numfiles-nfiles
+        if (flast < 0):
+            flast = 0
+            
+
+        self.niter = 1
+        self.vals = np.zeros((self.ntheta, self.nr,self.nq,1),dtype='float64')
+        self.iters = np.zeros(2          ,dtype='int32')
+        self.time  = np.zeros(2          ,dtype='float64')        
+        
+        #Integrate in time using a midpoint method.
+        last_dt = 0.0
+        total_time = 0.0
+
+        # Read the initial file (last in the list). 
+        # Go ahead and store the last time and iteration in that file.
+        a = AZ_Avgs(filelist[numfiles-1],qcodes=qcodes,path=path)
+        self.iters[1] = a.iters[a.niter-1]
+        self.time[1] = a.time[a.niter-1]
+
+        for i in range(numfiles-1,flast-1,-1):
+
+            weights = np.zeros(a.niter,dtype='float64')
+            
+            if (i != 0):
+                #Read in the next file for time-step information
+                b = AZ_Avgs(filelist[i-1],qcodes=qcodes,path=path)
+            
+            weights[a.niter-1] = 0.5*(last_dt+a.time[a.niter-1]-a.time[a.niter-2])
+            for j in range(a.niter-2,0,-1):
+                weights[j] = 0.5*(a.time[j+1] -a.time[j-1])
+                
+            if (i != 0):
+                last_dt = a.time[0]-b.time[b.niter-1]
+                if (a.niter > 1):
+                    weights[0] = 0.5*(a.time[1]-b.time[b.niter-1])
+                else:
+                   weights[0] = (a.time[0]-b.time[b.niter-1])
+            else:
+                weights[0] = 0.5*(a.time[1]-a.time[0])
+
+            
+            for j in range(a.niter):
+                time_check = True
+                if (dt > 0):
+                    dt0 = self.time[1]-a.time[j]
+                    if (dt0 > dt):
+                        time_check = False
+                if (time_check):
+                    self.vals[:,:,:,0]+=a.vals[:,:,:,j]*weights[j]
+                    total_time += weights[j]
+                    self.iters[0] = a.iters[j]
+                    self.time[0] = a.time[j]
+
+            if (i != flast):
+                a = b
+
+        self.vals = self.vals/total_time
+        self.version=-self.version # negative version numbers indicate time-averaging
+        self.time_averaged = True
+
+        
+        
+    def read_data(self,qcodes = []):
+        """
+           Data-reading routine for the AZ_Avgs class.
+           
+           Input parameters:
+               qcodes    : {optional; list of ints} Quantity codes you wish to extract (if not all)
+               ntheta    : {optional; int; default = 0} Set this value to correct the variance in 
+                           version=2 AZ_Avgs (only mean is preserved otherwise for that version).
+           
+           Notes:
+                - This routine does not read header information.  Read_dimensions must be called first
+                  so that dimentions and the file descriptor are initialized. 
+        """
+    
+        self.vals  = np.zeros((self.ntheta, self.nr, self.nq, self.niter),dtype='float64')
+        self.iters = np.zeros(self.niter+self.time_averaged          ,dtype='int32')
+        self.time  = np.zeros(self.niter+self.time_averaged          ,dtype='float64')
+
+        #############################################
+        # Revision:
+        nq = self.nq
+        ntheta=self.ntheta
+        niter=self.niter
+        nr = self.nr
+        bs = self.byteswap
+        fd = self.fd
+        nrec = niter
 
         self.qv = np.reshape(swapread(fd,dtype='int32',count=nq,swap=bs),(nq), order = 'F')
         self.radius = np.reshape(swapread(fd,dtype='float64',count=nr,swap=bs),(nr), order = 'F')
         self.costheta = np.reshape(swapread(fd,dtype='float64',count=ntheta,swap=bs),(ntheta), order = 'F')
         self.sintheta = (1.0-self.costheta**2)**0.5
-        self.vals  = np.zeros((ntheta,nr,nq,nrec),dtype='float64')
-        self.iters = np.zeros(nrec,dtype='int32')
-        self.time  = np.zeros(nrec,dtype='float64')
+
 
         for i in range(nrec):
             tmp = np.reshape(swapread(fd,dtype='float64',count=nq*nr*ntheta,swap=bs),(ntheta,nr,nq), order = 'F')
@@ -1141,8 +1420,52 @@ class AZ_Avgs:
             self.time[i] = swapread(fd,dtype='float64',count=1,swap=bs)
             self.iters[i] = swapread(fd,dtype='int32',count=1,swap=bs)
 
-        self.lut = get_lut(self.qv)
-        fd.close()
+        if (self.time_averaged):
+            self.time[1] = swapread(fd,dtype='float64',count=1,swap=bs)
+            self.iters[1] = swapread(fd,dtype='int32',count=1,swap=bs) 
+            
+        self.fd.close()
+
+        self.lut = get_lut(self.qv)  # Lookup table        
+            
+    def read_dimensions(self,the_file,closefile=False):
+        """
+        
+            Header-reading routine for the AZ_Avgs class.
+            
+            This routine initialized the file descriptor and reads the dimensions 
+            and Endian information of a AZ_Avgs file only. It does not read the AZ_Avgs data itself.
+
+           
+            Input parameters:
+               the_file    : {string} AZ_Avgs file whose header is to be read.
+               closefile   : (Boolean; optional; default=False) Set to True to close the file 
+                             after reading the header information. 
+                   
+
+        """
+        print(the_file)
+        self.fd = open(the_file,'rb')        
+        specs = np.fromfile(self.fd,dtype='int32',count=6)
+        bcheck = specs[0]       # If not 314, we need to swap the bytes
+        self.byteswap = False
+        if (bcheck != 314):
+            specs.byteswap()
+            self.byteswap = True
+            
+        self.version = specs[1]
+        self.niter   = specs[2]
+        self.nr      = specs[3]
+        self.ntheta  = specs[4]
+        self.nq      = specs[5]
+
+        if (self.niter > 7):
+            self.niter = 7
+        
+        self.time_averaged = (self.version < 0)
+        if (closefile):
+            self.fd.close()
+
 
 class Point_Probes:
     """Rayleigh Point Probes Structure


### PR DESCRIPTION
This PR modifies the AZ_Avgs class so that it also accepts a list of multiple AZ_Avgs files. That data can either be concatenated or time-averaged as described in docstring. In addition, the class now contains an output method so that the current AZ_Avgs object structure can be saved to a new AZ_Avgs file.

Some notes:
1) Single files can still be read as they always have been.
2) This is a lot of new code. I've been using this new version of the AZ_Avgs class for a couple of years now. When doing a review, the most straightforward path is probably to test out the concatenation and time-averaging functionality.
