### PR TITLE
equation_coefficients class can now read old equation_coefficients files (again)

### DIFF
--- a/post_processing/reference_tools.py
+++ b/post_processing/reference_tools.py
@@ -104,7 +104,9 @@ class equation_coefficients:
         if self.version == 1:
             self.nconst = 11
             self.version = class_version
-            self.constants[10] = 1.
+            # need to increase constants array length by 1 (it's length 10)
+            # and the final entry should be 1.0
+            self.constants = numpy.array(self.constants.tolist() + [1.])
             print("Version of input file was 1.")
             print("Converting current equation_coefficients instance's version to %i." %class_version)
 


### PR DESCRIPTION
This fixes another inadvertent error in the recent pull request #495 which broke the ability of the Python class equation_coefficients() to read the relevant equation_coefficients files with version 1. The problem was that the routine expected the length of the constants array to be 11, but only 10 constants were read in with version 1. This is fixed by simply increasing the length of the constants array and simultaneously entering "1.0" for the last entry. 