### PR TITLE
Updated header size for "IV. Global Averages"

### DIFF
--- a/post_processing/Diagnostic_Plotting.ipynb
+++ b/post_processing/Diagnostic_Plotting.ipynb
@@ -218,7 +218,7 @@
    "metadata": {},
    "source": [
     "IV.  Global Averages\n",
-    "------------\n",
+    "=========\n",
     "\n",
     "**Summary:**   Full-volume averages of requested output variables over the full, spherical shell\n",
     "\n",
@@ -1819,7 +1819,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -1833,7 +1833,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.9.6"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This PR fixes a minor heading-size issue.  In the section of the documentation that describes how to plot output from Rayleigh, the Diagnostics_Plotting.ipynb notebook is displayed on the screen.  The section on plotting global averages had a smaller heading size than the other sections, preventing it from appearing in the index/table of contents displayed in the documentation. 