### PR TITLE
Update Diagnostics_Thermal_Equation.F90

### DIFF
--- a/src/Diagnostics/Diagnostics_Thermal_Equation.F90
+++ b/src/Diagnostics/Diagnostics_Thermal_Equation.F90
@@ -917,6 +917,7 @@ Contains
         !The "Flux" associated with the volume heating
         If (compute_quantity(vol_heat_flux)) Then
             ! Note that radial_integral_weights give int{f r^2}/int(r^2}
+            tmp1d(N_R) = 0.0d0 ! Initialize heat flux to zero at lower boundary
             Do r = N_R-1, 1,-1
                 mean_rho = half*(ref%density(r)     +  ref%density(r+1)    )
                 mean_t   = half*(ref%temperature(r) +  ref%temperature(r+1))


### PR DESCRIPTION
There was a bug in the heat flux (1433) calculation because tmp1d was allocated, but never initialized to zero. Often it would be zero and so the code would run fine, but occasionally NaNs were output in 1433. The initialization should fix this issue.