### PR TITLE
IO Bug Fix

### DIFF
--- a/src/IO/Spherical_IO.F90
+++ b/src/IO/Spherical_IO.F90
@@ -776,11 +776,12 @@ Contains
                 ! 12 is for the simtime+iteration at the end.
                 full_disp = self%buffer%qdisp*self%buffer%nvals+12 
                 new_disp = self%hdisp+full_disp*(self%current_rec-ncache)
-                !If (responsible) Write(6,*)'check disp: ', self%buffer%qdisp, self%buffer%ncache, self%buffer%spectral
 
-                Call self%buffer%write_data(disp=new_disp,file_unit=funit)
-                Call self%buffer%reset_cache_index()
-                If (output_rank) Call self%closefile_par()
+                If (self%file_open) Then
+                    Call self%buffer%write_data(disp=new_disp,file_unit=funit)
+                    Call self%buffer%reset_cache_index()
+                    If (output_rank) Call self%closefile_par()
+                Endif
 
             Endif            
 


### PR DESCRIPTION
This fixes a subtle bug in Rayleigh.  When opening a file for parallel I/O, Rayleigh records the error code.  It was intended that if a nonzero error code was found, so that the file_open variable remained false, no subsequent file operations would be performed.  A check on the file_open variable was missing, however, for everything but the operations related to writing the file header data.   This PR fixes this bug.

I've been emailing with @illorenzo7 and the NASA HECC staff about this already today, so I'm assigning the review to him.

-Nick

p.s.  I also removed a commented line of debugging code.