### PR TITLE
fix rendering of code-block in documentation

### DIFF
--- a/doc/source/User_Guide/getting_started.rst
+++ b/doc/source/User_Guide/getting_started.rst
@@ -40,6 +40,7 @@ named "radev" and installs all necessary packages.  The third line activates the
 This command will likely take a while (a few minutes).
 
 If you want to undo the change to the channel priority setting afterwards, you can run
+
 .. code-block:: bash
 
     conda config --set channel_priority flexible


### PR DESCRIPTION
An empty line is needed for interpreting the code-block correctly.