### PR TITLE
Add dependabot file

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+# Set update schedule for GitHub Actions
+
+version: 2
+updates:
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      # Check for updates to GitHub Actions every week
+      interval: "weekly"


### PR DESCRIPTION
Github actions has an automatic action that checks the Github actions we are using for newer versions and automatically creates pull requests to update these actions to the latest version. One example of this can be seen here: https://github.com/geodynamics/aspect/pull/5922. I think this would be useful for Rayleigh too to make sure we stay up to date and prevent security issues in the CI pipeline. Just adding this configuration file should enable the bot (it will probably create a bunch of PRs right away, but then will only occasionally find something).