### PR TITLE
fix recursive doc build

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -47,7 +47,7 @@ templates_path = ['_templates']
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path.
-exclude_patterns = ['_build','doc/build' '**.ipynb_checkpoints']
+exclude_patterns = ['_build', 'doc/build', '**.ipynb_checkpoints']
 nbsphinx_allow_errors = True
 nbsphinx_execute = 'never'
 


### PR DESCRIPTION
Our documentation build kept recursively ingesting the `doc/build` directory, which made everything slow down with every build.

The reason was a missing comma in exclude_patterns. That caused the two adjacent strings to be merged and prevented `doc/build` from being excluded.

Now subsequent builds are instant if nothing has changed.