### PR TITLE
Bug Fix:  Checkpoint file size

### DIFF
--- a/src/IO/Parallel_IO.F90
+++ b/src/IO/Parallel_IO.F90
@@ -1558,6 +1558,7 @@ Contains
         Logical, Intent(In), Optional :: clear_existing
         Integer(kind=MPI_OFFSET_KIND), Intent(In), Optional :: disp
         Integer(kind=MPI_OFFSET_KIND) :: hdisp, tdisp, fdisp, bdisp
+        Integer(kind=MPI_OFFSET_KIND) :: zero_file_size = 0
 
         ! A baseline displacement within the file can be passed to this routine.
         ! Can be due to header and/or multiple prior records.
@@ -1581,7 +1582,7 @@ Contains
 
                     If (present(clear_existing)) Then
                         If (clear_existing) Then
-                            Call MPI_FILE_set_size(funit, 0, ierr)
+                            Call MPI_FILE_set_size(funit, zero_file_size, ierr)
                         Endif
                     Endif
 

--- a/src/IO/Parallel_IO.F90
+++ b/src/IO/Parallel_IO.F90
@@ -1574,14 +1574,19 @@ Contains
             If (present(filename)) Then
                 ! The file is not open.  We must create it.
                 If (self%output_rank) Then
-                    If (present(clear_existing)) Then
-                        If (clear_existing) Then
-                            Call MPI_File_delete(filename, MPI_INFO_NULL, ierr)
-                        Endif
-                    Endif
+                    !If (present(clear_existing)) Then
+                    !    If (clear_existing) Then
+                    !        Call MPI_File_delete(filename, MPI_INFO_NULL, ierr)
+                    !    Endif
+                    !Endif
                     Call MPI_FILE_OPEN(self%ocomm%comm, filename, & 
                            MPI_MODE_WRONLY + MPI_MODE_CREATE, & 
                            MPI_INFO_NULL, funit, ierr) 
+                    If (present(clear_existing)) Then
+                        If (clear_existing) Then
+                            Call MPI_FILE_set_size(funit, 0, ierr)
+                        Endif
+                    Endif
                 Endif
             Else
                 error = .true.

--- a/src/IO/Parallel_IO.F90
+++ b/src/IO/Parallel_IO.F90
@@ -1542,7 +1542,7 @@ Contains
 
     End Subroutine Collate_Physical
 
-    Subroutine Write_Data(self,disp,file_unit,filename)
+    Subroutine Write_Data(self,disp,file_unit,filename,clear_existing)
         Implicit None
         Class(io_buffer) :: self
         Character*120, Intent(In), Optional :: filename
@@ -1555,6 +1555,7 @@ Contains
         Integer :: funit
 #endif
         Logical :: error
+        Logical, Intent(In), Optional :: clear_existing
         Integer(kind=MPI_OFFSET_KIND), Intent(In), Optional :: disp
         Integer(kind=MPI_OFFSET_KIND) :: hdisp, tdisp, fdisp, bdisp
 
@@ -1573,6 +1574,11 @@ Contains
             If (present(filename)) Then
                 ! The file is not open.  We must create it.
                 If (self%output_rank) Then
+                    If (present(clear_existing)) Then
+                        If (clear_existing) Then
+                            Call MPI_File_delete(filename, MPI_INFO_NULL, ierr)
+                        Endif
+                    Endif
                     Call MPI_FILE_OPEN(self%ocomm%comm, filename, & 
                            MPI_MODE_WRONLY + MPI_MODE_CREATE, & 
                            MPI_INFO_NULL, funit, ierr) 

--- a/src/IO/Parallel_IO.F90
+++ b/src/IO/Parallel_IO.F90
@@ -1574,19 +1574,17 @@ Contains
             If (present(filename)) Then
                 ! The file is not open.  We must create it.
                 If (self%output_rank) Then
-                    !If (present(clear_existing)) Then
-                    !    If (clear_existing) Then
-                    !        Call MPI_File_delete(filename, MPI_INFO_NULL, ierr)
-                    !    Endif
-                    !Endif
+
                     Call MPI_FILE_OPEN(self%ocomm%comm, filename, & 
                            MPI_MODE_WRONLY + MPI_MODE_CREATE, & 
                            MPI_INFO_NULL, funit, ierr) 
+
                     If (present(clear_existing)) Then
                         If (clear_existing) Then
                             Call MPI_FILE_set_size(funit, 0, ierr)
                         Endif
                     Endif
+
                 Endif
             Else
                 error = .true.

--- a/src/Physics/Checkpointing.F90
+++ b/src/Physics/Checkpointing.F90
@@ -167,7 +167,7 @@ Contains
         Do i = 1, numfields*2
             checkfile = Trim(my_path)//trim(checkpoint_prefix)//'/'//trim(checkpoint_suffix(i))
             Call checkpoint_buffer%cache_data_spectral(chktmp%s2a,i)
-            Call checkpoint_buffer%write_data(filename=checkfile)
+            Call checkpoint_buffer%write_data(filename=checkfile, clear_existing = .true.)
 
         Enddo
 
@@ -187,7 +187,7 @@ Contains
 
         checkfile = TRIM(my_path)//TRIM(checkpoint_prefix)//'/boundary_conditions'
         Call checkpoint_buffer%cache_data_spectral(bctmp%s2a,1)
-        Call checkpoint_buffer%write_data(filename=checkfile)
+        Call checkpoint_buffer%write_data(filename=checkfile, clear_existing = .true.)
 
         Call bctmp%deconstruct('s2a')
         !/////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
This fixes a bug in Rayleigh where a checkpoint file can appear to be too large if the file existed and was overwritten in a subsequent run with lower resolution.   This PR ensures that the file is deleted before being written to, preventing this bug.