### PR TITLE
Fix container push

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -42,6 +42,12 @@ jobs:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_LOGIN }}
 
+      - name: set lower case repository name
+        run: |
+          echo "REPO_NAME_LC=${REPO_NAME,,}" >> ${GITHUB_ENV}
+        env:
+          REPO_NAME: '${{ github.repository }}'
+
       - name: Build and push Docker image for main
         if: contains(github.event_name, 'push')
         uses: docker/build-push-action@v6
@@ -52,8 +58,8 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           tags: |
-            ghcr.io/${{ github.repository }}:latest
-            ${{ github.repository }}:latest
+            ghcr.io/${{env.REPO_NAME_LC}}:latest
+            ${{env.REPO_NAME_LC}}:latest
 
       - name: Build and push Docker image for release
         if: contains(github.event_name, 'release')
@@ -65,5 +71,5 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           tags: |
-            ghcr.io/${{ github.repository }}:${{github.ref_name}}
-            ${{ github.repository }}:${{github.ref_name}}
+            ghcr.io/${{env.REPO_NAME_LC}}:${{github.ref_name}}
+            ${{env.REPO_NAME_LC}}:${{github.ref_name}}


### PR DESCRIPTION
The Rayleigh automatic docker container build had problems for a while (maybe forever?), because it no longer builds containers with capital letters (like geodynamics/Rayleigh), but instead requires lowercase letter (geodynamics/rayleigh). This PR modifies our automatic build script to create an environment variable (`REPO_NAME_LC`) which contains the lowercase repository name (`rayleigh`) and use that as the docker container name. I tested that it works now on my own repository, see the container images created here: https://hub.docker.com/r/gassmoeller/rayleigh/tags
and here: https://github.com/gassmoeller/Rayleigh/pkgs/container/rayleigh

Once this is merged it will trigger a build run for the official Rayleigh images on
Dockerhub: https://hub.docker.com/r/geodynamics/rayleigh/tags
Github Container Registry: https://github.com/orgs/geodynamics/packages?repo_name=Rayleigh (currently empty)
