### PR TITLE
removed references to standard c++ libraries

### DIFF
--- a/configure
+++ b/configure
@@ -838,9 +838,9 @@ echo ""
 # Standard LIBRARIES
 if [[ $OSTYPE == *"darwin"* ]]
 then
-    STD_FLAGS="-lc++"
+    STD_FLAGS=""
 else
-    STD_FLAGS="-lstdc++"
+    STD_FLAGS=""
 fi
 
 ###############################################################################################


### PR DESCRIPTION
Rayleigh does not require references to standard c++ libraries in the configure file in order to make directories. 