### PR TITLE
add CMake support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -131,3 +131,8 @@ jobs:
         ./configure --openblas --with-blas=$CONDA_PREFIX --with-fftw=$CONDA_PREFIX --FC=mpifort --FFLAGS_DBG='-O0 -g -fbounds-check -ffpe-trap=invalid,zero,overflow -fbacktrace -ffixed-line-length-132 -Wall'
         make -j
         make install
+    - name: Build Rayleigh (CMake)
+      run: |
+        cd "$GITHUB_WORKSPACE"
+        cmake -Bbuild
+        cmake --build build -j -t install

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - The streamfunction equations solved by Rayleigh have been added to the documentation.   \[Tami Rogers; 6-20-2024; [#533](https://github.com/geodynamics/Rayleigh/pull/533)\]
 
+
 - Rayleigh now supports increasing radial resolution even when there are multiple Chebyshev domains.   \[Loren Matilsky; 6-20-2024; [#537](https://github.com/geodynamics/Rayleigh/pull/537)\]
+
+- Rayleigh can now also be built using CMake in addtion to the `configure` script.    \[Philipp Edelmann; 6-21-2024; [#536](https://github.com/geodynamics/Rayleigh/pull/536)\]
 
 ### Changed
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,8 @@ project(rayleigh LANGUAGES C Fortran)
 
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake)
 
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
 find_package(MPI COMPONENTS C REQUIRED Fortran REQUIRED)
 find_package(LAPACK COMPONENTS Fortran REQUIRED)
 find_package(FFTW REQUIRED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.28)
+cmake_minimum_required(VERSION 3.13)
 
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,11 @@
+cmake_minimum_required(VERSION 3.28)
+
+list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake)
+
+project(rayleigh LANGUAGES C Fortran)
+
+find_package(MPI COMPONENTS C REQUIRED Fortran REQUIRED)
+find_package(LAPACK COMPONENTS Fortran REQUIRED)
+find_package(FFTW REQUIRED)
+
+add_subdirectory(src)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,3 +1,22 @@
+#
+#  Copyright (C) 2024 by the authors of the RAYLEIGH code.
+#
+#  This file is part of RAYLEIGH.
+#
+#  RAYLEIGH is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 3, or (at your option)
+#  any later version.
+#
+#  RAYLEIGH is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with RAYLEIGH; see the file LICENSE.  If not see
+#  <http://www.gnu.org/licenses/>.
+
 cmake_minimum_required(VERSION 3.13)
 
 project(rayleigh LANGUAGES C Fortran)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,8 @@
 cmake_minimum_required(VERSION 3.13)
 
-list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake)
-
 project(rayleigh LANGUAGES C Fortran)
+
+list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake)
 
 find_package(MPI COMPONENTS C REQUIRED Fortran REQUIRED)
 find_package(LAPACK COMPONENTS Fortran REQUIRED)

--- a/cmake/FindFFTW.cmake
+++ b/cmake/FindFFTW.cmake
@@ -1,0 +1,286 @@
+# (C) Copyright 2011- ECMWF.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation nor
+# does it submit to any jurisdiction.
+
+##############################################################################
+#.rst:
+#
+# FindFFTW
+# ========
+#
+# Find the FFTW library. ::
+#
+#   find_package(FFTW [REQUIRED] [QUIET]
+#                [COMPONENTS [single] [double] [long_double] [quad]])
+#
+# By default, search for the double precision library ``fftw3``
+#
+# Search procedure
+# ----------------
+#
+# 1) FFTW_LIBRARIES and FFTW_INCLUDE_DIRS set by user
+#    --> Nothing is searched and these variables are used instead
+#
+# 2) Find MKL implementation via FFTW_ENABLE_MKL
+#    --> If FFTW_ENABLE_MKL is explicitely set to ON, only MKL is considered
+#        If FFTW_ENABLE_MKL is explictely set to OFF, MKL will not be considered
+#        If FFTW_ENABLE_MKL is undefined, MKL is preferred unless ENABLE_MKL is explicitely set to OFF
+#    --> MKLROOT environment variable helps to detect MKL (See FindMKL.cmake)
+#
+# 3) Find official FFTW impelementation
+#    --> FFTW_ROOT variable / environment variable helps to detect FFTW
+#
+# Components
+# ----------
+#
+# If a different version or multiple versions of the library are required,
+# these need to be specified as ``COMPONENTS``. Note that double must be given
+# explicitly if any ``COMPONENTS`` are specified.
+#
+# The libraries corresponding to each of the ``COMPONENTS`` are:
+#
+# :single:      ``FFTW::fftw3f``
+# :double:      ``FFTW::fftw3``
+# :long_double: ``FFTW::fftw3l``
+# :quad:        ``FFTW::fftw3q``
+#
+# Output variables
+# ----------------
+#
+# The following CMake variables are set on completion:
+#
+# :FFTW_FOUND:            true if FFTW is found on the system
+# :FFTW_LIBRARIES:        full paths to requested FFTW libraries
+# :FFTW_INCLUDE_DIRS:     FFTW include directory
+#
+# Input variables
+# ---------------
+#
+# The following CMake variables are checked by the function:
+#
+# :FFTW_USE_STATIC_LIBS:  if true, only static libraries are found
+# :FFTW_ROOT:             if set, this path is exclusively searched
+# :FFTW_DIR:              equivalent to FFTW_ROOT (deprecated)
+# :FFTW_PATH:             equivalent to FFTW_ROOT (deprecated)
+# :FFTW_LIBRARIES:        User overriden FFTW libraries
+# :FFTW_INCLUDE_DIRS:     User overriden FFTW includes directories
+# :FFTW_ENABLE_MKL:       User requests use of MKL implementation
+#
+##############################################################################
+
+list( APPEND _possible_components double single long_double quad )
+
+if( NOT FFTW_FIND_COMPONENTS )
+  set( FFTW_FIND_COMPONENTS double )
+endif()
+
+set( FFTW_double_LIBRARY_NAME fftw3 )
+set( FFTW_single_LIBRARY_NAME fftw3f )
+set( FFTW_long_double_LIBRARY_NAME fftw3l )
+set( FFTW_quad_LIBRARY_NAME fftw3q )
+
+macro( FFTW_CHECK_ALL_COMPONENTS )
+    set( FFTW_FOUND_ALL_COMPONENTS TRUE )
+    foreach( _component ${FFTW_FIND_COMPONENTS} )
+        if( NOT FFTW_${_component}_FOUND )
+            set( FFTW_FOUND_ALL_COMPONENTS false )
+        endif()
+    endforeach()
+endmacro()
+
+# Command line override
+foreach( _component ${FFTW_FIND_COMPONENTS} )
+    if( NOT FFTW_${_component}_LIBRARIES AND FFTW_LIBRARIES )
+        set( FFTW_${_component}_LIBRARIES ${FFTW_LIBRARIES} )
+    endif()
+    if( FFTW_${_component}_LIBRARIES )
+        set( FFTW_${_component}_FOUND TRUE )
+    endif()
+endforeach()
+
+### Check MKL
+FFTW_CHECK_ALL_COMPONENTS()
+if( NOT FFTW_FOUND_ALL_COMPONENTS )
+
+    if( NOT DEFINED FFTW_ENABLE_MKL AND NOT DEFINED ENABLE_MKL )
+        set( FFTW_ENABLE_MKL ON )
+        set( FFTW_FindMKL_OPTIONS QUIET )
+    elseif( FFTW_ENABLE_MKL )
+        set( FFTW_MKL_REQUIRED TRUE )
+    elseif( ENABLE_MKL AND NOT DEFINED FFTW_ENABLE_MKL )
+        set( FFTW_ENABLE_MKL ON )
+    endif()
+
+    if( FFTW_ENABLE_MKL )
+        if( NOT MKL_FOUND )
+            find_package( MKL ${FFTW_FindMKL_OPTIONS} )
+        endif()
+        if( MKL_FOUND )
+            if( NOT FFTW_INCLUDE_DIRS )
+                set( FFTW_INCLUDE_DIRS ${MKL_INCLUDE_DIRS}/fftw )
+            endif()
+            if( NOT FFTW_LIBRARIES )
+                set( FFTW_LIBRARIES ${MKL_LIBRARIES} )
+            endif()
+
+            foreach( _component ${FFTW_FIND_COMPONENTS} )
+                set( FFTW_${_component}_FOUND TRUE )
+                set( FFTW_${_component}_LIBRARIES ${MKL_LIBRARIES} )
+            endforeach()
+        else()
+            if( FFTW_MKL_REQUIRED )
+                if( FFTW_FIND_REQUIRED )
+                    message(CRITICAL "FindFFTW: MKL required, but MKL was not found" )
+                else()
+                    if( NOT FFTW_MKL_FIND_QUIETLY )
+                        message(STATUS "FindFFTW: MKL required, but MKL was not found" )
+                    endif()
+                    set( FFTW_FOUND FALSE )
+                    return()
+                endif()
+            endif()
+        endif()
+    endif()
+endif()
+
+### Standard FFTW
+if( (NOT FFTW_ROOT) AND EXISTS $ENV{FFTW_ROOT} )
+    set( FFTW_ROOT $ENV{FFTW_ROOT} )
+endif()
+if( (NOT FFTW_ROOT) AND FFTW_DIR )
+    set( FFTW_ROOT ${FFTW_DIR} )
+endif()
+if( (NOT FFTW_ROOT) AND EXISTS $ENV{FFTW_DIR} )
+    set( FFTW_ROOT $ENV{FFTW_DIR} )
+endif()
+if( (NOT FFTW_ROOT) AND FFTWDIR )
+    set( FFTW_ROOT ${FFTWDIR} )
+endif()
+if( (NOT FFTW_ROOT) AND EXISTS $ENV{FFTWDIR} )
+    set( FFTW_ROOT $ENV{FFTWDIR} )
+endif()
+if( (NOT FFTW_ROOT) AND FFTW_PATH )
+    set( FFTW_ROOT ${FFTW_PATH} )
+endif()
+if( (NOT FFTW_ROOT) AND EXISTS $ENV{FFTW_PATH})
+    set( FFTW_ROOT $ENV{FFTW_PATH} )
+endif()
+
+if( FFTW_ROOT ) # On cc[a|b|t] FFTW_DIR is set to the lib directory :(
+    get_filename_component(_dirname ${FFTW_ROOT} NAME)
+    if( _dirname MATCHES "lib" )
+        set( FFTW_ROOT "${FFTW_ROOT}/.." )
+    endif()
+endif()
+
+if( NOT FFTW_ROOT )
+    # Check if we can use PkgConfig
+    find_package(PkgConfig)
+
+    #Determine from PKG
+    if( PKG_CONFIG_FOUND AND NOT FFTW_ROOT )
+        pkg_check_modules( PKG_FFTW QUIET "fftw3" )
+    endif()
+endif()
+
+#Check whether to search static or dynamic libs
+set( CMAKE_FIND_LIBRARY_SUFFIXES_SAV ${CMAKE_FIND_LIBRARY_SUFFIXES} )
+
+if( ${FFTW_USE_STATIC_LIBS} )
+    set( CMAKE_FIND_LIBRARY_SUFFIXES ${CMAKE_STATIC_LIBRARY_SUFFIX} )
+else()
+    set( CMAKE_FIND_LIBRARY_SUFFIXES ${CMAKE_SHARED_LIBRARY_SUFFIX} )
+endif()
+
+
+if( FFTW_ROOT )
+    set( _default_paths NO_DEFAULT_PATH )
+    set( _lib_paths ${FFTW_ROOT} )
+    set( _include_paths ${FFTW_ROOT} )
+else()
+    set( _lib_paths ${PKG_FFTW_LIBRARY_DIRS} ${LIB_INSTALL_DIR} )
+    set( _include_paths ${PKG_FFTW_INCLUDE_DIRS} ${INCLUDE_INSTALL_DIR} )
+endif()
+
+# find includes
+if( NOT FFTW_INCLUDE_DIRS )
+    find_path(
+        FFTW_INCLUDE_DIR
+        NAMES "fftw3.h"
+        PATHS ${_include_paths}
+        PATH_SUFFIXES "include"
+        ${_default_paths}
+        )
+    if( NOT FFTW_INCLUDE_DIR )
+        if( NOT FFTW_FIND_QUIETLY OR FFTW_FIND_REQUIRED )
+            message( STATUS "FindFFTW: fftw include headers not found")
+        endif()
+    endif()
+
+    set( FFTW_INCLUDE_DIRS ${FFTW_INCLUDE_DIR} )
+endif()
+
+# find libs
+foreach( _component ${FFTW_FIND_COMPONENTS} )
+    if( NOT FFTW_${_component}_LIBRARIES )
+        find_library(
+            FFTW_${_component}_LIB
+            NAMES ${FFTW_${_component}_LIBRARY_NAME}
+            PATHS ${_lib_paths}
+            PATH_SUFFIXES "lib" "lib64"
+            ${_default_paths}
+            )
+        set( FFTW_${_component}_LIBRARIES ${FFTW_${_component}_LIB} )
+        if( FFTW_${_component}_LIBRARIES )
+            set( FFTW_${_component}_FOUND TRUE )
+        else()
+            if( NOT FFTW_FIND_QUIETLY OR FFTW_FIND_REQUIRED )
+                message(STATUS "FindFFTW: ${_component} precision required, but ${FFTW_${_component}_LIBRARY_NAME} was not found")
+            endif()
+            set( FFTW_${_component}_FOUND FALSE )
+        endif()
+    endif()
+endforeach()
+
+# Assemble FFTW_LIBRARIES
+if( NOT FFTW_LIBRARIES )
+    foreach( _component ${FFTW_FIND_COMPONENTS} )
+        list( APPEND FFTW_LIBRARIES ${FFTW_${_component}_LIBRARIES} )
+    endforeach()
+    list( REMOVE_DUPLICATES FFTW_LIBRARIES )
+endif()
+
+# FFTW CREATE_INTERFACE_TARGETS
+foreach( _component ${FFTW_FIND_COMPONENTS} )
+    set( _target FFTW::${FFTW_${_component}_LIBRARY_NAME} )
+
+    if( FFTW_${_component}_FOUND AND NOT TARGET ${_target} )
+        add_library( ${_target} INTERFACE IMPORTED )
+        target_link_libraries( ${_target} INTERFACE ${FFTW_${_component}_LIBRARIES} )
+        target_include_directories( ${_target} INTERFACE ${FFTW_INCLUDE_DIRS} )
+    endif()
+endforeach()
+
+if( NOT FFTW_FIND_QUIETLY AND FFTW_LIBRARIES )
+  message( STATUS "FFTW targets:" )
+  foreach( _component ${FFTW_FIND_COMPONENTS} )
+    set( _target FFTW::${FFTW_${_component}_LIBRARY_NAME} )
+    message( STATUS "    ${_target} (${_component} precision)  [${FFTW_${_component}_LIBRARIES}]")
+  endforeach()
+endif()
+
+
+set( CMAKE_FIND_LIBRARY_SUFFIXES ${CMAKE_FIND_LIBRARY_SUFFIXES_SAV} )
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args( FFTW
+                                   REQUIRED_VARS FFTW_INCLUDE_DIRS FFTW_LIBRARIES
+                                   HANDLE_COMPONENTS )
+
+set( FFTW_INCLUDES ${FFTW_INCLUDE_DIRS} ) # deprecated
+set( FFTW_LIB ${FFTW_double_LIBRARIES} ) # deprecated
+mark_as_advanced(FFTW_INCLUDE_DIRS FFTW_LIBRARIES FFTW_LIB)

--- a/cmake/FindMKL.cmake
+++ b/cmake/FindMKL.cmake
@@ -1,0 +1,91 @@
+# (C) Copyright 2011- ECMWF.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+# - Try to find MKL
+# Once done this will define
+#
+#  MKL_FOUND         - system has Intel MKL
+#  MKL_INCLUDE_DIRS  - the MKL include directories
+#  MKL_LIBRARIES     - link these to use MKL
+#
+# The following paths will be searched with priority if set in CMake or env
+#
+#  MKLROOT           - root directory of the MKL installation
+#  MKL_PATH          - root directory of the MKL installation
+#  MKL_ROOT          - root directory of the MKL installation
+
+option( MKL_PARALLEL "if mkl shoudl be parallel" OFF )
+
+if( MKL_PARALLEL )
+
+  set( __mkl_lib_par  MKL_LIB_INTEL_THREAD )
+  set( __mkl_lib_name mkl_intel_thread )
+
+  find_package(Threads)
+
+else()
+
+  set( __mkl_lib_par MKL_LIB_SEQUENTIAL )
+  set( __mkl_lib_name mkl_sequential )
+
+endif()
+
+# Search with priority for MKLROOT, MKL_PATH and MKL_ROOT if set in CMake or env
+find_path(MKL_INCLUDE_DIR mkl.h
+          PATHS ${MKLROOT} ${MKL_PATH} ${MKL_ROOT} $ENV{MKLROOT} $ENV{MKL_PATH} $ENV{MKL_ROOT}
+          PATH_SUFFIXES include NO_DEFAULT_PATH)
+
+find_path(MKL_INCLUDE_DIR mkl.h
+          PATH_SUFFIXES include)
+
+if( MKL_INCLUDE_DIR ) # use include dir to find libs
+
+  set( MKL_INCLUDE_DIRS ${MKL_INCLUDE_DIR} )
+
+  if( CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64" )
+    set( __pathsuffix "lib/intel64")
+    set( __libsfx _lp64 )
+  else()
+    set( __pathsuffix "lib/ia32")
+    set( __libsfx "" )
+  endif()
+
+  find_library( MKL_LIB_INTEL
+                PATHS ${MKLROOT} ${MKL_PATH} ${MKL_ROOT} $ENV{MKLROOT} $ENV{MKL_PATH} $ENV{MKL_ROOT}
+                PATH_SUFFIXES lib ${__pathsuffix}
+                NAMES mkl_intel${__libsfx} )
+
+  find_library( ${__mkl_lib_par}
+                PATHS ${MKLROOT} ${MKL_PATH} ${MKL_ROOT} $ENV{MKLROOT} $ENV{MKL_PATH} $ENV{MKL_ROOT}
+                PATH_SUFFIXES lib ${__pathsuffix}
+                NAMES ${__mkl_lib_name} )
+
+  find_library( MKL_LIB_CORE
+                PATHS ${MKLROOT} ${MKL_PATH} ${MKL_ROOT} $ENV{MKLROOT} $ENV{MKL_PATH} $ENV{MKL_ROOT}
+                PATH_SUFFIXES lib ${__pathsuffix}
+                NAMES mkl_core )
+
+  if( MKL_PARALLEL )
+    find_library( MKL_LIB_IOMP5
+                  PATHS ${MKLROOT} ${MKL_PATH} ${MKL_ROOT} $ENV{MKLROOT} $ENV{MKL_PATH} $ENV{MKL_ROOT}
+                  PATH_SUFFIXES lib ${__pathsuffix}
+                  NAMES iomp5 )
+  endif()
+
+  if( MKL_LIB_INTEL AND ${__mkl_lib_par} AND MKL_LIB_CORE )
+    set( MKL_LIBRARIES ${MKL_LIB_INTEL} ${${__mkl_lib_par}} ${MKL_LIB_CORE} ${MKL_LIB_IOMP5} ${CMAKE_THREAD_LIBS_INIT} )
+  endif()
+
+endif()
+
+include(FindPackageHandleStandardArgs)
+
+find_package_handle_standard_args( MKL DEFAULT_MSG
+                                   MKL_LIBRARIES MKL_INCLUDE_DIRS )
+
+mark_as_advanced( MKL_INCLUDE_DIR MKL_LIB_LAPACK MKL_LIB_INTEL MKL_LIB_SEQUENTIAL MKL_LIB_CORE )

--- a/doc/source/User_Guide/getting_started.rst
+++ b/doc/source/User_Guide/getting_started.rst
@@ -284,6 +284,21 @@ The ``output`` option is only respected when a particular ``target`` is specifie
 ``make output=a.out install`` will install all ``rayleigh`` executables, they will not
 be renamed.
 
+.. _cmake:
+Alternative: Configure using CMake
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+`CMake <https://cmake.org>`_ can be used as an alternative to the configure script. It is especially useful when running on a new platform not yet supported by configure or when you are generally more comfortable with CMake from other projects.
+
+.. code-block:: bash
+
+    # Create a build directory called "build" and configure Rayleigh in it.
+    cmake -Bbuild
+    # Optional: change settings (e.g., select a Debug or Release build)
+    cmake --build build -t edit_cache
+    # Build code in parallel and install in the bin directory
+    cmake --build -j -t install
+
 .. _spack-setup:
 
 Alternative: Installation using Spack

--- a/doc/source/User_Guide/getting_started.rst
+++ b/doc/source/User_Guide/getting_started.rst
@@ -299,6 +299,13 @@ Alternative: Configure using CMake
     # Build code in parallel and install in the bin directory
     cmake --build -j -t install
 
+To select a specific compiler set the ``FC`` (Fortran) and ``CC`` (C) environment variables when you run the first command.
+
+.. code-block:: bash
+
+    # Select the Intel compilers.
+    FC=ifort CC=icc cmake -Bbuild
+
 .. _spack-setup:
 
 Alternative: Installation using Spack

--- a/environment.yml
+++ b/environment.yml
@@ -23,7 +23,7 @@ dependencies:
   - compilers=1.4.2
   - openblas=0.3.25
   - fftw=3.3
-  - mpich=3.4
+  - openmpi=4.1.6
   - funcsigs=1.0
   - vtk=9.0
   - docopt=0.6

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -36,7 +36,8 @@ add_dependencies(rayleigh run_param_header)
 
 target_include_directories(rayleigh PRIVATE ${PROJECT_SOURCE_DIR}/src/Include ${CMAKE_CURRENT_BINARY_DIR})
 
-set(RAYLEIGH_CPU_OPTIMIZATIONS "none" CACHE PATH "Specify a CPU architecture to build for. Currently only 'native' or 'none' are supported.")
+set(RAYLEIGH_CPU_OPTIMIZATIONS "none" CACHE STRING "Specify a CPU architecture to build for. Currently only 'native' or 'none' are supported.")
+set_property(CACHE RAYLEIGH_CPU_OPTIMIZATIONS PROPERTY STRINGS "none" "native")
 
 if (RAYLEIGH_CPU_OPTIMIZATIONS STREQUAL "native")
   if(CMAKE_Fortran_COMPILER_ID STREQUAL "GNU")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -36,6 +36,23 @@ add_dependencies(rayleigh run_param_header)
 
 target_include_directories(rayleigh PRIVATE ${PROJECT_SOURCE_DIR}/src/Include ${CMAKE_CURRENT_BINARY_DIR})
 
+set(RAYLEIGH_CPU_OPTIMIZATIONS "none" CACHE PATH "Specify a CPU architecture to build for. Currently only 'native' or 'none' are supported.")
+
+if (RAYLEIGH_CPU_OPTIMIZATIONS STREQUAL "native")
+  if(CMAKE_Fortran_COMPILER_ID STREQUAL "GNU")
+    target_compile_options(rayleigh PRIVATE -march=native)
+    message(STATUS "enabling native optimizations")
+  elseif(CMAKE_Fortran_COMPILER_ID STREQUAL "Intel")
+    target_compile_options(rayleigh PRIVATE -xHost)
+  else()
+    message(FATAL_ERROR "For your compiler no native optimizations are automatically detected. Please specify compiler flags manually and set 'CPU_OPTIMIZATIONS' to 'none'")
+  endif()
+elseif (RAYLEIGH_CPU_OPTIMIZATIONS STREQUAL "none")
+  # do nothing, respect manually set compiler flags
+else()
+  message(FATAL_ERROR "Only 'native' and 'none' are supported for parameter 'CPU_OPTIMIZATIONS'")
+endif()
+
 if(CMAKE_Fortran_COMPILER_ID STREQUAL "GNU")
   target_compile_definitions(rayleigh PRIVATE GNU_COMPILER)
 elseif(CMAKE_Fortran_COMPILER_ID STREQUAL "Intel")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -28,7 +28,7 @@ file(GLOB SOURCES
   IO/cmkdir.c)
 list(REMOVE_ITEM SOURCES ${PROJECT_SOURCE_DIR}/src/Physics/Linear_Terms_Cart.F90)
 
-add_custom_target(run_param_header COMMAND env FC=${CMAKE_Fortran_COMPILER} ${PROJECT_SOURCE_DIR}/src/gen_header.sh Run_Param_Header.F ${CMAKE_BUILD_TYPE} "compile flags unavailable" $<TARGET_PROPERTY:rayleigh,LINK_OPTIONS>)
+add_custom_target(run_param_header COMMAND env FC=${CMAKE_Fortran_COMPILER} ${PROJECT_SOURCE_DIR}/src/gen_header.sh Run_Param_Header.F ${CMAKE_BUILD_TYPE} FROM_CMAKE $<TARGET_PROPERTY:rayleigh,LINK_OPTIONS>)
 
 add_executable(rayleigh ${SOURCES})
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,3 +1,22 @@
+#
+#  Copyright (C) 2024 by the authors of the RAYLEIGH code.
+#
+#  This file is part of RAYLEIGH.
+#
+#  RAYLEIGH is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 3, or (at your option)
+#  any later version.
+#
+#  RAYLEIGH is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with RAYLEIGH; see the file LICENSE.  If not see
+#  <http://www.gnu.org/licenses/>.
+
 file(GLOB SOURCES
   Data_Structures/*.F90
   Diagnostics/*.F90

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -28,7 +28,7 @@ file(GLOB SOURCES
   IO/cmkdir.c)
 list(REMOVE_ITEM SOURCES ${PROJECT_SOURCE_DIR}/src/Physics/Linear_Terms_Cart.F90)
 
-add_custom_target(run_param_header COMMAND env FC=${CMAKE_Fortran_COMPILER} ${PROJECT_SOURCE_DIR}/src/gen_header.sh Run_Param_Header.F ${CMAKE_BUILD_TYPE} FROM_CMAKE $<TARGET_PROPERTY:rayleigh,LINK_OPTIONS>)
+add_custom_target(run_param_header COMMAND env FC=${CMAKE_Fortran_COMPILER} ${PROJECT_SOURCE_DIR}/src/gen_header.sh Run_Param_Header.F $<$<STREQUAL:${CMAKE_BUILD_TYPE},>:Default>${CMAKE_BUILD_TYPE} FROM_CMAKE $<TARGET_PROPERTY:rayleigh,LINK_OPTIONS>)
 
 add_executable(rayleigh ${SOURCES})
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,4 +1,12 @@
-file(GLOB SOURCES */*.F90 IO/cmkdir.c)
+file(GLOB SOURCES
+  Data_Structures/*.F90
+  Diagnostics/*.F90
+  IO/*.F90
+  Math_Layer/*.F90
+  Parallel_Framework/*.F90
+  Physics/*.F90
+  Test_Suite/*.F90
+  IO/cmkdir.c)
 list(REMOVE_ITEM SOURCES ${PROJECT_SOURCE_DIR}/src/Physics/Linear_Terms_Cart.F90)
 
 add_custom_target(run_param_header COMMAND env FC=${CMAKE_Fortran_COMPILER} ${PROJECT_SOURCE_DIR}/src/gen_header.sh Run_Param_Header.F ${CMAKE_BUILD_TYPE} "compile flags unavailable" $<TARGET_PROPERTY:rayleigh,LINK_OPTIONS>)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,0 +1,26 @@
+file(GLOB SOURCES */*.F90 IO/cmkdir.c)
+list(REMOVE_ITEM SOURCES ${PROJECT_SOURCE_DIR}/src/Physics/Linear_Terms_Cart.F90)
+
+add_custom_target(run_param_header COMMAND env FC=${CMAKE_Fortran_COMPILER} ${PROJECT_SOURCE_DIR}/src/gen_header.sh Run_Param_Header.F ${CMAKE_BUILD_TYPE} "compile flags unavailable" $<TARGET_PROPERTY:rayleigh,LINK_OPTIONS>)
+
+add_executable(rayleigh ${SOURCES})
+
+add_dependencies(rayleigh run_param_header)
+
+target_include_directories(rayleigh PRIVATE ${PROJECT_SOURCE_DIR}/src/Include ${CMAKE_CURRENT_BINARY_DIR})
+
+if(CMAKE_Fortran_COMPILER_ID STREQUAL "GNU")
+  target_compile_definitions(rayleigh PRIVATE GNU_COMPILER)
+elseif(CMAKE_Fortran_COMPILER_ID STREQUAL "Intel")
+  target_compile_definitions(rayleigh PRIVATE INTEL_COMPILER)
+elseif(CMAKE_Fortran_COMPILER_ID STREQUAL "Cray")
+  target_compile_definitions(rayleigh PRIVATE CRAY_COMPILER)
+endif()
+
+if(MPI_Fortran_HAVE_F08_MODULE)
+  target_compile_definitions(rayleigh PRIVATE USE_MPI_F08_BINDINGS)
+endif()
+
+target_link_libraries(rayleigh MPI::MPI_Fortran)
+target_link_libraries(rayleigh LAPACK::LAPACK)
+target_link_libraries(rayleigh FFTW::fftw3)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -24,3 +24,5 @@ endif()
 target_link_libraries(rayleigh MPI::MPI_Fortran)
 target_link_libraries(rayleigh LAPACK::LAPACK)
 target_link_libraries(rayleigh FFTW::fftw3)
+
+install(TARGETS rayleigh DESTINATION ${CMAKE_SOURCE_DIR}/bin)

--- a/src/gen_header.sh
+++ b/src/gen_header.sh
@@ -75,13 +75,25 @@ var="$pref$val"
 
 #Build flags
 pref="    Character(len=512) :: build_fflags = \"---build fflags---"
-val="$3"
+if [ "$3" = FROM_CMAKE ] && command -v jq > /dev/null
+then
+    val=$(jq '.[0].command' ../compile_commands.json)
+    val="${val%%\"}"
+    val="${val##\"}"
+else
+    val="$3"
+fi
 var="$pref$val"
+
 "$SRC"/format_var.sh "$var" $HFILE
 
 #Build libraries
 pref="    Character(len=512) :: build_lib = \"---build lib---"
 val="$4"
+if [ "$3" = FROM_CMAKE ]
+then
+    val="${val##SHELL:}"
+fi
 var="$pref$val"
 "$SRC"/format_var.sh "$var" $HFILE
 

--- a/src/gen_header.sh
+++ b/src/gen_header.sh
@@ -20,6 +20,7 @@
 ###########################################################################
 HFILE=$1
 
+SRC="$(dirname "$0")"
 
 rm -rf $HFILE
 
@@ -28,73 +29,73 @@ pref="    Character(len=128) :: build_git_commit = \"---git hash---"
 val=$(git log -1 --pretty=format:"%H +++ %cd")
 var="$pref$val"
 
-./src/format_var.sh "$var" $HFILE
+"$SRC"/format_var.sh "$var" $HFILE
 
 #Git url
 pref="    Character(len=128) :: build_git_url = \"---git url---"
 val=$(git config remote.origin.url)
 var="$pref$val"
-./src/format_var.sh "$var" $HFILE
+"$SRC"/format_var.sh "$var" $HFILE
 
 #Git branch
 pref="    Character(len=128) :: build_git_branch = \"---git branch---"
 val=$(git rev-parse --abbrev-ref HEAD)
 var="$pref$val"
-./src/format_var.sh "$var" $HFILE
+"$SRC"/format_var.sh "$var" $HFILE
 
 #Build date
 pref="    Character(len=128) :: build_date = \"---build date---"
 val=$(date)
 var="$pref$val"
-./src/format_var.sh "$var" $HFILE
+"$SRC"/format_var.sh "$var" $HFILE
 
 #Machine name
 pref="    Character(len=256) :: build_machine = \"---build machine---"
 val=$(uname -a)
 var="$pref$val"
-./src/format_var.sh "$var" $HFILE
+"$SRC"/format_var.sh "$var" $HFILE
 
 #Build directory
 pref="    Character(len=512) :: build_dir = \"---build dir---"
 val=$PWD
 var="$pref$val"
-./src/format_var.sh "$var" $HFILE
+"$SRC"/format_var.sh "$var" $HFILE
 
 #Custom directory specified (if any)
 pref="    Character(len=512) :: build_custom_dir = \"---custom dir---"
 val=$CUSTOMROOT
 var="$pref$val"
-./src/format_var.sh "$var" $HFILE
+"$SRC"/format_var.sh "$var" $HFILE
 
 #Build version
 pref="    Character(len=64 ) :: build_version = \"---build version---"
 val=$2
 var="$pref$val"
-./src/format_var.sh "$var" $HFILE
+"$SRC"/format_var.sh "$var" $HFILE
 
 #Build flags
 pref="    Character(len=512) :: build_fflags = \"---build fflags---"
 val="$3"
 var="$pref$val"
-./src/format_var.sh "$var" $HFILE
+"$SRC"/format_var.sh "$var" $HFILE
 
 #Build libraries
 pref="    Character(len=512) :: build_lib = \"---build lib---"
 val="$4"
 var="$pref$val"
-./src/format_var.sh "$var" $HFILE
+"$SRC"/format_var.sh "$var" $HFILE
 
 #Fortran compiler version
 pref="    Character(len=512) :: FC_version = \"---FC version---"
 ver=$($FC --version)
 val=$(echo "$ver" | sed -n 1p) # exclude lines 2 onward (copyright info)
 var="$pref$val"
-./src/format_var.sh "$var" $HFILE
+"$SRC"/format_var.sh "$var" $HFILE
 
 #Fortran compiler location
 pref="    Character(len=512) :: FC_location = \"---FC location---"
 val=$(which $FC)
 var="$pref$val"
-./src/format_var.sh "$var" $HFILE
+"$SRC"/format_var.sh "$var" $HFILE
 
 #more $HFILE


### PR DESCRIPTION
This adds support for building Rayleigh using CMake. It is purely optional and does not interfere with the traditional, `configure`-based approach.

You can try it like this:
```sh
cmake -B build
cmake --build build -j
```
The `rayleigh` executable will be placed in `build/src`.

Todo:

- [x] Fix `Run_Param_Header.F`. The Fortran flags are currently missing. The linker flags have a `SHELL:` prefix.
- [x] Document CMake build procedure including how to make `Debug` and `Release` builds.
- [x] Test on more systems, in particular MKL based ones.
- [x] Add CI tests for the CMake build.
- [x] Install the executable in `bin`.