### PR TITLE
Random documentation fixes

### DIFF
--- a/doc/source/User_Guide/getting_started.rst
+++ b/doc/source/User_Guide/getting_started.rst
@@ -326,9 +326,6 @@ To see the dependencies being installed you can use:
 
     spack spec rayleigh ^intel-mkl
 
-.. _benchmark:
-
-
 .. _hpc_installation_instructions:
 
 Installation on HPC systems

--- a/doc/source/User_Guide/getting_started.rst
+++ b/doc/source/User_Guide/getting_started.rst
@@ -36,7 +36,7 @@ Once you have Conda installed, create a Conda environment using the environment 
 
 Because Rayleigh installs a number of different packages the first of these lines simplifies the
 search for a compatible selection of package versions. The second line creates a new environment
-named "radev" and installs all necessary packages.  The third line activates the environment.
+named ``radev`` and installs all necessary packages.  The third line activates the environment.
 This command will likely take a while (a few minutes).
 
 If you want to undo the change to the channel priority setting afterwards, you can run
@@ -58,7 +58,7 @@ Building the documentation is the same on Linux and Mac.
     cd /path/to/Rayleigh
     make doc
 
-Once the documetation builds, you can access it by opening Rayleigh/doc/build/html/index.html in your web browser.
+Once the documetation builds, you can access it by opening ``Rayleigh/doc/build/html/index.html`` in your web browser.
 
 Building the code is again the same on Linux and Mac. Execute the following:
 
@@ -69,7 +69,7 @@ Building the code is again the same on Linux and Mac. Execute the following:
     ./configure -openblas --FC=mpifort
     make
 
-At this point, you can run "make install," and run the code using mpirun as you normally would (keep the radev environment active when doing this).
+At this point, you can run ``make install`` and run the code using ``mpirun`` as you normally would (keep the ``radev`` environment active when doing this).
 
 
 
@@ -89,8 +89,8 @@ This container is set up to get used to Rayleigh not to run productive models wi
 
 This command will create a terminal inside the container and drop you in a directory
 that contains a pre-compiled version of Rayleigh. You can run input examples or
-tests by executing `rayleigh.opt` or `rayleigh.dbg` and look at the output files, but
-all files will be deleted when you `exit` the container.
+tests by executing ``rayleigh.opt`` or ``rayleigh.dbg`` and look at the output files, but
+all files will be deleted when you ``exit`` the container.
 
 .. note:: If you use Apptainer/Singularity instead of docker you can keep the model output files, because Apptainer by default mounts the current directory into the container. The command to run Rayleigh inside the container is ``mpirun -np X apptainer exec geodynamics/rayleigh:latest rayleigh.opt``` (assuming you have a Rayleigh input file in the current directory).
 
@@ -217,71 +217,71 @@ Rayleigh is compiled using the standard Linux installation scheme of
 configure/make/make-install. From within the Rayleigh directory, run
 these commands:
 
-#. **./configure** – See Rayleigh/INSTALL or run ./configure --help to
+#. ``./configure`` – See Rayleigh/INSTALL or run ./configure --help to
    see relevant options.
 
-#. **make** – This produces the code. You can run **make -j** to build several
+#. ``make`` – This produces the code. You can run **make -j** to build several
    files in parallel and speed up the build this way.
 
-#. **make install** – This places the Rayleigh executables in
+#. ``make install`` – This places the Rayleigh executables in
    Rayleigh/bin. If you would like to place them in (say)
-   /home/my_rayleigh/bin, run configure as: **./configure
-   –prefix=/home/my_rayleigh**, i.e., the executables will be placed in the
-   **$(prefix)/bin** directory.
+   /home/my_rayleigh/bin, run configure as: ``./configure
+   –prefix=/home/my_rayleigh``, i.e., the executables will be placed in the
+   ``$(prefix)/bin`` directory.
 
-For most builds, two executables will be created: rayleigh.opt and
-rayleigh.dbg. Use them as follows:
+For most builds, two executables will be created: ``rayleigh.opt`` and
+``rayleigh.dbg``. Use them as follows:
 
-#. When running production jobs, use **rayleigh.opt**.
+#. When running production jobs, use ``rayleigh.opt``.
 
 #. If you encounter an unexpected crash and would like to report the
-   error, rerun the job with **rayleigh.dbg**. This version of the code
+   error, rerun the job with ``rayleigh.dbg``. This version of the code
    is compiled with debugging symbols. It will (usually) produce
    meaningful error messages in place of the gibberish that is output
    when rayleigh.opt crashes.
 
-If *configure* detects the Intel compiler, you will be presented with a
-number of choices for the vectorization option. If you select *all*,
-rayleigh.opt will not be created. Instead, rayleigh.sse, rayleigh.avx,
-etc. will be placed in Rayleigh/bin. This is useful if running on a
+If ``configure`` detects the Intel compiler, you will be presented with a
+number of choices for the vectorization option. If you select ``all``,
+``rayleigh.opt`` will not be created. Instead, ``rayleigh.sse``, ``rayleigh.avx``,
+etc. will be placed in ``Rayleigh/bin``. This is useful if running on a
 machine with heterogeneous node architectures (e.g., Pleiades). If you
 are not running on such a machine, pick the appropriate vectorization
 level, and rayleigh.opt will be compiled using that vectorization level.
 
-The default behavior of the **make** command is to build both the
-optimized, **rayleigh.opt**, and the debug versions, **rayleigh.dbg**. As
+The default behavior of the ``make`` command is to build both the
+optimized, ``rayleigh.opt``, and the debug versions, ``rayleigh.dbg``. As
 described above, if Intel is used and *all* is selected, every version will
-be compiled. To build only a single version, the **target=<target>** option
-may be used at the **make** stage, for example:
+be compiled. To build only a single version, the ``target=<target>`` option
+may be used at the ``make`` stage, for example:
 
-#. **make target=opt** - build only the optimized version, **rayleigh.opt**
+#. ``make target=opt`` - build only the optimized version, ``rayleigh.opt``
 
-#. **make target=dbg** - build only the debug version, **rayleigh.dbg**
+#. ``make target=dbg`` - build only the debug version, ``rayleigh.dbg``
 
-#. **make target=avx** - build only the AVX version, **rayleigh.avx**
+#. ``make target=avx`` - build only the AVX version, ``rayleigh.avx``
 
 When building a single target, the final name of the executable can be changed
-with the **output=<output>** option during the **make install** command. For example,
-to build the optimized version and name the executable **a.out**:
+with the ``output=<output>`` option during the ``make install`` command. For example,
+to build the optimized version and name the executable ``a.out``:
 
-#. **make target=opt** - only build the optimized version
+#. ``make target=opt`` - only build the optimized version
 
-#. **make target=opt output=a.out install** - install the optimized version as **a.out**
+#. ``make target=opt output=a.out install`` - install the optimized version as ``a.out``
 
-Inspection of the **$(prefix)/bin** directory (specified at configure time with the -prefix
-option) will show a new file named **a.out**.
+Inspection of the ``$(prefix)/bin`` directory (specified at configure time with the -prefix
+option) will show a new file named ``a.out``.
 
 If both the optimized version and the debug version have already been built, they
 can be renamed at install time as:
 
-#. **make** - build both optimized and debug version (or all versions)
+#. ``make`` - build both optimized and debug version (or all versions)
 
-#. **make target=opt output=a.out.opt install** - install and rename the optimized version
+#. ``make target=opt output=a.out.opt install`` - install and rename the optimized version
 
-#. **make target=dbg output=a.out.dbg install** - install and rename the debug version
+#. ``make target=dbg output=a.out.dbg install`` - install and rename the debug version
 
-The **output** option is only respected when a particular **target** is specified. Running
-**make output=a.out install** will install all **rayleigh.*** executables, they will not
+The ``output`` option is only respected when a particular ``target`` is specified. Running
+``make output=a.out install`` will install all ``rayleigh`` executables, they will not
 be renamed.
 
 .. _spack-setup:
@@ -333,7 +333,7 @@ Installation on HPC systems
 
 Given the amount of computational resources required to simulate convection in highly turbulent parameter regimes, many users will want to run Rayleigh in a HPC environment.  Here we provide instructions for compilation on two widely-used, national-scale supercomputing systems:  TACC Stampede2 and NASA Pleiades.   
 
-Example jobscripts containing the necessary commands to compile and run Rayleigh on various systems may be found in *Rayleigh/job_scripts/*.
+Example jobscripts containing the necessary commands to compile and run Rayleigh on various systems may be found in ``Rayleigh/job_scripts/``.
 
 .. _stampede2:
 
@@ -405,7 +405,7 @@ We suggest using the default Intel and MPI compilers provided by Pleiades as in 
 
    1) comp-intel/2020.4.304   2) mpi-hpe/mpt.2.25
 
-Note that Pleiades is a heterogeneous cluster, composed of many (primarily Intel) processor types. We suggest selecting the 'ALL' option when configuring Rayleigh to ensure that a unique executable is created for each of the possible vectorization options.  An example jobscript for Pleiades may be found in *Rayleigh/job_scripts/NASA_Pleiades*.
+Note that Pleiades is a heterogeneous cluster, composed of many (primarily Intel) processor types. We suggest selecting the ``ALL`` option when configuring Rayleigh to ensure that a unique executable is created for each of the possible vectorization options.  An example jobscript for Pleiades may be found in ``Rayleigh/job_scripts/NASA_Pleiades``.
 
 
 
@@ -441,7 +441,7 @@ benchmark-appropriate values. For example, setting ``benchmark_mode = 1`` define
 Christensen et al. (2001) :cite:`CHRISTENSEN200125` initial conditions. A benchmark report is
 written every 5000 time steps by setting
 ``benchmark_report_interval = 5000``. The benchmark reports are text
-files found within directory **path_to_my_sim/Benchmark_Reports/** and
+files found within directory ``path_to_my_sim/Benchmark_Reports/`` and
 numbered according to the appropriate time step. The
 | ``benchmark_integration_interval`` variable sets the interval at which
 measurements are taken to calculate the values reported in the
@@ -457,37 +457,36 @@ To run this benchmark, create a directory from within which to run your
 benchmark, and follow along with the commands below. Modify the
 directory structure a each step as appropriate:
 
-#. mkdir path_to_my_sim
+#. ``mkdir path_to_my_sim``
 
-#. cd path_to_my_sim
+#. ``cd path_to_my_sim``
 
-#. cp
-   path_to_rayleigh/Rayleigh/input_examples/c2001_case0_minimal   main_input
+#. ``cp
+   path_to_rayleigh/Rayleigh/input_examples/c2001_case0_minimal main_input``
 
-#. cp path_to_rayleigh/Rayleigh/bin/rayleigh.opt   rayleigh.opt (or use
-   *ln -s* in lieu of *cp*)
+#. ``cp path_to_rayleigh/Rayleigh/bin/rayleigh.opt rayleigh.opt`` (or use
+   ``ln -s`` in lieu of ``cp``)
 
-#. mpiexec -np **N** ./rayleigh.opt -nprow **X** -npcol **Y** -nr **R**
-   -ntheta **T**
+#. ``mpiexec -np N ./rayleigh.opt -nprow X -npcol Y -nr R -ntheta T``
 
-For the value **N**, select the number of cores you wish to run with.
+For the value ``N``, select the number of cores you wish to run with.
 For this short test, 32 cores is more than sufficient. Even with only
 four cores, the lower-resolution test suggested below will only take
-around half an hour. The values **X** and **Y** are integers that
+around half an hour. The values ``X`` and ``Y`` are integers that
 describe the process grid. They should both be at least 2, and must
 satisfy the expression
 
 .. math:: N=X \times Y.
 
 Some suggested combinations are {N,X,Y} = {32,4,8}, {16,4,4}, {8,2,4},
-{4,2,2}. The values **R** and **T** denote the number of radial and
+{4,2,2}. The values ``R`` and ``T`` denote the number of radial and
 latitudinal collocation points respectively. Select either {R,T}={48,64}
 or {R,T}={64,96}. The lower-resolution case takes about 3 minutes to run
 on 32 Intel Haswell cores. The higher-resolution case takes about 12
 minutes to run on 32 Intel Haswell cores.
 
 Once your simulation has run, examine the file
-path_to_my_sim/Benchmark_Reports/00025000. You should see output similar
+``path_to_my_sim/Benchmark_Reports/00025000``. You should see output similar
 to that presented in Tables table_benchmark_low_ or table_benchmark_high_ . Your numbers may differ
 slightly, but all values should have a % difference of less than 1. If
 this condition is satisfied, your installation is working correctly.
@@ -599,7 +598,7 @@ Rayleigh below. Rayleigh’s input parameters are grouped in so-called
 namelists, which are subcategories of related input parameters that will
 be read upon program start and assigned to Fortran variables with
 identical names. Below are the first four Fortran namelists in the input
-file **c2001_case0_minimal**.
+file ``c2001_case0_minimal``.
 
 ::
 
@@ -631,7 +630,7 @@ Boussinesq MHD Benchmark: c2001_case1_minimal
 
 The MHD Boussinesq benchmark with an insulating inner core of
 Christensen et al. (2001) :cite:`CHRISTENSEN200125` is denoted as Case 1 and is specified with
-input file **c2001_case1_minimal**. Only the namelists modified compared
+input file ``c2001_case1_minimal``. Only the namelists modified compared
 to Case 0 (\ :ref:`cookbookCase0Minimal` above) are shown
 below.
 
@@ -658,7 +657,7 @@ Steady Anelastic non-MHD Benchmark: j2011_steady_hydro_minimal
 
 Jones et al. (2011) describes a benchmark for an anelastic hydrodynamic
 solution that is steady in a drifting frame. This benchmark is specified
-for Rayleigh with input file **j2011_steady_hydro_minimal**. Below are
+for Rayleigh with input file ``j2011_steady_hydro_minimal``. Below are
 the relevant Fortran namelists.
 
 ::
@@ -691,7 +690,7 @@ Steady Anelastic MHD Benchmark: j2011_steady_mhd_minimal
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The anelastic MHD benchmark described in Jones et al. (2011) can be run
-with main input file **j2011_steady_mhd_minimal**. The Fortran namelists
+with main input file ``j2011_steady_mhd_minimal``. The Fortran namelists
 differing from the Jones et al. (2011) anelastic hydro benchmark
 (§:ref:`cookbookHydroAnelastic` above) are shown here.
 
@@ -718,7 +717,7 @@ This is a Boussinesq convection benchmark described in Breuer et al. (2010) :cit
 in a dual buoyancy system that allows both thermal and chemical buoyancy sources. 
 The case 0 contains three input lists that describes varying contributions of 
 thermal vs chemical Rayleigh numbers whereas the total Rayleigh number stays the same. 
-This benchmark is specified for Rayleigh with input file b2010_case0_*T_input. 
+This benchmark is specified for Rayleigh with input file ``b2010_case0_*T_input``. 
 Below is an example for 80% thermal and 20% chemical convection scene for the 
 relevant Fortran namelists:
 

--- a/doc/source/User_Guide/getting_started.rst
+++ b/doc/source/User_Guide/getting_started.rst
@@ -17,7 +17,7 @@ Setting up a Rayleigh Development Environment
 
 When running Rayleigh on HPC resources, always compile the software with the recommended compiler and link against
 libraries optimized for the architecture you are running on. We provide example
-instructions for some common systems at `Installation Instructions for HPC systems`_.
+instructions for some common systems at `Installation on HPC systems`_.
 
 When developing Rayleigh or editing its documentation, however, such optimizations are rarely necessary.  Instead, it is sufficient for the code and documentation to compile.  For this purpose, we recommend setting up a `conda environment`_ or using our `Docker container`_.  Instructions for setting up an environment on Linux and Mac OS are provided below.
 

--- a/doc/source/User_Guide/model_setup.rst
+++ b/doc/source/User_Guide/model_setup.rst
@@ -407,7 +407,7 @@ to consider whether it makes sense to separately initialize the
 spherically-symmetric component of the thermal field with a profile that
 is in conductive balance. This is almost certainly the case when running
 with fixed temperature conditions. The logical namelist variable
-``conductive_profile`` can be used for this purpose. It’s default value
+``conductive_profile`` can be used for this purpose. Its default value
 is ``.false.`` (off), and its value is ignored completely when restarting
 from a checkpoint. To initialize a simulation with a random temperature
 field superimposed on a spherically-symmetric, conductive background
@@ -456,7 +456,7 @@ vector-potential functions are given a random power distribution
 described by Equation eq_init_. Each mode’s random
 amplitude is then determined by namelist variable ``mag_amp``. This
 variable should be interpreted as an approximate magnetic field strength
-(it’s value is rescaled appropriately for the poloidal and toroidal
+(its value is rescaled appropriately for the poloidal and toroidal
 vector potentials, which are differentiated to yield the magnetic
 field).
 

--- a/doc/source/User_Guide/model_setup.rst
+++ b/doc/source/User_Guide/model_setup.rst
@@ -26,8 +26,8 @@ to store the output.
 Do not cross the beams: no running two models from within the same
 directory.**
 
-After you create your run directory, you will want to copy (cp) or soft
-link (ln -s ) the executable from Rayleigh/bin to your run directory.
+After you create your run directory, you will want to copy (``cp``) or soft
+link (``ln -s``) the executable from ``Rayleigh/bin`` to your run directory.
 Soft-linking is recommended; if you recompile the code, the executable
 remains up-to-date. If running on an IBM machine, copy the script named
 Rayleigh/etc/make_dirs to your run directory and execute the script.
@@ -39,8 +39,8 @@ Next, you must create a main_input file. This file contains the
 information that describes how your simulation is run. Rayleigh always
 looks for a file named main_input in the directory that it is launched
 from. Copy one of the sample input files from the
-Rayleigh/input_examples/ into your run directory, and rename it to
-main_input. The file named *benchmark_diagnostics_input* can be used to
+``Rayleigh/input_examples/`` into your run directory, and rename it to
+main_input. The file named ``benchmark_diagnostics_input`` can be used to
 generate output for the diagnostics plotting tutorial (see
 §\ :ref:`commmon_diagnostics`).
 
@@ -167,7 +167,7 @@ points.
 Employing a Finite-Difference Approach in Radius
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Rayleigh's default behavior is to employ a Chebyshev collocation scheme in radius.   If desired, a finite-difference method can be applied instead.  This mode is activated by setting the value of ``chebyshev`` to .false. in the ``numerical_controls_namelist``.  At present, Rayleigh's finite-difference scheme employs a five-point stencil with 4th-order accuracy in the interior points.  Boundary derivatives are taken with second-order accuracy.   By default, a uniform radial grid is assumed.  Consider the following example:
+Rayleigh's default behavior is to employ a Chebyshev collocation scheme in radius.   If desired, a finite-difference method can be applied instead.  This mode is activated by setting the value of ``chebyshev`` to ``.false.`` in the ``numerical_controls_namelist``.  At present, Rayleigh's finite-difference scheme employs a five-point stencil with 4th-order accuracy in the interior points.  Boundary derivatives are taken with second-order accuracy.   By default, a uniform radial grid is assumed.  Consider the following example:
 
 ::
 
@@ -189,7 +189,7 @@ This results in the uniform grid:
   radius = 1.000 , 1.333 , 1.667 , 2.000
       dr = 0.333 , 0.333 , 0.333
 
-An example input file using a uniform radial grid and a finite-difference scheme is provided in ``input_examples\main_input_mhd_jones_FD``.  If desired, a nonuniform grid can also be generated.  There are two ways to do this: via *main_input* and via a grid-description file. 
+An example input file using a uniform radial grid and a finite-difference scheme is provided in ``input_examples\main_input_mhd_jones_FD``.  If desired, a nonuniform grid can also be generated.  There are two ways to do this: via ``main_input`` and via a grid-description file. 
 
 
 Using Main_Input to Specify a Nonuniform Grid
@@ -258,7 +258,7 @@ An arbitrary radial grid may also be generated using Python and then stored to a
 
    my_grid.write('grid_layout_128.dat')   # Store contents to file
 
-Note that we could have generated the grid in either ascending or descending order.  The *write* method accounts for the grid-ordering before storing its contents to the file.  Now that we have created a grid-description file ('grid_layout_128.dat' in this example), we indicate the relevant filename in ``main_input`` using the ``radial_grid_file`` parameter:
+Note that we could have generated the grid in either ascending or descending order.  The *write* method accounts for the grid-ordering before storing its contents to the file.  Now that we have created a grid-description file (``grid_layout_128.dat`` in this example), we indicate the relevant filename in ``main_input`` using the ``radial_grid_file`` parameter:
 
 ::
 
@@ -318,7 +318,7 @@ the benchmark described in :ref:`benchmark` that you set
 other input flags in favor of running the specified benchmark.
 
 A number of logical variables can be used to turn certain physics on
-(value = .true.) or off ( value = .false.). These variables are
+(``value = .true.``) or off (``value = .false.``). These variables are
 described in Table table_logicals_, with default
 values indicated in brackets.
 
@@ -357,8 +357,8 @@ A Rayleigh simulation may be initialized with a random thermal and/or
 magnetic field, or it may be restarted from an existing checkpoint file
 (see §\ :ref:`checkpointing` for a detailed
 discussion of checkpointing). This behavior is controlled through the
-**initial_conditions_namelist** and the **init_type** and
-**magnetic_init_type** variables. The init_type variable controls the
+``initial_conditions_namelist`` and the ``init_type`` and
+``magnetic_init_type`` variables. The init_type variable controls the
 behavior of the velocity and thermal fields at initialization time.
 Available options are:
 
@@ -378,7 +378,7 @@ Available options are:
 
 When initializing a random thermal field, all spherical harmonic modes
 are independently initialized with a random amplitude whose maximum
-possible value is determined by the namelist variable **temp_amp**. The
+possible value is determined by the namelist variable ``temp_amp``. The
 mathematical form of of this random initialization is given by
 
 .. _eq_init:
@@ -407,8 +407,8 @@ to consider whether it makes sense to separately initialize the
 spherically-symmetric component of the thermal field with a profile that
 is in conductive balance. This is almost certainly the case when running
 with fixed temperature conditions. The logical namelist variable
-**conductive_profile** can be used for this purpose. It’s default value
-is .false. (off), and its value is ignored completely when restarting
+``conductive_profile`` can be used for this purpose. It’s default value
+is ``.false.`` (off), and its value is ignored completely when restarting
 from a checkpoint. To initialize a simulation with a random temperature
 field superimposed on a spherically-symmetric, conductive background
 state, something similar to the following should appear in your
@@ -424,8 +424,8 @@ main_input file:
    
 Alternatively, you may wish to specify an ell=0 initial thermal profile
 that is neither random nor conductive.  To create your own profile, follow the example found in
-Rayleigh/examples/custom_thermal_profile/custom_thermal_profile.ipynb.   Then, use the following combination
-of input parameters in main_input:
+``Rayleigh/examples/custom_thermal_profile/custom_thermal_profile.ipynb``.   Then, use the following combination
+of input parameters in ``main_input``:
 
 ::
 
@@ -454,7 +454,7 @@ values for magnetic_input type are:
 For the randomized magnetic field, both the poloidal and toroidal
 vector-potential functions are given a random power distribution
 described by Equation eq_init_. Each mode’s random
-amplitude is then determined by namelist variable **mag_amp**. This
+amplitude is then determined by namelist variable ``mag_amp``. This
 variable should be interpreted as an approximate magnetic field strength
 (it’s value is rescaled appropriately for the poloidal and toroidal
 vector potentials, which are differentiated to yield the magnetic
@@ -480,7 +480,7 @@ Generic Initial Conditions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The user can input any initial conditions from data files generated by
-a python routine "rayleigh_spectral_input.py", which can be called as
+a python routine ``rayleigh_spectral_input.py``, which can be called as
 a script or imported as a python class.
 
 The available generic initial conditions options are
@@ -499,12 +499,12 @@ The available generic initial conditions options are
 
    /
 
-where `T_init_file` is a user generated initial temperature field and
-<filename> is the name of the file generated by the python script.  If
-`T_init_file` is not specified the initial field will be zero by
+where ``T_init_file`` is a user generated initial temperature field and
+``<filename>`` is the name of the file generated by the python script.  If
+``T_init_file`` is not specified the initial field will be zero by
 default.  The same for the other fields.  Fields T, W, Z, and P are
-only initialized from the file if `init_type=8`.  Fields C and A are
-only initialized from file if `magnetic_init_type=8`.
+only initialized from the file if ``init_type=8``.  Fields C and A are
+only initialized from file if ``magnetic_init_type=8``.
 
 To generate a generic initial condition input file, for example, if a user wanted to specify a single mode in that input file then they could just run the script:
 
@@ -553,7 +553,7 @@ Alternatively, in "module" mode in a python shell:
    si.write('example')
 
 
-The above commands will generate a file called `example` which can be
+The above commands will generate a file called ``example`` which can be
 called by
 
 ::
@@ -564,7 +564,7 @@ called by
 
 Note that these two examples will have produced different data formats - the first one sparse (listing only the mode specified) and the second one dense (listing all modes).
 
-For more examples including magnetic potentials see `tests/generic_input`.
+For more examples including magnetic potentials see ``tests/generic_input``.
 
 Custom Reference States
 -----------------------
@@ -584,7 +584,7 @@ Creating a Coefficients File
 The first step in modifying Rayleigh's equation coefficients is to generate an equation coefficients file.
 This file will be used alongside options defined in main_input to determine which combination of coefficients are overridden.
 In order create your coefficients file, you will need to create an instance of the equation_coefficients class, provided
-in post_processing/reference_tools.py.  Constant and nonconstant coefficients may then be set through  set_constant and set_function methods respectively.
+in ``post_processing/reference_tools.py``.  Constant and nonconstant coefficients may then be set through  set_constant and set_function methods respectively.
 
 The equation_coefficient class is instantiated by passing a radial grid to its init method.  This grid can be cast in ascending or descending order, but it should generally possess a much finer mesh than what you plan to use in Rayleigh.
 Nonconstant coefficients specified in the coefficients file will be interpolated onto the Rayleigh grid at input time.   
@@ -676,7 +676,7 @@ main_input, its value will be set to Rayleigh's internal default value of 0.   C
 The resulting values of :math:`c_2,\,c_5,\,c_{10}` will be 1.0, 0.0, and 14.0 respectively.  The constant :math:`c_5` will not be set to 20.0 (the value specified in the coefficients file).
 
 
-To specify a subset of constants, use the override_constant flag for each constant you wish to override, as shown below.
+To specify a subset of constants, use the ``override_constant`` flag for each constant you wish to override, as shown below.
 
 ::
 
@@ -752,14 +752,14 @@ Behavior of Transport Coefficients
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Transport coefficients may also be specified as desired, but nu_type, kappa_type, and eta_type still behave as described :ref:`below <transport>`.
-If you wish to specify a custom diffusivity profile, set the corresponding type to 3.  In that case, the corresponding nonconstant coefficient MUST be set in the equation coefficients file.  Moreover, if reference_type=4, these corresponding constant must be set in either the coefficients file or in main_input (regardless of the diffusion type specified).  
+If you wish to specify a custom diffusivity profile, set the corresponding type to 3.  In that case, the corresponding nonconstant coefficient MUST be set in the equation coefficients file.  Moreover, if reference_type=4, these corresponding constant must be set in either the coefficients file or in ``main_input`` (regardless of the diffusion type specified).  
 
 For diffusion types 2 and 3, if the reference_type is not 4, the value of {nu,kappa,eta}_top normally used by that reference_type will be invoked if the corresponding constant coefficient is not set.
 
 A Note on Volumetric Heating
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Finally, if specifying a custom form for the volumetric heating, please ensure that heating_type is set to a positive, nonzero value in the reference_namelist.  Otherwise, reference heating will be deactivated.  Any Rayleigh-initialization of the heating function that takes place initially will be overridden by the with_custom_reference or reference_type=4 flags. 
+Finally, if specifying a custom form for the volumetric heating, please ensure that heating_type is set to a positive, nonzero value in the reference_namelist.  Otherwise, reference heating will be deactivated.  Any Rayleigh-initialization of the heating function that takes place initially will be overridden by the ``with_custom_reference`` or ``reference_type=4`` flags. 
 
 
 Custom Reference State Examples
@@ -793,44 +793,44 @@ Boundary Conditions & Internal Heating
 --------------------------------------
 
 Boundary conditions are controlled through the
-**Boundary_Conditions_Namelist**. All Rayleigh simulations are run with
+``Boundary_Conditions_Namelist``. All Rayleigh simulations are run with
 impenetrable boundaries. These boundaries may be either no-slip or
 stress-free (default). If you want to employ no-slip conditions at both
-boundaries, set **no_slip_boundaries = .true.**. If you wish to set
-no-slip conditions at only one boundary, set **no_slip_top=.true.** or
-**no_slip_bottom=.true.** in the Boundary_Conditions_Namelist.
+boundaries, set ``no_slip_boundaries = .true.``. If you wish to set
+no-slip conditions at only one boundary, set ``no_slip_top=.true.`` or
+``no_slip_bottom=.true.`` in the Boundary_Conditions_Namelist.
 
 By default, magnetic boundary conditions are set to match to a potential field at
 each boundary.
 
 By default, the thermal anomoly :math:`\Theta` is set to a fixed value
 at each boundary. The upper and lower boundary-values are specified by
-setting **T_top** and **T_bottom** respectively in the
+setting ``T_top`` and ``T_bottom`` respectively in the
 Boundary_Conditions_Namelist. Their defaults values are 1 and 0
 respectively.
 
 Alternatively, you may specify a constant value of
 :math:`\partial\Theta/\partial r` at each boundary. This is accomplished
-by setting the variables **fix_dTdr_top** and **fix_dTdr_bottom**.
+by setting the variables ``fix_dTdr_top`` and ``fix_dTdr_bottom``.
 Values of the gradient may be enforced by setting the namelist variables
-**dTdr_top** and **dTdr_bottom**. Both default to a value of zero.
+``dTdr_top`` and ``dTdr_bottom``. Both default to a value of zero.
 
 Generic Boundary Conditions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Boundary conditions for temperature, :math:`T`, and the magnetic poloidal potential, :math:`C`,
 may also be set using generic spectral input.  As with initial conditions (see :ref:`sec:generic_ic`)
-this is done by generating a generic input file using the **rayleigh_spectral_input.py** script.
+this is done by generating a generic input file using the ``rayleigh_spectral_input.py`` script.
 The file output from this script can then be applied using:
 
--  **fix_Tvar_top** and **T_top_file** (overrides **T_top** for a constant boundary condition)
+-  ``fix_Tvar_top`` and ``T_top_file`` (overrides ``T_top`` for a constant boundary condition)
    to set a fixed upper :math:`T` boundary condition
--  **fix_dTdr_top** and **dTdr_top_file** (overrides **dTdr_top**) to set a fixed upper :math:`T` gradient boundary condition
--  **fix_Tvar_bottom** and **T_bottom_file** (overrides **T_bottom**) to set a fixed lower :math:`T` boundary condition
--  **fix_dTdr_bottom** and **dTdr_bottom_file** (overrides **dTdr_bottom**) to set a fixed lower :math:`T` gradient boundary
+-  ``fix_dTdr_top`` and ``dTdr_top_file`` (overrides ``dTdr_top``) to set a fixed upper :math:`T` gradient boundary condition
+-  ``fix_Tvar_bottom`` and ``T_bottom_file`` (overrides ``T_bottom``) to set a fixed lower :math:`T` boundary condition
+-  ``fix_dTdr_bottom`` and ``dTdr_bottom_file`` (overrides ``dTdr_bottom``) to set a fixed lower :math:`T` gradient boundary
    condition
--  **fix_poloidal_top** and **C_top_file** (overrides **impose_dipole_field**) to set a fixed upper :math:`C` boundary condition
--  **fix_poloidal_bottom** and **C_bottom_file** (overrides **impose_dipole_field**) to set a fixed lower :math:`C` boundary condition
+-  ``fix_poloidal_top`` and ``C_top_file`` (overrides ``impose_dipole_field``) to set a fixed upper :math:`C` boundary condition
+-  ``fix_poloidal_bottom`` and ``C_bottom_file`` (overrides ``impose_dipole_field``) to set a fixed lower :math:`C` boundary condition
 
 For example, to set a :math:`C` boundary condition on both boundaries with modes (l,m) = (1,0) and (1,1) set to pre-calculated
 values run:
@@ -852,19 +852,19 @@ conditions in `main_input` using:
    C_bottom_file = 'cbottom_init_bc'
    /
 
-This can be seen being applied in `tests/generic_input`.
+This can be seen being applied in ``tests/generic_input``.
 
 Internal Heating
 ~~~~~~~~~~~~~~~~
 
 The internal heating function :math:`Q(r)` is activated and described by
-two variables in the **Reference_Namelist**. These are **Luminosity**
-and **heating_type**. Note that these values are part of the
-**Reference_Namelist** and not the **Boundary_Conditions** namelist.
+two variables in the ``Reference_Namelist``. These are ``Luminosity``
+and ``heating_type``. Note that these values are part of the
+``Reference_Namelist`` and not the ``Boundary_Conditions`` namelist.
 Three heating types (0,1, and 4) are fully supported at this time.
 Heating type zero corresponds to no heating. This is the default.
 
-**Heating_type=1:** This heating type is given by :
+``Heating_type=1:`` This heating type is given by :
 
 .. math::
 
@@ -885,7 +885,7 @@ where :math:`\gamma` is a normalization constant defined such that
 This heating profile is particularly useful for emulating radiative
 heating in a stellar convection zone.
 
-**Heating_type=4:** This heating type corresponds a heating that is
+``Heating_type=4:`` This heating type corresponds a heating that is
 variable in radius, but constant in *energy density*. Namely
 
 .. math:: \hat{\rho}\hat{T}\frac{\partial \Theta}{\partial t}=\gamma.
@@ -893,11 +893,11 @@ variable in radius, but constant in *energy density*. Namely
 The constant :math:`\gamma` in this case is also set by enforcing
 Equation eq_lum_.
 
-**Note:** If internal heating is used in combination with **fix_dTdr_top**, then the value of :math:`\partial\Theta/\partial r` 
-at the upper boundary is set by Rayleigh.  Any value for **dTdr_top** specified in main_input is ignored.  This is done to ensure consistency with the internal 
+**Note:** If internal heating is used in combination with ``fix_dTdr_top``, then the value of :math:`\partial\Theta/\partial r` 
+at the upper boundary is set by Rayleigh.  Any value for ``dTdr_top`` specified in main_input is ignored.  This is done to ensure consistency with the internal 
 heating and any flux passing through the lower boundary due
-to the use of a fixed-flux condition.  To override this behavior, set **adjust_dTdr_top** to .false. in the
-**Boundary_Conditions** namelist.
+to the use of a fixed-flux condition.  To override this behavior, set ``adjust_dTdr_top`` to ``.false.`` in the
+``Boundary_Conditions`` namelist.
 
 .. _output_controls:
 
@@ -968,7 +968,7 @@ Transport coefficients (viscosity, thermal diffusivity) are specified in the tra
 
 Variables in the Transport_Namelist
 that must be specified when running in dimensional anelastic mode. In
-addition, **reference_type=2** must also be specified in the
+addition, ``reference_type=2`` must also be specified in the
 Reference_Namelist.
 
    +-----------------------------------+-----------------------------------+

--- a/doc/source/User_Guide/physics_math_overview.rst
+++ b/doc/source/User_Guide/physics_math_overview.rst
@@ -193,7 +193,7 @@ Nondimensional Boussinesq Formulation of the MHD Equations
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Rayleigh can be run using a nondimensional, Boussinesq formulation
-of the MHD equations (**reference_type=1**). The nondimensionalization
+of the MHD equations (``reference_type=1``). The nondimensionalization
 employed is as follows:
 
 .. math::
@@ -281,8 +281,8 @@ Here :math:`\Theta` refers to the temperature (perturbation from the background)
 Dimensional Anelastic Formulation of the MHD Equations
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-When run in dimensional, anelastic mode (cgs units; **reference_type=2**
-), the following values are assigned to the functions
+When run in dimensional, anelastic mode (cgs units; ``reference_type=2``),
+the following values are assigned to the functions
 :math:`\mathrm{f}_i` and the constants :math:`c_i`:
 
 .. math::
@@ -310,15 +310,15 @@ linearized equation of state
 acceleration, :math:`c_P` is the specific heat at constant pressure, and
 :math:`\Omega_0` is the frame rotation rate. The viscous, thermal, and
 magnetic diffusivities (also assumed to be spherically symmetric and time-independent) are given by :math:`\nu(r)`, :math:`\kappa(r)`, and
-:math:`\eta(r)`, respectively. Note that the entropy gradient term :math:`f_{14}(r)v_r` is only used in Equation :eq:`theta_evol` if **advect_reference_state=.true.**. Finally, :math:`Q(r)` is an internal heating
+:math:`\eta(r)`, respectively. Note that the entropy gradient term :math:`f_{14}(r)v_r` is only used in Equation :eq:`theta_evol` if ``advect_reference_state=.true.``. Finally, :math:`Q(r)` is an internal heating
 function; it might represent radiative heating or heating due to nuclear
-fusion, for instance. In our convention, the volume integral of :math:`\mathrm{f}_6(r)` equals unity, and :math:`c_{10}` equals the **luminosity** or **heating_integral** :math:`L_*` specified in the main_input file. When using a custom reference state, this allows easy adjustment of the luminosity using the **override_constants** formalism, e.g.,
+fusion, for instance. In our convention, the volume integral of :math:`\mathrm{f}_6(r)` equals unity, and :math:`c_{10}` equals the ``luminosity`` or ``heating_integral`` :math:`L_*` specified in the main_input file. When using a custom reference state, this allows easy adjustment of the luminosity using the **override_constants** formalism, e.g.,
 
-**override_constants(10) = T**
+``override_constants(10) = T``
 
-**ra_constants(10) = 3.846d33**
+``ra_constants(10) = 3.846d33``
 
-specified in the in the **reference_namelist**.
+specified in the in the ``reference_namelist``.
 
 Note that in the anelastic formulation, the
 thermal variable :math:`\Theta` is interpreted as the entropy perturbation,
@@ -360,7 +360,7 @@ Nondimensional Anelastic MHD Equations
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 To run in nondimensional anelastic mode, you must set
-**reference_type=3** in the Reference_Namelist. The reference state is
+``reference_type=3`` in the Reference_Namelist. The reference state is
 assumed to be polytropic with a :math:`\frac{1}{r^2}` profile for
 gravity. When this mode is
 active, the following nondimensionalization is used
@@ -397,7 +397,7 @@ choices result in the functions :math:`\mathrm{f}_i` and the constants
        &\vdots &c_{10}&\rightarrow L_* \\
        \mathrm{f}_{14}(r)&\rightarrow 0&c_{11}&\rightarrow 0.\end{aligned}
 
-As in the Boussinesq case, the nondimensional diffusivities are defined according to, e.g., :math:`\tilde{\nu}(r) \equiv \nu(r)/\nu_o`. The nondimensional heating :math:`\tilde{Q}(r)` is defined such that its volume integral equals the nondimensional **luminosity** or **heating_integral** set in the *main_input* file. As in the dimensional anelastic case, the volume integral of :math:`\mathrm{f}_6(r)` equals unity, and :math:`\mathrm{c}_{10} = L_*`. The unit for luminosity in this nondimensionalization (to get a dimensional luminosity from the nondimensional :math:`L_*`) is :math:`\rho_oL^3T_o\Delta s\Omega_0`. 
+As in the Boussinesq case, the nondimensional diffusivities are defined according to, e.g., :math:`\tilde{\nu}(r) \equiv \nu(r)/\nu_o`. The nondimensional heating :math:`\tilde{Q}(r)` is defined such that its volume integral equals the nondimensional ``luminosity`` or ``heating_integral`` set in the *main_input* file. As in the dimensional anelastic case, the volume integral of :math:`\mathrm{f}_6(r)` equals unity, and :math:`\mathrm{c}_{10} = L_*`. The unit for luminosity in this nondimensionalization (to get a dimensional luminosity from the nondimensional :math:`L_*`) is :math:`\rho_oL^3T_o\Delta s\Omega_0`. 
 
 Two new nondimensional numbers appear in our equations, in addition to those defined for the Boussinesq case. :math:`\mathrm{Di}`, the
 dissipation number, is defined by

--- a/doc/source/User_Guide/run_at_scale.rst
+++ b/doc/source/User_Guide/run_at_scale.rst
@@ -54,9 +54,9 @@ would, and place an appropriately modified main_input into each
 directory. These directories should all reside within the same parent
 directory. Within that parent directory, you should place a copy of the
 Rayleigh executable (or a softlink). In addition, you should create a
-text file named **run_list** that contains the name of each simulation
+text file named ``run_list`` that contains the name of each simulation
 directory, one name per line. An ensemble job may then be executed by
-calling Rayleigh with **nruns** command line flag as:
+calling Rayleigh with the ``-nruns`` command line flag as:
 
 ::
 

--- a/doc/source/User_Guide/run_rayleigh.rst
+++ b/doc/source/User_Guide/run_rayleigh.rst
@@ -7,7 +7,7 @@
 Running Rayleigh
 ================
 
-After setting up a custom `main_input` file, now it is time to run the new model.
+After setting up a custom ``main_input`` file, now it is time to run the new model.
 This section focuses on the basics of running a Rayleigh model.
 
 .. _load_balance:
@@ -152,10 +152,10 @@ points for a given run. These files begin with an 8-digit prefix
 indicating the time step at which the checkpoint was created.
 
 The frequency with which standard checkpoints are generated can be
-controlled by modifying the **checkpoint_interval** variable in the
-**temporal_controls_namelist**. For example, if you want to generate a
+controlled by modifying the **checkpoint_interval`` variable in the
+``temporal_controls_namelist``. For example, if you want to generate a
 checkpoint once every 50,000 time steps, you would modify your
-main_input file to read:
+``main_input`` file to read:
 
 ::
 
@@ -167,10 +167,10 @@ The default value of checkpoint_interval is 1,000,000, which is
 typically much larger than what you will use in practice.
 
 Restarting from a checkpoint is accomplished by first assigning a value
-of -1 to the variables **init_type** and/or **magnetic_init_type** in
-the **initial_conditions_namelist**. In addition, the time step from
+of -1 to the variables ``init_type`` and/or ``magnetic_init_type`` in
+the ``initial_conditions_namelist``. In addition, the time step from
 which you wish to restart from should be specified using the
-**restart_iter** variable in the initial_conditions_namelist. The
+``restart_iter`` variable in the initial_conditions_namelist. The
 example below will restart both the magnetic and hydrodynamic variables
 using the set of checkpoint files beginning with the prefix 00005000.
 
@@ -210,7 +210,7 @@ assigning a value of zero to restart_iter:
     restart_iter = 0        ! Restart using the most recent checkpoint
    /
 
-In this case, Rayleigh reads the **last_checkpoint** file (found within
+In this case, Rayleigh reads the ``last_checkpoint`` file (found within
 the Checkpoints directory) to determine which checkpoint it reads.
 
 .. _quicksaves:
@@ -231,15 +231,15 @@ high-cadence, but require low storage due to the rotating reuse of
 quicksave files.
 
 The cadence with which quicksaves are written can be specified by
-setting the **quicksave_interval** variable in the
-**temporal_controls_namelist**. Alternatively, the elapsed wall time (in
+setting the ``quicksave_interval`` variable in the
+``temporal_controls_namelist``. Alternatively, the elapsed wall time (in
 minutes) that passes between quicksaves may be controlled by specifying
 the **quicksave_minutes** variable. If both quicksave_interval and
 quicksave_minutes are specified, quicksave_minutes takes precedence.
 
 What distinguishes quicksaves from standard checkpoints is that only a
 specified number of quicksaves exist on the disk at any given time. That
-number is determined by the value of **num_quicksaves**. Quicksave files
+number is determined by the value of ``num_quicksaves``. Quicksave files
 begin with the prefix *quicksave_XX*, where XX is a 2-digit code,
 ranging from 1 through num_quicksaves and indicates the quicksave
 number. Consider the following example:
@@ -258,7 +258,7 @@ files beginning with prefix quicksave_02 will be generated. Following
 that, at time step 30,000, another checkpoint will be generated, *but it
 will overwrite the existing quicksave_01 files*. At time step 40,000,
 the quicksave_02 files will be overwritten, and so forth. Because the
-**num_quicksaves** was set to 2, filenames with prefix quicksave_03 will
+``num_quicksaves`` was set to 2, filenames with prefix quicksave_03 will
 never be generated.
 
 Note that checkpoints beginning with an 8-digit prefix (e.g., 00035000)
@@ -292,7 +292,7 @@ Checkpoint Logs
 ~~~~~~~~~~~~~~~
 
 When checkpoints are written, the number of the most recent checkpoint
-is appended to a file named **checkpoint_log**, found in the Checkpoints
+is appended to a file named ``checkpoint_log``, found in the Checkpoints
 directory. The checkpoint log can be used to identify the time step
 number of a quicksave file that otherwise has no identifying
 information. While this information is also contained in the grid_etc
@@ -311,35 +311,35 @@ Controlling Run Length & Time Stepping
 --------------------------------------
 
 A simulation’s runtime and time-step size can be controlled using the
-**temporal_controls** namelist. The length of time for which a
+``temporal_controls`` namelist. The length of time for which a
 simulation runs before completing is controlled by the namelist variable
-**max_time_minutes**. The maximum number of time steps that a simulation
+``max_time_minutes``. The maximum number of time steps that a simulation
 will run for is determined by the value of the namelist
-**max_iterations**. The simulation will complete when it has run for
-*max_time_minutes minutes* or when it has run for *max_iterations time
+``max_iterations``. The simulation will complete when it has run for
+``max_time_minutes`` *minutes* or when it has run for ``max_iterations`` *time
 steps* – whichever occurs first.
 
 An orderly shutdown of Rayleigh can be manually triggered by creating a file
-with the name set in **terminate_file** (i.e., running the command *touch
+with the name set in ``terminate_file`` (i.e., running the command *touch
 terminate* in the default setting). If the file is found, Rayleigh will stop
 after the next time step and write a checkpoint file. The existence of
-**terminate_file** is checked every **terminate_check_interval** iterations.
+``terminate_file`` is checked every ``terminate_check_interval`` iterations.
 The check can be switched off completely by setting
-**terminate_check_interval** to -1. Both of these options are set in the
-**io_controls_namelist**. With the appropriate job script this feature can be
+``terminate_check_interval`` to -1. Both of these options are set in the
+``io_controls_namelist``. With the appropriate job script this feature can be
 used to easily restart the code with new settings without losing the current
-allocation in the queuing system. A **terminate_file** left over from
+allocation in the queuing system. A ``terminate_file`` left over from
 a previous run is automatically deleted when the code starts.
 
 Time-step size in Rayleigh is controlled by the Courant-Friedrichs-Lewy
 condition (CFL; as determined by the fluid velocity and Alfvén speed). A
-safety factor of **cflmax** is applied to the maximum time step
+safety factor of ``cflmax`` is applied to the maximum time step
 determined by the CFL. Time-stepping is adaptive. An additional variable
-**cflmin** is used to determine if the time step should be increased.
+``cflmin`` is used to determine if the time step should be increased.
 
 The user may also specify the maximum allowed time-step size through the
-namelist variable **max_time_step**. The minimum allowable time-step
-size is controlled through the variable **min_time_step**. If the CFL
+namelist variable ``max_time_step``. The minimum allowable time-step
+size is controlled through the variable ``min_time_step``. If the CFL
 condition is less than this value, the simulation will exit.
 
 Let :math:`\Delta t` be the current time-step size, and let
@@ -395,13 +395,13 @@ I/O Format Controls
 
 By default, integer output is reported with 8 digits and padded with leading zeros.  This includes integer iteration
 numbers reported to stdout at each timestep and integer-number filenames created through diagnostics and checkpointing
-output.  If desired, the number of digits may be controlled through the **integer_output_digits** variable.   When
-reading in a Checkpoint created with a different number of digits, set the **integer_input_digits** variable to an appropriate
+output.  If desired, the number of digits may be controlled through the ``integer_output_digits`` variable.   When
+reading in a Checkpoint created with a different number of digits, set the ``integer_input_digits`` variable to an appropriate
 value.  
 
 At several points in the code, floating-point output is sent to stdout.  This output is formatted using scienific notation, with
 three digits to the right of the decimal place.     The number of digits after the decimal can be controlled through the
-**decimal_places** variable.
+``decimal_places`` variable.
 
 As an example, the following combination of inputs
 ::
@@ -450,7 +450,7 @@ buffered on-node and written to disk only when the run has terminated.
 There are situations where it can be advantageous to have a regularly
 updated log file whose update frequency may be controlled. This feature
 exists in Rayleigh and may be accessed by assigning values to
-**stdout_flush_interval** and **stdout_file** in the io controls
+``stdout_flush_interval`` and ``stdout_file`` in the io controls
 namelist.
 
 ::
@@ -461,7 +461,7 @@ namelist.
    /
 
 Set stdout_file to the name of a file that will contain Rayleigh’s text
-output. In the example above, a file named *routput* will be appear in
+output. In the example above, a file named ``routput`` will be appear in
 the simulation directory and will be updated periodically throughout the
 run. The variable stdout_flush_interval determines how many lines of
 text are buffered before they are flushed to routput. Rayleigh prints
@@ -474,11 +474,11 @@ accumulated.
 Changes in the time-step size and self-termination of the run will also
 force a text-buffer flush. Unexpected crashes and sudden termination by
 the system job scheduler do not force a buffer flush. Note that the
-default value of stdout_file is **‘nofile’**. If this value is
+default value of stdout_file is ``'nofile'``. If this value is
 specified, output will directed to normal stdout.
 
 To save on disk space for logs of very long runs, the number of status outputs
-can be reduced by specifying **statusline_interval** in the
+can be reduced by specifying ``statusline_interval`` in the
 **io_controls_namelist**. This causes only every n-th status line to be
 written.
 


### PR DESCRIPTION
This fixes some broken internal links and typos. Another major change is the more consistent use of `verbatim` formatting in the text when it relates to code.