### PR TITLE
Finite-Difference Documentation Bug Fix

### DIFF
--- a/doc/source/User_Guide/model_setup.rst
+++ b/doc/source/User_Guide/model_setup.rst
@@ -174,8 +174,6 @@ Rayleigh's default behavior is to employ a Chebyshev collocation scheme in radiu
     rmin = 1.0
     rmax = 2.0
     n_r = 4
-    dr_weights = 0.1,0.3,0.2
-    nr_count = 2,4,2
    /
    &numerical_controls_namelist
     chebyshev=.false.


### PR DESCRIPTION
This corrects a small error in the finite-difference portion of the documentation.  The initial example in that section is intended to illustrate how to set up a uniform grid in radius.  Two lines of code were included in that example erroneously, however, which produced a nonuniform grid.
