### PR TITLE
Pleiades Installation Instruction Update

### DIFF
--- a/doc/source/User_Guide/getting_started.rst
+++ b/doc/source/User_Guide/getting_started.rst
@@ -415,9 +415,8 @@ Installation on NASA's Pleiades cluster is similarly straightforward.  After clo
 .. code-block:: bash
 
    module purge
-   module load comp-intel
-   module load mpi-hpe
-   ./configure --FC=mpif90 --CC=icc  # select 'ALL'
+   module load comp-intel mpi-hpe
+   ./configure --FC=mpif90 --CC=icc -mkl  # select 'ALL'
    make -j
    make install
    

--- a/doc/source/User_Guide/newtonian_cooling.txt
+++ b/doc/source/User_Guide/newtonian_cooling.txt
@@ -24,7 +24,9 @@ and a value of 2 yields
 .. math::
    :label: ncteq2
 
-   \Delta\Theta_\mathrm{eq} = A\mathrm{cos}(\theta)\mathrm{sin}(\phi).
+   \Delta\Theta_\mathrm{eq} = A\mathrm{cos}(\theta)\mathrm{sin}(\phi)\mathrm{log}(\hat{P}/\hat{P}_\mathrm{bottom})/\mathrm{log}(\hat{P}_\mathrm{top}/\hat{P}_\mathrm{bottom}),
+
+where :math:`\hat{P}` is the reference state pressure.
 
 The amplitude :math:`A` is controlled by setting the variable  ``newtonian_cooling_tvar_amp``.   As an example, to use Newtonian cooling, one might add the following four lines to the ``physical_controls_namelist``.
 

--- a/doc/source/User_Guide/newtonian_cooling.txt
+++ b/doc/source/User_Guide/newtonian_cooling.txt
@@ -1,0 +1,40 @@
+.. _newtonian_cooling:
+
+Newtonian Cooling
+-----------------------
+
+We have added an initial implementation of Newtonian cooling to the code that adds a term to the thermal energy equation of the form
+
+.. math::
+   :label: newton
+
+   \frac{\partial \Theta}{\partial t}  = \frac{\Delta\Theta_{\mathrm{eq}}-\Theta}{\tau_\mathrm{eq}}.
+
+Here, :math:`\Delta\Theta_\mathrm{eq}` is a target temperature/entropy variation about the background state and :math:`\tau_\mathrm{eq}` is the cooling timescale.  Newtonian cooling can be turned on by setting ``newtonian_cooling=.true.`` in the ``physical_controls_namelist``, and the cooling time is similarly controlled by specifying the value of ``newtonian_cooling_time``.  
+
+At present, :math:`\Delta\Theta_\mathrm{eq}` is allowed to take one of two forms.  These are controlled by setting the ``newtonian_cooling_type`` variable in ``physical_controls_namelist``.  A value of 1 yields
+
+.. math::
+   :label: ncteq1
+   
+   \Delta\Theta_\mathrm{eq} = A,
+
+and a value of 2 yields
+
+.. math::
+   :label: ncteq2
+
+   \Delta\Theta_\mathrm{eq} = A\mathrm{cos}(\theta)\mathrm{sin}(\phi).
+
+The amplitude :math:`A` is controlled by setting the variable  ``newtonian_cooling_tvar_amp``.   As an example, to use Newtonian cooling, one might add the following four lines to the ``physical_controls_namelist``.
+
+::
+
+   &physical_controls_namelist
+    newtonian_cooling = .true.
+    newtonian_cooling_type = 1
+    newtonian_cooling_time = 1.0d0
+    newtonian_cooling_tvar_amp = 1.0d0
+   /
+
+

--- a/doc/source/User_Guide/under_development.rst
+++ b/doc/source/User_Guide/under_development.rst
@@ -16,8 +16,6 @@ Arbitrary Scalar Fields
 
 .. include:: arbitrary_scalar_fields.txt 
 
-
-
-
+.. include:: newtonian_cooling.txt
 
 

--- a/src/Physics/Controls.F90
+++ b/src/Physics/Controls.F90
@@ -79,7 +79,7 @@ Module Controls
     ! --- Newtonian Cooling Variables
     Logical :: newtonian_cooling = .false.  ! Turn newtonian_cooling on/off
     Integer :: newtonian_cooling_type = 1
-    Real*8  :: newtonian_cooling_timescale = 1.0d22
+    Real*8  :: newtonian_cooling_time = 1.0d22
 
     Namelist /Physical_Controls_Namelist/ magnetism, nonlinear, rotation, lorentz_forces, &
                 & viscous_heating, ohmic_heating, advect_reference_state, benchmark_mode, &

--- a/src/Physics/Controls.F90
+++ b/src/Physics/Controls.F90
@@ -80,14 +80,14 @@ Module Controls
     Logical :: newtonian_cooling = .false.  ! Turn newtonian_cooling on/off
     Integer :: newtonian_cooling_type = 1
     Real*8  :: newtonian_cooling_time = 1.0d22
-    Real*8  :: newtonian_delta_tvar_Eq = 0.0d0
+    Real*8  :: newtonian_cooling_tvar_amp = 0.0d0
 
     Namelist /Physical_Controls_Namelist/ magnetism, nonlinear, rotation, lorentz_forces, &
                 & viscous_heating, ohmic_heating, advect_reference_state, benchmark_mode, &
                 & benchmark_integration_interval, benchmark_report_interval, &
                 & momentum_advection, inertia, n_active_scalars, n_passive_scalars, &
                 & newtonian_cooling, newtonian_cooling_type, newtonian_cooling_time, &
-                & newtonian_delta_tvar_eq
+                & newtonian_cooling_tvar_amp
 
     !///////////////////////////////////////////////////////////////////////////
     !   Temporal Controls

--- a/src/Physics/Controls.F90
+++ b/src/Physics/Controls.F90
@@ -80,12 +80,14 @@ Module Controls
     Logical :: newtonian_cooling = .false.  ! Turn newtonian_cooling on/off
     Integer :: newtonian_cooling_type = 1
     Real*8  :: newtonian_cooling_time = 1.0d22
+    Real*8  :: newtonian_delta_tvar_Eq = 0.0d0
 
     Namelist /Physical_Controls_Namelist/ magnetism, nonlinear, rotation, lorentz_forces, &
                 & viscous_heating, ohmic_heating, advect_reference_state, benchmark_mode, &
                 & benchmark_integration_interval, benchmark_report_interval, &
                 & momentum_advection, inertia, n_active_scalars, n_passive_scalars, &
-                & newtonian_cooling
+                & newtonian_cooling, newtonian_cooling_type, newtonian_cooling_time, &
+                & newtonian_delta_tvar_eq
 
     !///////////////////////////////////////////////////////////////////////////
     !   Temporal Controls

--- a/src/Physics/Controls.F90
+++ b/src/Physics/Controls.F90
@@ -69,16 +69,23 @@ Module Controls
     Integer :: n_active_scalars = 0         ! number of active scalar fields
     Integer :: n_passive_scalars = 0        ! number of passive scalar fields
 
+
     ! --- This flag determines if the code is run in benchmark mode
     !     0 (default) is no benchmarking.  1-5 are various accuracy benchmarks (see documentation)
     Integer :: benchmark_mode = 0
     Integer :: benchmark_integration_interval = -1 ! manual override of integration_interval
     Integer :: benchmark_report_interval = -1      ! and report interval in Benchmarking.F90 (for debugging)
 
+    ! --- Newtonian Cooling Variables
+    Logical :: newtonian_cooling = .false.  ! Turn newtonian_cooling on/off
+    Integer :: newtonian_cooling_type = 1
+    Real*8  :: newtonian_cooling_timescale = 1.0d22
+
     Namelist /Physical_Controls_Namelist/ magnetism, nonlinear, rotation, lorentz_forces, &
                 & viscous_heating, ohmic_heating, advect_reference_state, benchmark_mode, &
                 & benchmark_integration_interval, benchmark_report_interval, &
-                & momentum_advection, inertia, n_active_scalars, n_passive_scalars
+                & momentum_advection, inertia, n_active_scalars, n_passive_scalars, &
+                & newtonian_cooling
 
     !///////////////////////////////////////////////////////////////////////////
     !   Temporal Controls

--- a/src/Physics/Sphere_Driver.F90
+++ b/src/Physics/Sphere_Driver.F90
@@ -21,7 +21,7 @@
 Module Sphere_Driver
     Use ClockInfo
     Use Sphere_Hybrid_Space,   Only : rlm_spacea, rlm_spaceb, hybrid_init
-    Use Sphere_Physical_Space, Only : physical_space, ohmic_heating_coeff
+    Use Sphere_Physical_Space, Only : physical_space, ohmic_heating_coeff, physical_space_init
     Use Sphere_Spectral_Space, Only : post_solve, advancetime, ctemp, post_solve_FD
     Use Diagnostics_Interface, Only : Reboot_Diagnostics
     Use Spherical_IO, Only : time_to_output
@@ -130,6 +130,7 @@ Contains
 
 
         Call Hybrid_Init()
+        Call Physical_Space_Init()
         Call StopWatch(loop_time)%StartClock()
         max_time_seconds = 60*max_time_minutes
 

--- a/src/Physics/Sphere_Physical_Space.F90
+++ b/src/Physics/Sphere_Physical_Space.F90
@@ -123,6 +123,7 @@ Contains
         Call Temperature_Advection()
         Call Volumetric_Heating()
 
+
         do i = 1, n_active_scalars
           Call chi_Advection(chiavar(i), dchiadr(i), dchiadt(i), dchiadp(i))
           Call chi_Source_function(chiavar(i))
@@ -241,7 +242,22 @@ Contains
             Enddo
             !$OMP END PARALLEL DO
         Endif
+
+
+        If (newtonian_cooling) Then
+            ! Added a volumetric heating to the energy equation
+            !$OMP PARALLEL DO PRIVATE(t,r,k)
+            Do t = my_theta%min, my_theta%max
+                Do r = my_r%min, my_r%max
+                    Do k =1, n_phi
+                        wsp%p3b(k,r,t,tvar) = wsp%p3b(k,r,t,tvar)+0.0d0
+                    Enddo
+                Enddo
+            Enddo
+            !$OMP END PARALLEL DO
+        Endif
     End Subroutine Volumetric_Heating
+
 
     Subroutine chi_Source_Function(chivar)
         Implicit None

--- a/src/Physics/Sphere_Physical_Space.F90
+++ b/src/Physics/Sphere_Physical_Space.F90
@@ -38,6 +38,16 @@ Module Sphere_Physical_Space
     Implicit None
 
 Contains
+    
+    Subroutine Physical_Space_Init()
+        Implicit None
+        
+        ! Any persistant arrays needs for physical space routines can be
+        ! initialized here.
+
+
+    End Subroutine Physical_Space_Init
+
     Subroutine physical_space()
         Implicit None
         Integer :: i

--- a/src/Physics/Sphere_Physical_Space.F90
+++ b/src/Physics/Sphere_Physical_Space.F90
@@ -44,6 +44,9 @@ Contains
     Subroutine Physical_Space_Init()
         Implicit None
         Integer :: k, r, t
+        Real*8, Allocatable :: press(:)
+
+        
         
         ! Any persistant arrays needs for physical space routines can be
         ! initialized here.
@@ -66,11 +69,15 @@ Contains
 
             If (newtonian_cooling_type .eq. 2) Then
                 ! Angular variation (ell=1,m=1, motivated by hot Jupiters)
+
+                Allocate(press(1:N_R))
+                press = ref%density*ref%temperature
                 If (my_rank .eq. 0) Write(6,*) 'Newtonian cooling is active.  Type = 2'
                 Do t = my_theta%min, my_theta%max
                     Do r = my_r%min, my_r%max
                         Do k =1, n_phi
                             tvar_eq(k,r,t) = newtonian_cooling_tvar_amp*costheta(t)*sinphi(k)
+                            tvar_eq(k,r,t) = tvar_eq(k,r,t)*log(press(r)/press(N_R))/log(press(1)/press(N_R))
                         Enddo
                     Enddo
                 Enddo

--- a/src/Physics/Sphere_Physical_Space.F90
+++ b/src/Physics/Sphere_Physical_Space.F90
@@ -43,6 +43,7 @@ Contains
     
     Subroutine Physical_Space_Init()
         Implicit None
+        Integer :: k, r, t
         
         ! Any persistant arrays needs for physical space routines can be
         ! initialized here.
@@ -50,7 +51,13 @@ Contains
             Allocate(tvar_eq(1:n_phi, my_r%min:my_r%max, my_theta%min:my_theta%max))
             tvar_eq(:,:,:) = 0.0d0
             If (newtonian_cooling_type .eq. 1) Then
-                tvar_eq(:,:,:) = 0.0d0
+                Do t = my_theta%min, my_theta%max
+                    Do r = my_r%min, my_r%max
+                        Do k =1, n_phi
+                            tvar_eq(k,r,t) = newtonian_delta_tvar_eq*costheta(t)*sinphi(k)
+                        Enddo
+                    Enddo
+                Enddo
             Endif
         Endif
 

--- a/src/Physics/Sphere_Physical_Space.F90
+++ b/src/Physics/Sphere_Physical_Space.F90
@@ -50,7 +50,21 @@ Contains
         If (newtonian_cooling) Then
             Allocate(tvar_eq(1:n_phi, my_r%min:my_r%max, my_theta%min:my_theta%max))
             tvar_eq(:,:,:) = 0.0d0
+
             If (newtonian_cooling_type .eq. 1) Then
+                ! No angular variation
+                Do t = my_theta%min, my_theta%max
+                    Do r = my_r%min, my_r%max
+                        Do k =1, n_phi
+                            tvar_eq(k,r,t) = newtonian_delta_tvar_eq
+                        Enddo
+                    Enddo
+                Enddo
+            Endif
+
+
+            If (newtonian_cooling_type .eq. 2) Then
+                ! Angular variation (ell=1,m=1, motivated by hot Jupiters)
                 Do t = my_theta%min, my_theta%max
                     Do r = my_r%min, my_r%max
                         Do k =1, n_phi

--- a/src/Physics/Sphere_Physical_Space.F90
+++ b/src/Physics/Sphere_Physical_Space.F90
@@ -76,7 +76,7 @@ Contains
                 Do t = my_theta%min, my_theta%max
                     Do r = my_r%min, my_r%max
                         Do k =1, n_phi
-                            tvar_eq(k,r,t) = newtonian_cooling_tvar_amp*costheta(t)*sinphi(k)
+                            tvar_eq(k,r,t) = newtonian_cooling_tvar_amp*sintheta(t)*sinphi(k)
                             tvar_eq(k,r,t) = tvar_eq(k,r,t)*log(press(r)/press(N_R))/log(press(1)/press(N_R))
                         Enddo
                     Enddo

--- a/src/Physics/Sphere_Physical_Space.F90
+++ b/src/Physics/Sphere_Physical_Space.F90
@@ -53,10 +53,11 @@ Contains
 
             If (newtonian_cooling_type .eq. 1) Then
                 ! No angular variation
+                If (my_rank .eq. 0) Write(6,*) 'Newtonian cooling is active.  Type = 1'
                 Do t = my_theta%min, my_theta%max
                     Do r = my_r%min, my_r%max
                         Do k =1, n_phi
-                            tvar_eq(k,r,t) = newtonian_delta_tvar_eq
+                            tvar_eq(k,r,t) = newtonian_cooling_tvar_amp
                         Enddo
                     Enddo
                 Enddo
@@ -65,10 +66,11 @@ Contains
 
             If (newtonian_cooling_type .eq. 2) Then
                 ! Angular variation (ell=1,m=1, motivated by hot Jupiters)
+                If (my_rank .eq. 0) Write(6,*) 'Newtonian cooling is active.  Type = 2'
                 Do t = my_theta%min, my_theta%max
                     Do r = my_r%min, my_r%max
                         Do k =1, n_phi
-                            tvar_eq(k,r,t) = newtonian_delta_tvar_eq*costheta(t)*sinphi(k)
+                            tvar_eq(k,r,t) = newtonian_cooling_tvar_amp*costheta(t)*sinphi(k)
                         Enddo
                     Enddo
                 Enddo

--- a/src/Physics/Sphere_Physical_Space.F90
+++ b/src/Physics/Sphere_Physical_Space.F90
@@ -37,6 +37,8 @@ Module Sphere_Physical_Space
     Use Benchmarking, Only : benchmark_checkup
     Implicit None
 
+    Real*8, Allocatable :: tvar_eq(:,:,:)
+
 Contains
     
     Subroutine Physical_Space_Init()
@@ -44,7 +46,13 @@ Contains
         
         ! Any persistant arrays needs for physical space routines can be
         ! initialized here.
-
+        If (newtonian_cooling) Then
+            Allocate(tvar_eq(1:n_phi, my_r%min:my_r%max, my_theta%min:my_theta%max))
+            tvar_eq(:,:,:) = 0.0d0
+            If (newtonian_cooling_type .eq. 1) Then
+                tvar_eq(:,:,:) = 0.0d0
+            Endif
+        Endif
 
     End Subroutine Physical_Space_Init
 
@@ -260,7 +268,8 @@ Contains
             Do t = my_theta%min, my_theta%max
                 Do r = my_r%min, my_r%max
                     Do k =1, n_phi
-                        wsp%p3b(k,r,t,tvar) = wsp%p3b(k,r,t,tvar)+0.0d0
+                        wsp%p3b(k,r,t,tvar) = wsp%p3b(k,r,t,tvar) + &
+                                      (tvar_eq(k,r,t) -wsp%p3b(k,r,t,tvar))/newtonian_cooling_time
                     Enddo
                 Enddo
             Enddo


### PR DESCRIPTION
The logic recently changed in the configure file so that the -mkl flag must be passed to configure when using MKL.  This is true even when using an Intel compiler with MKLROOT specified in the user's environment.   This PR updates the documentation to reflect this change.  In addition, it is best practice on Pleiades to load the compiler and mpi module at the same time owing to a bug that occurs on some node types if they are run one after the other.  This has nothing to do with Rayleigh, but I've updated the documentation to hopefully help people avoid this bug.