### PR TITLE
Updated Pleiades install instructions.

### DIFF
--- a/doc/source/User_Guide/getting_started.rst
+++ b/doc/source/User_Guide/getting_started.rst
@@ -415,9 +415,8 @@ Installation on NASA's Pleiades cluster is similarly straightforward.  After clo
 .. code-block:: bash
 
    module purge
-   module load comp-intel
-   module load mpi-hpe
-   ./configure --FC=mpif90 --CC=icc  # select 'ALL'
+   module load comp-intel mpi-hpe
+   ./configure --FC=mpif90 --CC=icc -mkl  # select 'ALL'
    make -j
    make install
    


### PR DESCRIPTION
The logic recently changed in the configure file so that the -mkl flag must be passed to configure when using MKL. This is true even when using an Intel compiler with MKLROOT specified in the user's environment. This PR updates the documentation to reflect this change. In addition, it is best practice on Pleiades to load the compiler and mpi module at the same time owing to a bug that occurs on some node types if they are run one after the other. This has nothing to do with Rayleigh, but I've updated the documentation to hopefully help people avoid this bug.