### PR TITLE
check the  documentation build in the conda action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -125,7 +125,6 @@ jobs:
         auto-update-conda: true
         miniconda-version: "latest"
     - name: Build documentation
-      continue-on-error: true
       run: |
         cd "$GITHUB_WORKSPACE"
         make doc

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - The logic in the configure script that determines the library-link flags for compilation on different systems has been simplified.   \[Rene Gassmoeller; 6-19-2024; [#534](https://github.com/geodynamics/Rayleigh/pull/534)\]
 
+- The documentation build has been split into HTML (`make doc`) and PDF (`make docpdf`) outputs.   \[Philipp Edelmann; 6-21-2024; [#552](https://github.com/geodynamics/Rayleigh/pull/552)\]
+
 ### Fixed
 
 - Rayleigh no longer attempts to update the record count and close a diagnostics file (e.g., G_Avgs) that failed to open correctly.  \[Nick Featherstone; 6-18-2024; [#510](https://github.com/geodynamics/Rayleigh/pull/510) , [#523](https://github.com/geodynamics/Rayleigh/pull/523)  \]

--- a/Makefile
+++ b/Makefile
@@ -91,6 +91,9 @@ endif
 .PHONY: doc
 doc:
 	@sphinx-build -M html "." "doc/build"
+
+.PHONY: docpdf
+docpdf:
 	@sphinx-build -M latexpdf "." "doc/build"
 
 .PHONY: distclean

--- a/doc/source/User_Guide/getting_started.rst
+++ b/doc/source/User_Guide/getting_started.rst
@@ -58,7 +58,7 @@ Building the documentation is the same on Linux and Mac.
     cd /path/to/Rayleigh
     make doc
 
-Once the documetation builds, you can access it by opening ``Rayleigh/doc/build/html/index.html`` in your web browser.
+Once the documetation builds, you can access it by opening ``Rayleigh/doc/build/html/index.html`` in your web browser. To build the PDF version of the documentation (same content as HTML) you run ``make docpdf``.
 
 Building the code is again the same on Linux and Mac. Execute the following:
 


### PR DESCRIPTION
At the moment the build just continues on failed documentation builds in the Conda action. That's not very useful and we might as well skip the documentation build. We should check it though to make sure the docs also build on macOS.

This PR makes the action fail on error and splits the documentation build into HTML (`make doc`) and PDF (`make docpdf`) outputs.