### PR TITLE
Add documentation to the cmake build system

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,3 +66,5 @@ find_package(LAPACK COMPONENTS Fortran REQUIRED)
 find_package(FFTW REQUIRED)
 
 add_subdirectory(src)
+
+add_subdirectory(doc)

--- a/conf.py
+++ b/conf.py
@@ -51,7 +51,7 @@ templates_path = ['_templates']
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path.
-exclude_patterns = ['_build', 'doc/build', '**.ipynb_checkpoints']
+exclude_patterns = ['_build', '**doc/build', '**.ipynb_checkpoints']
 nbsphinx_allow_errors = True
 nbsphinx_execute = 'never'
 

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -1,0 +1,76 @@
+#
+#  Copyright (C) 2024 by the authors of the RAYLEIGH code.
+#
+#  This file is part of RAYLEIGH.
+#
+#  RAYLEIGH is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 3, or (at your option)
+#  any later version.
+#
+#  RAYLEIGH is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with RAYLEIGH; see the file LICENSE.  If not see
+#  <http://www.gnu.org/licenses/>.
+
+
+CMAKE_MINIMUM_REQUIRED(VERSION 3.13.4)
+
+####################################################
+# Generate the manual
+####################################################
+
+# Find the documentation sources
+file(GLOB_RECURSE SOURCES
+  source/*)
+
+# Build HTML target
+message(STATUS "===== Configuring documentation ===============")
+message(STATUS "")
+
+ADD_CUSTOM_COMMAND(
+  OUTPUT
+    ${PROJECT_BINARY_DIR}/doc/build/html/index.html
+  COMMAND
+    sphinx-build -M html ${PROJECT_SOURCE_DIR} ${PROJECT_BINARY_DIR}/doc/build
+  DEPENDS
+    ${SOURCES}
+  COMMENT
+    "Generating the html documentation."
+)
+
+ADD_CUSTOM_TARGET(doc_html
+  DEPENDS 
+    ${PROJECT_BINARY_DIR}/doc/build/html/index.html
+)
+
+# Build pdf target
+ADD_CUSTOM_COMMAND(
+  OUTPUT
+    ${PROJECT_BINARY_DIR}/doc/build/latex/rayleigh.pdf
+  COMMAND
+    sphinx-build -M latexpdf ${PROJECT_SOURCE_DIR} ${PROJECT_BINARY_DIR}/doc/build
+  DEPENDS
+    ${SOURCES}
+  COMMENT
+    "Generating the latexpdf documentation."
+)
+
+ADD_CUSTOM_TARGET(doc_pdf
+  DEPENDS
+    ${PROJECT_BINARY_DIR}/doc/build/latex/rayleigh.pdf
+)
+
+################################################################
+# The final target: Build it all
+################################################################
+message(STATUS "Setting up build information")
+ADD_CUSTOM_TARGET(doc
+  DEPENDS
+    doc_html
+    doc_pdf
+)


### PR DESCRIPTION
This adds the targets `make doc`, `make doc_html`, and `make_pdf` to the cmake build system. `make doc` builds both of the other targets.

The targets depend on all files in `doc/source` so it is only rebuild if something changes in that directory.

The only change to the existing system that I had to make was the modification to the conf.py that makes the exclude path of `doc/build` independent of the directory it is executed from (otherwise I got the same recursive addition of build files we repaired earlier in the week).