### PR TITLE
[wip] Simplified and minimal update to include pseudo-incompressibility

### DIFF
--- a/src/Physics/Controls.F90
+++ b/src/Physics/Controls.F90
@@ -79,7 +79,7 @@ Module Controls
     Namelist /Physical_Controls_Namelist/ magnetism, nonlinear, rotation, lorentz_forces, &
                 & viscous_heating, ohmic_heating, advect_reference_state, benchmark_mode, &
                 & benchmark_integration_interval, benchmark_report_interval, &
-                & momentum_advection, inertia, n_active_scalars, n_passive_scalars,
+                & momentum_advection, inertia, n_active_scalars, n_passive_scalars, &
                 & pseudo_incompressible
 
     !///////////////////////////////////////////////////////////////////////////

--- a/src/Physics/Controls.F90
+++ b/src/Physics/Controls.F90
@@ -63,6 +63,7 @@ Module Controls
     Logical :: lorentz_forces = .true.      ! Turn Lorentz forces on or off (default is on - as long as magnetism is on)
     Logical :: viscous_heating = .true.     ! Turns viscous heating on/off
     Logical :: ohmic_heating = .true.
+    Logical :: pseudo_incompressible = .false.  ! Switch from anelastic to pseudo-incompressible approximation
     Logical :: advect_reference_state = .true.  ! Set to true to advect the reference state temperature or entropy
                                                 ! This has no effect for adiabatic reference states.
                                                 ! Generally only do this if reference state is nonadiabatic
@@ -78,7 +79,8 @@ Module Controls
     Namelist /Physical_Controls_Namelist/ magnetism, nonlinear, rotation, lorentz_forces, &
                 & viscous_heating, ohmic_heating, advect_reference_state, benchmark_mode, &
                 & benchmark_integration_interval, benchmark_report_interval, &
-                & momentum_advection, inertia, n_active_scalars, n_passive_scalars
+                & momentum_advection, inertia, n_active_scalars, n_passive_scalars,
+                & pseudo_incompressible
 
     !///////////////////////////////////////////////////////////////////////////
     !   Temporal Controls
@@ -216,6 +218,7 @@ Contains
         lorentz_forces = .true.
         viscous_heating = .true.
         ohmic_heating = .true.
+        pseudo_incompressible = .false.
         advect_reference_state = .true.
         benchmark_mode = 0
         benchmark_integration_interval = -1

--- a/src/Physics/PDE_Coefficients.F90
+++ b/src/Physics/PDE_Coefficients.F90
@@ -1303,7 +1303,7 @@ Contains
         Enddo
         ref%exp_entropy = exp(ref%entropy/pressure_specific_heat)
         ref%dsdr_over_cp = ref%dsdr/pressure_specific_heat
-        Call log_deriv(ref%dsdr_over_cp(:), ref%d2s_over_cp(i), no_log=.true.)
+        Call log_deriv(ref%dsdr_over_cp(:), ref%d2s_over_cp(:), no_log=.true.)
 
     End Subroutine Get_Custom_Reference
 
@@ -2067,7 +2067,8 @@ Contains
         
         
         If (pseudo_incompressible) Then
-            W_Diffusion_Coefs_0 = W_Diffusion_Coefs_0 - nu*(4.0d0/3.0d0)*ref%dsdr_over_cp*(dnu - ref%dlnrho -ref%dsdr_over_cp - 2.0d0/radius)
+            W_Diffusion_Coefs_0 = W_Diffusion_Coefs_0 - nu*(4.0d0/3.0d0)*ref%dsdr_over_cp*(dlnu - ref%dlnrho -ref%dsdr_over_cp)
+            W_Diffusion_Coefs_0 = W_Diffusion_Coefs_0 + nu*(8.0d0/3.0d0)*ref%dsdr_over_cp/radius
             W_Diffusion_Coefs_0  = W_Diffusion_Coefs_0  - nu*(4.0d0/3.0d0)*ref%d2s_over_cp
             W_Diffusion_Coefs_1  = W_Diffusion_Coefs_1  - nu*(7.0d0/3.0d0)*ref%dsdr_over_cp
             DW_Diffusion_Coefs_0 = DW_Diffusion_Coefs_0 + nu*ref%dsdr_over_cp/3.0d0

--- a/src/Physics/Sphere_Hybrid_Space.F90
+++ b/src/Physics/Sphere_Hybrid_Space.F90
@@ -49,13 +49,14 @@ Contains
         Allocate(drho_term(my_r%min:my_r%max))
         r1 = my_r%min
         r2 = my_r%max
-        over_rhor(r1:r2) = one_over_r(r1:r2)/ref%density(r1:r2)
-        over_rhorsq(r1:r2) = OneOverRSquared(r1:r2)/ref%density(r1:r2)
-        drho_term(r1:r2) = ref%dlnrho(r1:r2)+one_over_r(r1:r2)
         If (pseudo_incompressible) Then
-            over_rhosq(r1:r2) = over_rhosq(r1:r2)/ ref%exp_entropy(r1:r2)
-            over_rhor(r1:r2)  = over_rhor(r1:r2) / ref%exp_entropy(r1:r2)
-            drho_term(r1:r2)  = drho_term(r1:r2) + ref%dsdr_over_cp(r1:r2)
+            over_rhor(r1:r2)  = one_over_r(r1:r2)/(ref%density(r1:r2)*ref%exp_entropy(r1:r2))
+            over_rhorsq(r1:r2)= OneOverRSquared(r1:r2)/(ref%density(r1:r2)*ref%exp_entropy(r1:r2))
+            drho_term(r1:r2)  = ref%dlnrho(r1:r2)+one_over_r(r1:r2) + ref%dsdr_over_cp(r1:r2)
+        Else
+            over_rhor(r1:r2)  = one_over_r(r1:r2)/ref%density(r1:r2)
+            over_rhorsq(r1:r2)= OneOverRSquared(r1:r2)/ref%density(r1:r2)
+            drho_term(r1:r2)  = ref%dlnrho(r1:r2)+one_over_r(r1:r2)
         Endif
 
     End Subroutine Hybrid_Init

--- a/src/Physics/Sphere_Linear_Terms.F90
+++ b/src/Physics/Sphere_Linear_Terms.F90
@@ -282,7 +282,7 @@ Contains
                   Call add_implicit_term(chipeq(i),chipvar(i), 1, amp,lp)
                 end do
 
-            Else
+            Else    ! l > 0
 
                 !==================================================
                 !                Radial Momentum Equation
@@ -291,20 +291,40 @@ Contains
 
                 ! Temperature
                 amp = -ref%Buoyancy_Coeff/H_Laplacian
+                If (pseudo_incompressible) Then
+                    amp = amp*ref%exp_entropy
+                Endif
                 Call add_implicit_term(weq, tvar, 0, amp,lp)            ! Gravity
 
                 ! Chi
                 do i = 1, n_active_scalars
                   amp = -ref%chi_buoyancy_coeff(i,:)/H_Laplacian
+                  If (pseudo_incompressible) Then
+                      amp = amp*ref%exp_entropy
+                  Endif
                   Call add_implicit_term(weq, chiavar(i), 0, amp,lp)    ! Gravity
                 end do
 
 
-                ! Pressure
+                ! Pressure Force
                 !amp = 1.0d0/(Ek*H_Laplacian)*ref%density        ! dPdr
                 amp = ref%dpdr_W_term/H_Laplacian
+                If (pseudo_incompressible) Then
+                    amp = amp*ref%exp_entropy
+                Endif
                 Call add_implicit_term(weq,pvar, 1, amp,lp)
 
+
+                ! Add the buoyancy term ignored under the LBR approximation
+                ! -(ds/dr) rho/(c_P * H_Laplacian) (P/rho)
+                ! amp = -rho/(c_P * H_Laplacian) (ds/dr)               Non-LBR Anelastic (not implemented)
+                ! amp = -exp(s/c_P) rho/(c_P * H_Laplacian) (ds/dr)    Pseudo-incompressible
+                If (pseudo_incompressible) Then
+                    amp = -ref%exp_entropy * ref%density * ref%dsdr_over_cp / H_Laplacian
+                    add_implicit_term(weq,pvar, 0, amp, lp)
+                Endif
+                
+                
                 ! W
 
                 If (inertia) Then
@@ -333,6 +353,9 @@ Contains
                 ! Pressure
                 !amp = -(1.0d0)/Ek*ref%density
                 amp = ref%pressure_dwdr_term
+                If (pseudo_incompressible) Then
+                    amp = amp*ref%exp_entropy
+                Endif
                 Call add_implicit_term(peq,pvar, 0, amp,lp)
 
                 ! W
@@ -980,6 +1003,9 @@ Contains
                 ! Else stress-free
                 r = 1
                 samp = -(2.0d0/radius(r)+ref%dlnrho(r))
+                If (pseudo_incompressible) Then
+                    samp = samp - ref%dsdr_over_cp(r)
+                Endif
                 Call Load_BC(lp,r,peq,wvar,one,2)
                 Call Load_BC(lp,r,peq,wvar,samp,1)
 
@@ -997,6 +1023,9 @@ Contains
                 !stress_free_bottom
                 r = N_R
                 samp = -(2.0d0/radius(r)+ref%dlnrho(r))
+                If (pseudo_incompressible) Then
+                    samp = samp - ref%dsdr_over_cp(r)
+                Endif
                 Call Load_BC(lp,r,peq,wvar,one,2)
                 Call Load_BC(lp,r,peq,wvar,samp,1)
                 Call Load_BC(lp,r,zeq,zvar,one,1)

--- a/src/Physics/Sphere_Linear_Terms.F90
+++ b/src/Physics/Sphere_Linear_Terms.F90
@@ -321,7 +321,7 @@ Contains
                 ! amp = -exp(s/c_P) rho/(c_P * H_Laplacian) (ds/dr)    Pseudo-incompressible
                 If (pseudo_incompressible) Then
                     amp = -ref%exp_entropy * ref%density * ref%dsdr_over_cp / H_Laplacian
-                    add_implicit_term(weq,pvar, 0, amp, lp)
+                    Call add_implicit_term(weq,pvar, 0, amp, lp)
                 Endif
                 
                 

--- a/src/Physics/Sphere_Physical_Space.F90
+++ b/src/Physics/Sphere_Physical_Space.F90
@@ -445,6 +445,14 @@ Contains
             !$OMP END PARALLEL DO
         Endif
 
+        ! Multiply by rho_*/rho = exp(s/c_P)  if pseudo-incompressible
+        If (pseudo_incompressible) Then
+            !$OMP PARALLEL DO PRIVATE(t,r,k)
+            DO_IDX
+                RHSP(IDX,wvar) = RHSP(IDX,wvar)*ref%exp_entropy(r)
+            END_DO
+            !$OMP END PARALLEL DO
+        Endif
 
 
     End Subroutine Momentum_Advection_Radial
@@ -561,8 +569,6 @@ Contains
         Endif
 
 
-
-
         ! At this point, we have [u dot grad u]_theta
         ! Multiply by radius/sintheta so that we have r[u dot grad u]_theta/sintheta (getting ready for Z and dWdr RHS building)
         !$OMP PARALLEL DO PRIVATE(t,r,k)
@@ -570,10 +576,22 @@ Contains
             RHSP(IDX,pvar) = RHSP(IDX,pvar)*radius(r)*csctheta(t)
         END_DO
         !$OMP END PARALLEL DO
+        
+                
+        ! Multiply by rho_*/rho = exp(s/c_P)  if pseudo-incompressible
+        If (pseudo_incompressible) Then
+            !$OMP PARALLEL DO PRIVATE(t,r,k)
+            DO_IDX
+                RHSP(IDX,pvar) = RHSP(IDX,pvar)*ref%exp_entropy(r)
+            END_DO
+            !$OMP END PARALLEL DO
+        Endif
 
 
 
     End Subroutine Momentum_Advection_Theta
+    
+    
     Subroutine Momentum_Advection_Phi()
         Implicit None
         Integer :: t, r, k
@@ -637,7 +655,19 @@ Contains
             RHSP(IDX,zvar) = RHSP(IDX,zvar)*radius(r)*csctheta(t)
         END_DO
         !OMP END PARALLEL DO
+        
+        ! Multiply by rho_*/rho = exp(s/c_P)  if pseudo-incompressible
+        If (pseudo_incompressible) Then
+            !$OMP PARALLEL DO PRIVATE(t,r,k)
+            DO_IDX
+                RHSP(IDX,pvar) = RHSP(IDX,pvar)*ref%exp_entropy(r)
+            END_DO
+            !$OMP END PARALLEL DO
+        Endif
+        
     End Subroutine Momentum_Advection_Phi
+    
+    
     Subroutine Phi_Derivatives()
         Implicit None
         Integer :: i


### PR DESCRIPTION
Added the capability to switch from anelastic to the pseudo-incompressible approximation.  With pseudo-incompressibility turned off, it has run the hydro anelastic benchmark on Pleiades without throwing errors, but it ran incredible slow.  Made as a draft pull to allow other developers to check the implementation.