### PR TITLE
Bug Fix:  Diagnostics and Second Radial Derivatives when Using Finite-Difference Mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixed
 
+- Fixed a bug that was causing Rayleigh to crash during output if finite-difference mode was active and second-order derivatives in radius were required for output. \[Nick Featherstone; 6-26-2024; [#566](https://github.com/geodynamics/Rayleigh/pull/566) \]
+
 - Rayleigh no longer attempts to update the record count and close a diagnostics file (e.g., G_Avgs) that failed to open correctly.  \[Nick Featherstone; 6-18-2024; [#510](https://github.com/geodynamics/Rayleigh/pull/510) , [#523](https://github.com/geodynamics/Rayleigh/pull/523)  \]
 
 - Fixed a bug that was causing documentation build to become progressively slower for subsequent builds due to recursive inclusion of the doc\build directory  \[Philipp Edelmann; 6-17-2024; [#527](https://github.com/geodynamics/Rayleigh/pull/527)\]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,8 +38,6 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixed
 
-- Fixed a bug that was causing Rayleigh to crash during output if finite-difference mode was active and second-order derivatives in radius were required for output. \[Nick Featherstone; 6-26-2024; [#566](https://github.com/geodynamics/Rayleigh/pull/566) \]
-
 - Rayleigh no longer attempts to update the record count and close a diagnostics file (e.g., G_Avgs) that failed to open correctly.  \[Nick Featherstone; 6-18-2024; [#510](https://github.com/geodynamics/Rayleigh/pull/510) , [#523](https://github.com/geodynamics/Rayleigh/pull/523)  \]
 
 - Fixed a bug that was causing documentation build to become progressively slower for subsequent builds due to recursive inclusion of the doc\build directory  \[Philipp Edelmann; 6-17-2024; [#527](https://github.com/geodynamics/Rayleigh/pull/527)\]
@@ -51,6 +49,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - The standard c++ libraries are no longer linked when compiling Rayleigh; \[Brandon Lazard; 6-19-2024; [#532](https://github.com/geodynamics/Rayleigh/pull/532)\]
 
 - Running the configure command now requires the correct combination of library locations to be specified; \[Brandon Lazard; 6-21-2024] [#535](https://github.com/geodynamics/Rayleigh/pull/535) 
+
+- Fixed a bug that was causing Rayleigh to crash during output if finite-difference mode was active and second-order derivatives in radius were required for output. \[Nick Featherstone; 6-26-2024; [#566](https://github.com/geodynamics/Rayleigh/pull/566) \]
 
 
 ## [1.2.0] - 5-29-2024

--- a/src/Makefile.fdeps
+++ b/src/Makefile.fdeps
@@ -25,7 +25,7 @@ Diagnostics_Mean_Correction.o : Diagnostics_Mean_Correction.F90 indices.F Diagno
 Diagnostics_Miscellaneous.o : Diagnostics_Miscellaneous.F90 indices.F Diagnostics_Base.o 
 Diagnostics_Poynting_Flux.o : Diagnostics_Poynting_Flux.F90 indices.F Diagnostics_Base.o 
 Diagnostics_Scalars.o : Diagnostics_Scalars.F90 indices.F Controls.o Diagnostics_Base.o 
-Diagnostics_Second_Derivatives.o : Diagnostics_Second_Derivatives.F90 indices.F Spectral_Derivatives.o Structures.o Diagnostics_Base.o 
+Diagnostics_Second_Derivatives.o : Diagnostics_Second_Derivatives.F90 indices.F Finite_Difference.o Spectral_Derivatives.o Structures.o Diagnostics_Base.o 
 Diagnostics_Thermal_Energies.o : Diagnostics_Thermal_Energies.F90 indices.F Diagnostics_ADotGradB.o Diagnostics_Base.o 
 Diagnostics_Thermal_Equation.o : Diagnostics_Thermal_Equation.F90 indices.F Diagnostics_ADotGradB.o Diagnostics_Base.o 
 Diagnostics_Thermodynamic_Gradients.o : Diagnostics_Thermodynamic_Gradients.F90 indices.F Diagnostics_Base.o 


### PR DESCRIPTION
This fixes a bug related to finite-difference mode.  When diagnostic output quantities are requested that require a second radial derivative, that derivative is calculated at output time.  The subroutine that handles the derivative calculations at output time was lacking any logic that would call the appropriate finite-difference derivative routine.  Instead, a Chebyshev derivative routine was called, which caused a crash because the Chebyshev grid object had not been initialized.  This PR fixes this bug by adding appropriate finite-difference logic to Diagnostics_Second_Derivatives.F90.