### PR TITLE
Checkpointing interval can now be specified in minutes.

### DIFF
--- a/doc/source/Namelist_Definitions/temporal_controls_namelist.txt
+++ b/doc/source/Namelist_Definitions/temporal_controls_namelist.txt
@@ -12,6 +12,8 @@
   Number of iterations between successive checkpoint outputs.  Default value is -1 (no checkpointing).
 **check_frequency**
   (deprecated) Same as checkpoint_interval.
+**checkpoint_minutes**
+  Time in minutes between successive numbered checkpoints.  If this variable is set to a positive value (default is -1), the value of checkpoint_interval will be ignored.
 **quicksave_interval**
   Number of iterations between successive quicksave outputs.  Default value is -1 (no quicksaves).
 **num_quicksaves**

--- a/doc/source/User_Guide/run_rayleigh.rst
+++ b/doc/source/User_Guide/run_rayleigh.rst
@@ -152,7 +152,7 @@ points for a given run. These files begin with an 8-digit prefix
 indicating the time step at which the checkpoint was created.
 
 The frequency with which standard checkpoints are generated can be
-controlled by modifying the **checkpoint_interval`` variable in the
+controlled by modifying the **checkpoint_interval** variable in the
 ``temporal_controls_namelist``. For example, if you want to generate a
 checkpoint once every 50,000 time steps, you would modify your
 ``main_input`` file to read:
@@ -165,6 +165,17 @@ checkpoint once every 50,000 time steps, you would modify your
 
 The default value of checkpoint_interval is 1,000,000, which is
 typically much larger than what you will use in practice.
+
+Alternatively, you can specify the interval in minutes between which successive checkpoints are written.
+To do so, set the ``checkpoint_minutes`` variable:
+
+::
+
+   &temporal_controls_namelist
+    checkpoint_minutes= 30.0d0  ! Save a checkpoint once every half hour.
+   /
+
+If the ``checkpoint_minutes`` variable is set to a positive value in main_input, any value set for ``checkpoint_interval`` will be ignored.
 
 Restarting from a checkpoint is accomplished by first assigning a value
 of -1 to the variables ``init_type`` and/or ``magnetic_init_type`` in
@@ -260,6 +271,15 @@ will overwrite the existing quicksave_01 files*. At time step 40,000,
 the quicksave_02 files will be overwritten, and so forth. Because the
 ``num_quicksaves`` was set to 2, filenames with prefix quicksave_03 will
 never be generated.
+
+As with numbered checkpoints, the number of minutes between successive quicksaves
+can be specified as an alternative to quicksave_interval.  To do so, set the ``quicksave_minutes`` variable:
+
+::
+
+   &temporal_controls_namelist
+    quicksave_minutes= 15.0d0  ! Create a quicksave once every 15 minutes.
+   /
 
 Note that checkpoints beginning with an 8-digit prefix (e.g., 00035000)
 are still written to disk regularly and are not affected by the

--- a/src/Physics/Controls.F90
+++ b/src/Physics/Controls.F90
@@ -108,6 +108,7 @@ Module Controls
     Integer :: quicksave_interval =  -1        ! Number of iterations between quicksave dumps
     Integer :: num_quicksaves = 3              ! Number of quick-save checkpoints to write before rolling back to #1
     Real*8  :: quicksave_minutes = -1.0d0      ! Time in minutes between quick saves (overrides quicksave interval)
+    Real*8  :: checkpoint_minutes = -1.0d0     ! Time in minutes between checkpoints (overrides quicksave interval)
 
     Real*8  :: cflmax = 0.6d0, cflmin = 0.4d0  ! Limits for the cfl condition
     Real*8  :: max_time_step = 1.0d0           ! Maximum timestep to take, whatever CFL says (should always specify this in main_input file)
@@ -118,7 +119,7 @@ Module Controls
                 & cflmax, cflmin, max_time_step, diagnostic_reboot_interval, min_time_step, &
                 & num_quicksaves, quicksave_interval, checkpoint_interval, quicksave_minutes, &
                 & max_time_minutes, save_last_timestep, new_iteration, save_on_sigterm, &
-                & max_simulated_time
+                & max_simulated_time, checkpoint_minutes
 
 
 


### PR DESCRIPTION
This PR adds the checkpoint_minutes variable to the temporal_controls namelist.  Similarly to the quicksave_minutes variable, this can be used as an alternative to specifying the number of timesteps between adjacent checkpoints.

I've also updated the documentation to reflect this change.

I'm tagging @jorafb on this as a potential reviewer.
