### PR TITLE
Consistency Check for Indexed Outputs (e.g., Shell_Slices, Meridional_Slices)

### DIFF
--- a/src/IO/Spherical_IO.F90
+++ b/src/IO/Spherical_IO.F90
@@ -1721,7 +1721,7 @@ Contains
                 jmin =  indices_inout(i)+1
                 
                 ! Only expand the subrange if the values of jmin and jmax
-                ! are consistent.
+                ! are consistent and if they fall within the grid bounds.
                 If ((jmin .ge. 1) .and. (jmax .ge. jmin)) Then
                     Do j = jmin,jmax
                         If (j .le. indmax) Then

--- a/src/IO/Spherical_IO.F90
+++ b/src/IO/Spherical_IO.F90
@@ -1695,8 +1695,8 @@ Contains
     Subroutine Parse_Inds(indices_inout, indmax, indcount)
         IMPLICIT NONE
         INTEGER, INTENT(InOut) :: indices_inout(:)
+        INTEGER, INTENT(In)    :: indmax
         INTEGER, INTENT(InOut), Optional :: indcount
-        INTEGER, INTENT(In) :: indmax
         INTEGER, ALLOCATABLE :: indices_out(:)
         INTEGER :: i, j,ind,ni, jmin, jmax
         !Converts index lists of the form [1,-4] to [1,2,3,4].
@@ -1808,13 +1808,7 @@ Contains
         ngrid = size(coord_grid)
         Call Parse_Inds(indices,ngrid)
 
-        
-        ! Remove any indices whose values are outside of the grid bounds.
-
-        !Call Enforce_Bounds(indices,ngrid)
     END SUBROUTINE Interpret_Indices
-
-
 
 
 End Module Spherical_IO

--- a/src/IO/Spherical_IO.F90
+++ b/src/IO/Spherical_IO.F90
@@ -1692,29 +1692,45 @@ Contains
 
     END SUBROUTINE nrm_to_index
 
-    Subroutine Parse_Inds(indices_inout, indcount)
+    Subroutine Parse_Inds(indices_inout, indmax, indcount)
         IMPLICIT NONE
         INTEGER, INTENT(InOut) :: indices_inout(:)
         INTEGER, INTENT(InOut), Optional :: indcount
+        INTEGER, INTENT(In) :: indmax
         INTEGER, ALLOCATABLE :: indices_out(:)
         INTEGER :: i, j,ind,ni, jmin, jmax
-        !Converts index lists of the form [1,-4] to [1,2,3,4]
+        !Converts index lists of the form [1,-4] to [1,2,3,4].
+        !Also ensures that only values within the grid bounds are retained.
         i = 1
         ind = 1
         ni = size(indices_inout)
         ALLOCATE(indices_out(1:ni))
         indices_out(:) = -1
-        DO WHILE( (indices_inout(i) .gt. -1) .and. (i .le. ni))
-            indices_out(ind) = indices_inout(i)
-            ind = ind+1
+        
+
+        Do While (i .lt. ni)
+            j = indices_inout(i)
+            if ((j .ge. 1) .and. (j .le. indmax)) Then
+                indices_out(ind) = j
+                ind = ind+1
+            Endif
+
             IF ( indices_inout(i+1) .lt. -1) THEN
                 ! User has specified a sub-range in this coordinate
                 jmax = -indices_inout(i+1) 
                 jmin =  indices_inout(i)+1
-                Do j = jmin,jmax
-                    indices_out(ind) = j
-                    ind = ind+1
-                ENDDO
+                
+                ! Only expand the subrange if the values of jmin and jmax
+                ! are consistent.
+                If ((jmin .ge. 1) .and. (jmax .ge. jmin)) Then
+                    Do j = jmin,jmax
+                        If (j .le. indmax) Then
+                            indices_out(ind) = j
+                            ind = ind+1
+                        Endif
+                    ENDDO
+                Endif
+
                 i = i + 1  ! We increment an extra time here to skip the next negative number
             ENDIF
             i = i + 1
@@ -1726,7 +1742,7 @@ Contains
 
     SUBROUTINE PROCESS_COORDINATES()
         IMPLICIT NONE
-        INTEGER :: i
+        INTEGER :: i,lmax,ngrid
         Real*8, Allocatable :: tmp_theta(:), tmp_phi(:)
         ALLOCATE(tmp_theta(1:ntheta), tmp_phi(1:nphi))
 
@@ -1756,7 +1772,9 @@ Contains
         DeALLOCATE(tmp_theta,tmp_phi)
         
         ! Parse the SPH_MODE_ELL list:
-        Call Parse_inds(sph_mode_ell, SPH_MODE_Nell)
+        lmax = maxval(pfi%inds_3s)
+        ngrid = lmax+1
+        Call Parse_inds(sph_mode_ell,ngrid, SPH_MODE_Nell)
         If (SPH_Mode_nell .gt. 0) Then
             Do i =1, sph_mode_nell
                 sph_mode_nmode = sph_mode_nmode+(sph_mode_ell(i)+1)
@@ -1771,6 +1789,7 @@ Contains
         REAL*8, INTENT(InOut) :: coord_grid(:), indices_nrm(:)
         LOGICAL, INTENT(In), Optional :: revg
         LOGICAL :: reverse_grid 
+        Integer :: ngrid
         IF (present(revg)) THEN
             IF (revg) reverse_grid = .true.
         ELSE
@@ -1786,7 +1805,16 @@ Contains
 
         ! Next, interpret any range shorthand used.
         ! e.g., convert [1,-4,8] to [1,2,3,4,8]
-        Call Parse_Inds(indices)
+        ngrid = size(coord_grid)
+        Call Parse_Inds(indices,ngrid)
+
+        
+        ! Remove any indices whose values are outside of the grid bounds.
+
+        !Call Enforce_Bounds(indices,ngrid)
     END SUBROUTINE Interpret_Indices
+
+
+
 
 End Module Spherical_IO


### PR DESCRIPTION
This PR implements some consistency/sanity checks when Rayleigh interprets the values of variables such as shellslice_levels, meridional_indices etc.  Previously, Rayleigh would accept values that fell outside of the grid bounds, which could lead to crashes.  With this addition, indicial values that fall outside of the grid bounds are filtered out.   If unallowed values are specified for the normalized indices (e.g., shell_slice_levels_nrm), those should also be filtered out by these modifications to the code logic.

This addresses the cause of the 2nd crash reported in issue #570. 