### PR TITLE
Removal of Write(6,*)

### DIFF
--- a/src/Diagnostics/Diagnostics_Base.F90
+++ b/src/Diagnostics/Diagnostics_Base.F90
@@ -146,13 +146,6 @@ Module Diagnostics_Base
     Integer :: lforce_r, lforcepp_r, lforcemm_r
 Contains
 
-    Subroutine Generate_Diagnostic_Labels()
-        ! Define labels for our quantity codes
-        Write(6,*)'A line of code.'
-        !Call Load_Label(v_r,'V_r')
-        !Call Load_Label(v_theta,'V_theta')
-        !Call Load_Label(v_phi, 'V_phi')
-    End Subroutine Generate_Diagnostic_Labels
 
     Subroutine Initialize_Diagnostics_Buffer()
         Logical :: dbtrans, dbconfig

--- a/src/Diagnostics/Diagnostics_Custom.F90
+++ b/src/Diagnostics/Diagnostics_Custom.F90
@@ -210,7 +210,6 @@ Contains
         !END_DO
 
         If (compute_quantity(ell0_vr)) Then
-            Write(6,*)'Ell0_vr', ell0_vr
             DO_PSI
                 qty(PSI) = ell0_values(r,vr)
             END_DO
@@ -218,7 +217,6 @@ Contains
         Endif
 
         If (compute_quantity(ell0_tvar)) Then
-            Write(6,*)'Ell0 tvar', ell0_tvar
             DO_PSI
                 qty(PSI) = ell0_values(r,tvar)
             END_DO
@@ -226,7 +224,6 @@ Contains
         Endif
 
         If (compute_quantity(ell0_dpdr)) Then
-            Write(6,*)'Ell0 tvar', ell0_dpdr
             DO_PSI
                 qty(PSI) = ell0_values(r,dpdr)
             END_DO

--- a/src/Diagnostics/Diagnostics_Interface.F90
+++ b/src/Diagnostics/Diagnostics_Interface.F90
@@ -376,7 +376,6 @@ Contains
             Endif
         Else
             If (MOD(iteration,diagnostic_reboot_interval) .eq. 0) Then
-                if (my_rank .eq. 0) WRITE(6,*)'REBOOTING DIAGNOSTICS!'
                 ! Find the name of the current reboot file.
                 ndigits = count_digits(reboot_count)
                 Write(ndigstr,'(i1.1)') ndigits

--- a/src/Diagnostics/Diagnostics_Mean_Correction.F90
+++ b/src/Diagnostics/Diagnostics_Mean_Correction.F90
@@ -437,7 +437,6 @@ Contains
         !//////////////////////////////////////////////////////
         ! Perform the averaging
         if (compute_mean_correct) then
-            !Write(6,*)'Allocated: ', allocated(mean_3dbuffer), allocated(mean_ell0buffer)
 
             Call ComputeEll0(mean_3dbuffer,mean_ell0buffer)
         endif

--- a/src/Diagnostics/Diagnostics_Miscellaneous.F90
+++ b/src/Diagnostics/Diagnostics_Miscellaneous.F90
@@ -40,7 +40,6 @@ Contains
                 qty(PSI) = sin(k*2.0d0*mypi/n_phi) &
                     & *(sintheta(t)**2)*radius(r)
             END_DO
-            Write(6,*)'Diagnostic1!', my_rank
             Call Add_Quantity(qty)
         Endif
 

--- a/src/Diagnostics/Diagnostics_Second_Derivatives.F90
+++ b/src/Diagnostics/Diagnostics_Second_Derivatives.F90
@@ -309,7 +309,7 @@ Contains
         Call d2buffer%init(field_count = ddfcount, config = 'p3b')
 
         Call d2buffer%construct('p3a')
-        !WRITE(6,*)'BCHECK: ', shape(d2buffer%p3a)
+
         Call d2buffer%deconstruct('p3a')
     End Subroutine Initialize_Second_Derivatives
 
@@ -350,12 +350,10 @@ Contains
 
         !///////////////////////////////////////////////////////////
         ! Step 1: Initialize p3b portion of d2buffer
-        !Write(6,*)'Constructing the buffer...', d2buffer%nf3b
 
         Call d2buffer%construct('p3b')
         d2buffer%config = 'p3b'
 
-        !Write(6,*)'Complete...'
 
         !///////////////////////////////////////////////////////////
         ! Steps 2-3:  Load radial and theta derivatives
@@ -363,7 +361,6 @@ Contains
             d2buffer%p3b(:,:,:,ddindmap(1,i)) = inbuffer(:,:,:,ddindmap(2,i))
         Enddo
 
-        !Write(6,*)'Steps 1-3 complete.'
 
         !////////////////////////////////////////////////////////////////
         ! Step 4:  Move to p1b/p1a configuration
@@ -388,7 +385,6 @@ Contains
         d2buffer%p1b = 0.0
         d2buffer%config='p1a'
 
-        !Write(6,*)'Steps 4 complete.'
 
         !////////////////////////////////////////////////////////////
         ! Steps 5-6:  Load d2_by_dr2 and d2_by_drdt into the buffer
@@ -408,17 +404,14 @@ Contains
         Call d2buffer%deconstruct('p1b')
 
         ! Ordering of fields in buffer is now dxdr, dxdt, dxdrdr, dxdrdt
-        !Write(6,*)'Steps 5-6 complete.'
 
         !///////////////////////////////////////////////////////////////
         ! Step 7:  Move to s2a & overwrite dxdt with sintheta*{dxdtdt}
         Call d2buffer%reform()
 
-        !Write(6,*)'Step 7 reformation complete'
 
         Call Allocate_rlm_Field(ddtemp)
 
-        !Write(6,*)'Step 7 allocation complete', nddfields
 
         Do i = nddfields+1,nddfields*2
             ! We overwrite dxdt with sintheta* {dxdtdt}
@@ -428,18 +421,15 @@ Contains
             END_DO
         Enddo
 
-        !Write(6,*)'Step 7 derivatves complete'
 
         Call DeAllocate_rlm_Field(ddtemp)
 
-        !Write(6,*)'Step 7 deallocation complete'
 
         Call d2buffer%construct('p2a')
         Call Legendre_Transform(d2buffer%s2a,d2buffer%p2a)
         Call d2buffer%deconstruct('s2a')
         d2buffer%config = 'p2a'
 
-        !Write(6,*)'Step 7 complete.'
 
         !/////////////////////////////////////////////////////////////////////
         !  Steps 8-10 : phi derivatives
@@ -478,7 +468,6 @@ Contains
         Enddo
 
         Call d2buffer%deconstruct('p3b')
-       ! Write(6,*)'Steps 8-10 complete.'
 
         !//////////////////////////////////////////
         ! Step 11:   Finalize
@@ -510,7 +499,6 @@ Contains
             END_DO
         ENDDO
 
-        !Write(6,*)'Step 11 complete.'
     End Subroutine Compute_Second_Derivatives
 
     Subroutine Allocate_rlm_Field(arr)

--- a/src/Diagnostics/Diagnostics_TurbKE_Budget.F90
+++ b/src/Diagnostics/Diagnostics_TurbKE_Budget.F90
@@ -199,7 +199,6 @@ Contains
         ! Viscous Transport of turbulent kinetic energy.
         !    -div.F_TV = div.(sigma'.u') = (div.sigma').u' + Phi_T
         If (compute_quantity(transport_viscous_pKE)) Then
-            !Write(6,*)dvrdrdr, shape(d2_fbuffer)
             DO_PSI2
                 one_over_rsin = one_over_r(r) * csctheta(t)
                 ctn_over_r = one_over_r(r) * cottheta(t)

--- a/src/Makefile.fdeps
+++ b/src/Makefile.fdeps
@@ -68,7 +68,7 @@ Sphere_Hybrid_Space.o : Sphere_Hybrid_Space.F90 indices.F PDE_Coefficients.o Clo
 Sphere_Linear_Terms.o : Sphere_Linear_Terms.F90 Math_Constants.o PDE_Coefficients.o ClockInfo.o Timers.o BoundaryConditions.o Fields.o Linear_Solve.o ProblemSize.o Controls.o Load_Balance.o 
 Sphere_Physical_Space.o : Sphere_Physical_Space.F90 indices.F Benchmarking.o Math_Constants.o PDE_Coefficients.o ClockInfo.o Timers.o General_MPI.o Diagnostics_Interface.o Fields.o Spectral_Derivatives.o Fourier_Transform.o ProblemSize.o Controls.o Parallel_Framework.o 
 Sphere_Spectral_Space.o : Sphere_Spectral_Space.F90 Sphere_Linear_Terms.o Timers.o ClockInfo.o BoundaryConditions.o Fields.o Linear_Solve.o Finite_Difference.o ProblemSize.o Controls.o Parallel_Framework.o Load_Balance.o 
-Spherical_Buffer.o : Spherical_Buffer.F90 Timers.o General_MPI.o Load_Balance.o Structures.o Parallel_Framework.o MPI_LAYER.o 
+Spherical_Buffer.o : Spherical_Buffer.F90 BufferedOutput.o Timers.o General_MPI.o Load_Balance.o Structures.o Parallel_Framework.o MPI_LAYER.o 
 Spherical_IO.o : Spherical_IO.F90 Ra_MPI_Base.o Parallel_IO.o MakeDir.o Math_Constants.o BufferedOutput.o Legendre_Transforms.o Fourier_Transform.o General_MPI.o ISendReceive.o SendReceive.o Parallel_Framework.o Spherical_Buffer.o 
 Structures.o : Structures.F90 
 TestSuite.o : TestSuite.F90 ProblemSize.o Test_Cheby.o Test_SHT.o 

--- a/src/Makefile.fdeps
+++ b/src/Makefile.fdeps
@@ -1,5 +1,5 @@
 All_to_All.o : All_to_All.F90 Ra_MPI_Base.o 
-Benchmarking.o : Benchmarking.F90 Initial_Conditions.o BoundaryConditions.o Math_Constants.o PDE_Coefficients.o Legendre_Polynomials.o Fields.o Spherical_IO.o Controls.o ProblemSize.o 
+Benchmarking.o : Benchmarking.F90 BufferedOutput.o Initial_Conditions.o BoundaryConditions.o Math_Constants.o PDE_Coefficients.o Legendre_Polynomials.o Fields.o Spherical_IO.o Controls.o ProblemSize.o 
 BoundaryConditions.o : BoundaryConditions.F90 Controls.o Checkpointing.o PDE_Coefficients.o Generic_Input.o Load_Balance.o Fields.o ProblemSize.o Math_Constants.o 
 BufferedOutput.o : BufferedOutput.F90 
 Chebyshev_Polynomials.o : Chebyshev_Polynomials.F90 Structures.o 
@@ -39,7 +39,7 @@ Fourier_Derivatives.o : Fourier_Derivatives.F90
 Fourier_Transform.o : Fourier_Transform.F90 Parallel_Framework.o 
 General_IO.o : General_IO.F90 General_MPI.o Parallel_Framework.o 
 General_MPI.o : General_MPI.F90 Ra_MPI_Base.o 
-Generic_Input.o : Generic_Input.F90 ProblemSize.o SendReceive.o Load_Balance.o Spherical_Buffer.o Parallel_Framework.o Ra_MPI_Base.o 
+Generic_Input.o : Generic_Input.F90 BufferedOutput.o ProblemSize.o SendReceive.o Load_Balance.o Spherical_Buffer.o Parallel_Framework.o Ra_MPI_Base.o 
 ISendReceive.o : ISendReceive.F90 Ra_MPI_Base.o 
 Initial_Conditions.o : Initial_Conditions.F90 Load_Balance.o BufferedOutput.o Math_Utility.o Linear_Solve.o ClockInfo.o BoundaryConditions.o PDE_Coefficients.o General_MPI.o Timers.o Controls.o Generic_Input.o Checkpointing.o Math_Constants.o SendReceive.o Legendre_Transforms.o Fourier_Transform.o Parallel_Framework.o Fields.o ProblemSize.o 
 Input.o : Input.F90 MPI_LAYER.o Ra_MPI_Base.o Checkpointing.o Parallel_Framework.o PDE_Coefficients.o TestSuite.o Initial_Conditions.o BoundaryConditions.o Spherical_IO.o Controls.o ProblemSize.o 

--- a/src/Math_Layer/Chebyshev_Polynomials.F90
+++ b/src/Math_Layer/Chebyshev_Polynomials.F90
@@ -357,9 +357,7 @@ Contains
         Integer :: bsize(4), i,j,k,n,offset, ind1,ind2
 
         bsize = shape(buffer)
-        !do n = 1, self%domain_count
-        !    WRite(6,*)'da check: ', self%rda(n), self%npoly(n)
-        !Enddo
+
         Do k = 1, bsize(4)
         Do j = 1, bsize(3)
         Do i = 1, bsize(2)

--- a/src/Math_Layer/Finite_Difference.F90
+++ b/src/Math_Layer/Finite_Difference.F90
@@ -233,7 +233,7 @@ Contains
             stencil_radius = stencil_size/2
             stencil_center = stencil_radius+1
             offset = (N_S-stencil_size)/2
-            Write(6,*)'I am in and dorder is : ', d
+
             Do jj = jjmin, jjmax
                 Do ii = iimin, iimax
 
@@ -543,7 +543,7 @@ Contains
         !
         !    Currently only type 1 is supported by the derivative routines and Implicit.F
         !*****************************************************************************************************
-        !Write(6,*)deriv_order
+
          ngrid = Size(grid)
         stencil_radius = n_stencil/2
         stencil_center = stencil_radius+1
@@ -594,7 +594,6 @@ Contains
             dsum = zero
 
             Do j = jstart, jend
-                !Write(6,*)i,jstart,jend,stencil_center
                 dees(j) = grid(i+j-stencil_center)-grid(i)
                 dsum = dsum+ABS(dees(j))
             Enddo

--- a/src/Math_Layer/Fourier_Transform.F90
+++ b/src/Math_Layer/Fourier_Transform.F90
@@ -47,9 +47,7 @@ Contains
                 !Note that when using MKL, iret will be 0 always.
                 !iret = 0 means an error when using normal FFTW, but for MKL
                 ! This routine is a wrapper that does nothing.
-            !write(6,*)"iret is: ", iret
-            ! comment
-            !write(6,*)"FFTW planning with nthreads: ", nthread
+
             call dfftw_plan_with_nthreads(nthread)
         Endif
 #endif

--- a/src/Math_Layer/Legendre_Polynomials.F90
+++ b/src/Math_Layer/Legendre_Polynomials.F90
@@ -77,7 +77,6 @@ Subroutine DeAllocate_Plms(depar)
     Endif
     If (present(depar)) Then
         If (depar .and. parity) Then
-            Write(6,*)'DeAllocating Parity Arrays'
             Call DeAllocate_Parity_Plms()
         Endif
     Endif

--- a/src/Math_Layer/Legendre_Transforms.F90
+++ b/src/Math_Layer/Legendre_Transforms.F90
@@ -1011,7 +1011,7 @@ Subroutine StP_4d_dgp2(data_in, data_out)
         If (n_l_even(m) .gt. 0) then
 
             jend = n_l_even(m)
-            !write(6,*)jend,rmn,rmx,nfield
+
             Allocate(temp3(1:jend,rmn:rmx,1:2,1:nfield))
             Do f = 1, nfield
             Do imi = 1, 2

--- a/src/Math_Layer/Linear_Solve.F90
+++ b/src/Math_Layer/Linear_Solve.F90
@@ -1032,7 +1032,7 @@ Module Linear_Solve
 
         n = Size(mat,1)
         Call Dgetrf(n, n, mat, n, pvt, info)
-    !  Write(6,*)'info : ',info,n
+
     End Subroutine LU_Decompose_full
 
 
@@ -1093,7 +1093,6 @@ Module Linear_Solve
         Integer :: ma, mb, info
 
         If (Present(na)) Then
-            Write(6,*)'na specified: ', na, Size(rhs,1)
             ma = na
         Else
             ma = Size(mat,1)
@@ -1101,18 +1100,12 @@ Module Linear_Solve
 
         If (Present(nb)) Then
             mb = nb
-            Write(6,*)'mb specified: ', mb, Size(rhs)/Size(rhs,1)
         Else
             mb = Size(rhs)/Size(rhs,1)
         End If
 
         Call dgetrs('N', ma, mb, mat, Size(mat,1), pvt, rhs, Size(rhs,1), info)
 
-
-        !If(Present(nb)) Then
-        If (info .ne. 0) Then
-            Write(6,*)'Problem is solve!  info is ', info
-        Endif
 
     End Subroutine LU_Solve_full
 
@@ -1207,8 +1200,6 @@ Module Linear_Solve
 
         If (equation_set(mind,eind)%solvefor) Then
 
-        !Write(6,*)'Loading sparse matrix'
-
         nlinks = equation_set(mind,eind)%nlinks
         nsub = cpgrid%domain_count
         N_rows = ndim1*nlinks
@@ -1243,7 +1234,7 @@ Module Linear_Solve
 
         rindex = 1
         s_offset = 0
-        !Write(6,*)'INSIDE: ', eind, mind, nlinks
+
         Do n = 1, nlinks
             c_offset = 0
             Do i = 1, nsub
@@ -1434,9 +1425,9 @@ Module Linear_Solve
 
         offleft = 0                 !Column offset for left-side domain
         offright = cpgrid%npoly(1)  !Column offset for right-side domain
-        !write(6,*)'rind check: ', rind, r
+
         Do hh = 1, nsub -1
-            !write(6,*)'rcheck 2: ', r
+
             ! Clear this row completely
             mpointer(r+row,:) = 0.0d0
 
@@ -1486,7 +1477,6 @@ Module Linear_Solve
             Enddo
             off1 = off1+npoly
         Enddo
-        !write(6,*)'Rout: ', r-1
 
     End Subroutine Load_Interior_Rows_Cheby
 
@@ -1514,7 +1504,7 @@ Module Linear_Solve
         off1 = 0                    ! column offset associated with that domain
         rupper = cpgrid%npoly(1)    ! uppermost radial index that belongs to domain being considered
         local_index = r             ! local index within r's domain
-        !Write(6,*)'rcheck : ', local_index
+
         Do hh = 1, nsub-1
             If (local_index .gt. rupper) Then
                 off1 = off1+cpgrid%npoly(hh)
@@ -1523,7 +1513,7 @@ Module Linear_Solve
             Endif
             rupper = cpgrid%npoly(hh+1)
         Enddo
-        !Write(6,*)'local_index, r, domain : ', local_index, r, domain
+
         Do n = 1, cpgrid%rda(domain)-1     ! De-Alias at boundaries (single rows are really just for boundaries)
             mpointer(row+r,col+n+off1) = mpointer(row+r,col+n+off1) &
                 & + amp*cpgrid%dcheby(domain)%data(local_index,n,dorder)

--- a/src/Parallel_Framework/MPI_LAYER.F90
+++ b/src/Parallel_Framework/MPI_LAYER.F90
@@ -95,8 +95,6 @@ Contains
         Call mpi_comm_size(cgrp%comm, cgrp%np, err)
         Call mpi_comm_rank(cgrp%comm, cgrp%rank, err)
 
-        If (cgrp%rank .ne. col_rank) Write(6,*)'Error - ', cgrp%rank, col_rank
-        If (rgrp%rank .ne. row_rank) Write(6,*)'Error - ', rgrp%rank, row_rank
     End Subroutine RowColSplit
 
     Subroutine Exit_Comm_Lib(err)

--- a/src/Parallel_Framework/Parallel_Framework.F90
+++ b/src/Parallel_Framework/Parallel_Framework.F90
@@ -266,12 +266,11 @@ Contains
         self%nthreads = omp_get_max_threads()
         !$OMP PARALLEL PRIVATE(my_thread)
         my_thread = omp_get_thread_num()
-        write(6,*)'rank: ', my_mpi_Rank, 'thread: ', my_thread, 'nthread: ', omp_get_num_threads()
+
         !$OMP END PARALLEL
 #endif
 #ifdef usemkl
             my_thread = mkl_get_max_threads()
-            write(6,*)"MKL MAX: ", my_thread
 #endif
     End Subroutine OpenMp_Init
 

--- a/src/Parallel_Framework/Parallel_Framework.F90
+++ b/src/Parallel_Framework/Parallel_Framework.F90
@@ -301,7 +301,7 @@ Contains
         Allocate(self%all_3s(0:self%nprow-1))
         Call Standard_Balance(self%all_3s,self%n3s,self%rcomm)
         self%my_3s = self%all_3s(self%rcomm%rank)
-        !Write(6,*), self%my_3s%min, self%my_3s%max,self%rcomm%rank, self%my_3s%delta
+
         ! We assume a high-low pairing of m-values.
         ! This means that we need to set up an index array
         ! for the m-values that tells how many each processor has.

--- a/src/Parallel_Framework/SendReceive.F90
+++ b/src/Parallel_Framework/SendReceive.F90
@@ -89,7 +89,6 @@ Contains
         mstart = 1
     Endif
     Call mpi_send(x(istart,jstart,kstart,lstart,mstart), n, MPI_REAL8, p, tag2, comm2,  mpi_err)
-    !write(6,*)'zs ', p
     End Subroutine D_Send_5D
 
 
@@ -144,7 +143,7 @@ Contains
         lstart = 1
     Endif
     Call mpi_send(x(istart,jstart,kstart,lstart), n, MPI_REAL8, p, tag2, comm2,  mpi_err)
-    !write(6,*)'zs ', p
+
     End Subroutine D_Send_4D
 
     Subroutine D_Send_3D(x, n_elements, dest, tag, grp, indstart)
@@ -195,7 +194,6 @@ Contains
         kstart = 1
     Endif
     Call mpi_send(x(istart,jstart,kstart), n, MPI_REAL8, p, tag2, comm2,  mpi_err)
-    !write(6,*)'zs ', p
     End Subroutine D_Send_3D
 
     Subroutine D_Send_2D(x, n_elements, dest, tag, grp, indstart)

--- a/src/Parallel_Framework/Spherical_Buffer.F90
+++ b/src/Parallel_Framework/Spherical_Buffer.F90
@@ -25,6 +25,7 @@ Module Spherical_Buffer
     Use Load_Balance
     Use General_MPI
     Use Timers
+    Use BufferedOutput
     Implicit None
     Private
 
@@ -471,7 +472,7 @@ Contains
         If (self%dynamic_transpose_buffers) Then
             Allocate(self%send_buff(1:self%send_size32))
         Endif
-        !write(6,*)'executing new transpose'
+
         !--- Not sure if this is good or bad, but copy out the bounds of the loop for now
         nf = self%nf3b
 
@@ -593,7 +594,7 @@ Contains
         If (self%dynamic_transpose_buffers) Then
             Allocate(self%send_buff(1:self%send_size32))
         Endif
-        !write(6,*)'executing new transpose'
+
         !--- Not sure if this is good or bad, but copy out the bounds of the loop for now
         nf = self%nf3b
 
@@ -1279,38 +1280,38 @@ Contains
                 If (allocated(self%p1a)) Then
                     DeAllocate(self%p1a)
                 Else
-                    Write(6,*)'p1a does not appear to be allocated'
+                    Call stdout%print('p1a does not appear to be allocated')
                 Endif
             Case('p1b')
                 If (allocated(self%p1b)) Then
                     DeAllocate(self%p1b)
                 Else
-                    Write(6,*)'p1b does not appear to be allocated'
+                    Call stdout%print('p1b does not appear to be allocated')
                 Endif
             Case('p2a')
                 If (allocated(self%p2a)) Then
                     DeAllocate(self%p2a)
                 Else
-                    Write(6,*)'p2a does not appear to be allocated'
+                    Call stdout%print('p2a does not appear to be allocated')
                 Endif
             Case('p2b')
                 If (allocated(self%p2b)) Then
                     DeAllocate(self%p2b)
                 Else
-                    Write(6,*)'p2b does not appear to be allocated'
+                    Call stdout%print('p2b does not appear to be allocated')
                 Endif
 
             Case('p3a')
                 If (allocated(self%p3a)) Then
                     DeAllocate(self%p3a)
                 Else
-                    Write(6,*)'p3a does not appear to be allocated'
+                    Call stdout%print('p3a does not appear to be allocated')
                 Endif
             Case('p3b')
                 If (allocated(self%p3b)) Then
                     DeAllocate(self%p3b)
                 Else
-                    Write(6,*)'p3b does not appear to be allocated'
+                    Call stdout%print('p3b does not appear to be allocated')
                 Endif
             Case('s2a')
                 ! Appropriate for a triangular truncation
@@ -1324,7 +1325,7 @@ Contains
                     Enddo
                     DeAllocate(self%s2a)
                 Else
-                    Write(6,*)'s2a does not appear to be allocated.'
+                    Call stdout%print('s2a does not appear to be allocated.')
                 Endif
 
             Case('s2b')
@@ -1339,7 +1340,7 @@ Contains
                     Enddo
                     DeAllocate(self%s2b)
                 Else
-                    Write(6,*)'s2b does not appear to be allocated.'
+                    Call stdout%print('s2b does not appear to be allocated.')
                 Endif
 
         End Select
@@ -1434,7 +1435,7 @@ Contains
                     Else
                         mx4 = self%nf3a
                     Endif
-                    !Write(6,*)'p3a -- mx4 is: ', mx4, numfields, self%nf3a
+
                     Allocate(self%p3a(mn1:mx1, mn2:mx2, mn3:mx3, mn4:mx4))
                 Endif
             Case('p3b')
@@ -1451,7 +1452,7 @@ Contains
                     Else
                         mx4 = self%nf3b
                     Endif
-                    !Write(6,*)'Allocating p3b'
+
                     Allocate(self%p3b(mn1:mx1, mn2:mx2, mn3:mx3, mn4:mx4))
                 Endif
 
@@ -1475,7 +1476,7 @@ Contains
 
                     Allocate(self%s2a(mn1:mx1))
                     mx2 = maxval(pfi%inds_3s)    ! l_max = m_max
-                    !Write(6,*)'mx4 is: ', mx4, numfields, self%nf2a
+
                     Do i = mn1, mx1
                         mn2 = pfi%inds_3s(i)        !l_min = m
                         Allocate(self%s2a(i)%data(mn2:mx2,mn3:mx3,1:2,1:mx4))

--- a/src/Physics/Benchmarking.F90
+++ b/src/Physics/Benchmarking.F90
@@ -37,6 +37,7 @@ Module Benchmarking
     Use Math_Constants
     Use BoundaryConditions
     Use Initial_Conditions
+    Use BufferedOutput
 
     Implicit None
 
@@ -320,7 +321,7 @@ Contains
             custom_reference_file = file_remember
             heating_type = type_remember
             If (global_rank .eq. 0) Then
-                Write(6,*)'Reference Type 4 set for Benchmark Mode.'
+                Call stdout%print('Reference Type 4 set for Benchmark Mode.')
             Endif
         Endif
         
@@ -629,7 +630,7 @@ Contains
 
         If (benchmark_mode .gt. 0) Then
         If (mod(iteration,integration_interval) .eq. 0) Then
-            !Write(6,*)'Integrating!'
+
             !First we grab the volume-integrated quantities
 
             !We keep a time-series of volume-integrated quantities in memory
@@ -1056,7 +1057,6 @@ Contains
             im1 = i
         Enddo
 
-        If (xind .ne. (msymm+1)) Write(6,*)'ISSUE!'
 
         Do i = 1, nobs
             observations(i) = SUM(vsave(:,i))/msymm
@@ -1096,7 +1096,6 @@ Contains
         If (adjustx) Then
             xref(:) = xnow(:)
             drift_reference_time = time_in
-            !Write(6,*)'Adjusting X'
         Endif
 
         domegadt = domegadt/(msymm*delta_time*n_phi)*two_pi

--- a/src/Physics/Checkpointing.F90
+++ b/src/Physics/Checkpointing.F90
@@ -403,7 +403,6 @@ Contains
                 n_r_old_big = n_r_old
                 l_max_old_big = l_max_old
                 expected_bytes = n_r_old_big*((l_max_old_big+1)**2 + l_max_old_big+1)*8 !TODO: Make this work for general precision
-                write(6,*)'check: ', endian_tag, version, n_r_old
                 Do i = 1, numfields*2
                     If (read_var(i) .eq. 1) Then
                         checkfile = trim(checkpoint_prefix)//under_slash//trim(checkpoint_suffix(i))

--- a/src/Physics/Controls.F90
+++ b/src/Physics/Controls.F90
@@ -185,7 +185,7 @@ Contains
                 Call stdout%init(116,line_count = stdout_flush_interval,filename=ofilename)
         End Select
         If (.not. inertia) Then
-            Write(6,*)"Setting momentum_advection to False"
+            Call stdout%print("Setting momentum_advection to False")
             momentum_advection = .false.
         Endif
 

--- a/src/Physics/Fields.F90
+++ b/src/Physics/Fields.F90
@@ -368,10 +368,7 @@ Contains
             wsfcount(2,2) = 7 + n_active_scalars + n_passive_scalars 
             wsfcount(3,2) = 7 + n_active_scalars + n_passive_scalars 
         endif
-        !Write(6,*)'Fields initialized'
-        !Write(6,*)'c1a_counter is: ', wsp_indices%c1a_counter
-        !Write(6,*)'c2a_counter is: ', wsp_indices%c2a_counter
-        !Write(6,*)'c3a_counter is: ', wsp_indices%c3a_counter
+
 
     End Subroutine Initialize_Field_Structure
     Subroutine Initialize_Diagnostic_Indices()
@@ -451,9 +448,9 @@ Contains
             bindex(11) = dbpdt
             bindex(12) = dbpdp
         Endif
-        !Write(6,*)'NEW CHECK: ', wsp%nf3a, wsp_indices%c3a_counter
+
         output_nextra = wsp_indices%c3a_counter- wsfcount(3,1)
-        !Write(6,*)'CHECK:  ', output_nextra, wsp%nf3a, wsfcount(3,1)
+
     End Subroutine Initialize_Diagnostic_Indices
 
 End Module Fields

--- a/src/Physics/Generic_Input.F90
+++ b/src/Physics/Generic_Input.F90
@@ -29,6 +29,8 @@ module Generic_Input
 
   use SendReceive
   use ProblemSize
+  
+  use BufferedOutput
 
   implicit none
 
@@ -59,6 +61,7 @@ contains
     integer, allocatable, dimension(:) :: proc_lmn_count, col_lmn_count, col_lmn_ind1, col_coeffs_ind1, sendarri
     integer, allocatable, dimension(:,:) :: my_lmn_inds, lmn_inds, sendarri2
     real*8, allocatable, dimension(:,:) :: my_lmn_coeffs, lmn_coeffs, col_coeffs, sendarr2
+    character*7, intstr
 
     ! set up some sizes of mpi types
     call MPI_TYPE_GET_EXTENT(MPI_REAL8, lb, real_size, ierr)
@@ -88,8 +91,9 @@ contains
         pars(3) = l_l_max
       else
         n_lmn = 0
-        write(6,*)'Unknown generic input file mode: ', fmode
-        write(6,*)'Acceptable modes are 0 (sparse) or 1 (full).'
+        Write(intstr,'(i7)')fmode
+        Call stdout%print('Unknown generic input file mode: '//TRIM(ADJUSTL(intstr)) )
+        call stdout%print('Acceptable modes are 0 (sparse) or 1 (full).')
       endif
       close(15)
     end if
@@ -178,7 +182,8 @@ contains
             end if
           end do
         else
-          write(6,*)'Error opening generic input file: ', pfi%rcomm%rank
+          Write(intstr,'(i7)')pfi%rcomm%rank
+          Call stdout%print('Error opening generic input file: '//TRIM(ADJUSTL(intstr)))
         end if
         call MPI_FILE_CLOSE(funit, ierr)
 
@@ -307,7 +312,7 @@ contains
           field%p1b(n, 2, lm, field_ind) = my_lmn_coeffs(i, 2)
         end do
       else
-        write(6,*)'field%p1b not allocated in genericinput read_input!'
+        Call stdout%print('field%p1b not allocated in genericinput read_input!')
       end if
       deallocate(my_lmn_inds)
       deallocate(my_lmn_coeffs)
@@ -364,7 +369,8 @@ contains
             end if
           end do
         else
-          write(6,*)'Error opening generic input file: ', pfi%rcomm%rank
+          Write(intstr,'(i7)')pfi%rcomm%rank
+          Call stdout%print('Error opening generic input file: '//TRIM(ADJUSTL(intstr)))
         end if
         call MPI_FILE_CLOSE(funit, ierr)
 
@@ -454,7 +460,7 @@ contains
           field%p1b(1:l_max_n+1, 2, k, field_ind) = my_lmn_coeffs((k-1)*(l_max_n+1)+1:k*(l_max_n+1), 2)
         end do
       else
-        write(6,*)'field%p1b not allocated in genericinput read_input!'
+        Call stdout%print('field%p1b not allocated in genericinput read_input!')
       end if
       deallocate(my_lmn_coeffs)
 

--- a/src/Physics/Initial_Conditions.F90
+++ b/src/Physics/Initial_Conditions.F90
@@ -690,7 +690,7 @@ Contains
             rfunc(r) = (1-cos(x))*0.5d0
 
         Enddo
-        !write(6,*)'rf max ', maxval(rfunc1)
+
 
         ! We put our temporary field in spectral space
         Call tempfield%init(field_count = fcount, config = 's2b')
@@ -745,7 +745,6 @@ Contains
             rfunc1(r) = 0.2d0*(1.0d0-3.0d0*x*x+3.0d0*x**4-x**6)
             rfunc2(r) = r_outer*r_inner/radius(r)-r_inner
         Enddo
-        !write(6,*)'rf max ', maxval(rfunc1)
 
         ! We put our temporary field in spectral space
         Call tempfield%init(field_count = fcount, config = 's2b')
@@ -803,7 +802,7 @@ Contains
         !!!!!!!!!
         ! Stuff to set up background entropy gradient (taken from Mark's benchmark init in ASH)
         Delta_S = t_bottom ! bottom_entropy
-        If (my_rank .eq. 0) Write(6,*)'Delta_S is ', delta_s
+
         d = radius(1) - radius(N_R)
         beta = radius(N_R) / radius(1)
         n_rho = 5.0d0
@@ -905,7 +904,6 @@ Contains
             x = (radius(r)-r_inner)/(r_outer-r_inner)
             rfunc2(r) = sin(pi*x)*0.01d0
         Enddo
-        !write(6,*)'rf max ', maxval(rfunc1)
 
         ! We put our temporary field in spectral space
         Call tempfield%init(field_count = fcount, config = 's2b')
@@ -1032,7 +1030,6 @@ Contains
 
             rfunc2(r) = sin(pi*(radius(r)-r_inner))*radius(r)*nrm2  ! function form for a_2_0
         Enddo
-        !write(6,*)'rf max ', maxval(rfunc1)
 
         ! We put our temporary field in spectral space
         Call tempfield%init(field_count = fcount, config = 's2b')

--- a/src/Physics/PDE_Coefficients.F90
+++ b/src/Physics/PDE_Coefficients.F90
@@ -1246,8 +1246,8 @@ Contains
         Real*8 :: geofac
 
         If (my_rank .eq. 0) Then
-            Write(6,*)'Custom reference state specified.'
-            Write(6,*)'Reading from: ', custom_reference_file
+            Call stdout%print('Custom reference state specified.')
+            Call stdout%print('Reading from: '//TRIM(ADJUSTL(custom_reference_file)) )
         Endif
 
         Call Read_Custom_Reference_File(custom_reference_file)
@@ -1354,6 +1354,7 @@ Contains
         Character*12 :: dstring
         Character*8 :: dofmt = '(ES12.5)'
         Character(len=2) :: ind
+        Character*3 :: intstr
 
         cset(:) = 0
         input_constants(:) = 0.0d0
@@ -1368,17 +1369,14 @@ Contains
         Read(15)pi_integer
         If (pi_integer .ne. 314) Then
             close(15)
-            Write(6,*)'Trying to convert.  pi = : ', pi_integer
             Open(unit=15,file=ref_file,form='unformatted', status='old', &
                  CONVERT = 'BIG_ENDIAN' , access='stream')
             Read(15)pi_integer
             If (pi_integer .ne. 314) Then
                 Close(15)
-                Write(6,*)'Trying to convert again.  pi is now: ', pi_integer
                 Open(unit=15,file=ref_file,form='unformatted', status='old', &
                  CONVERT = 'LITTLE_ENDIAN' , access='stream')
                 Read(15)pi_integer
-                Write(6,*)'My final value of pi is: ', pi_integer
             Endif
         Endif
 
@@ -1427,7 +1425,7 @@ Contains
                     Write(ind, '(I2)') k
                     Write(dstring,dofmt) ra_constants(k)
                     Call stdout%print('c_'//Adjustl(ind)//' = '//Trim(dstring))
-                    !Write(6,*)'c: ', k, ra_constants(k)
+
                 Endif
             Enddo
 
@@ -1446,7 +1444,7 @@ Contains
             !input array of functions
             If (old_radius(1) .lt. old_radius(nr_ref)) Then
 
-                If (my_rank .eq. 0) Write(6,*)'Reversing Radial Indices in Custom Ref File!'
+                If (my_rank .eq. 0) Call stdout%print('Reversing Radial Indices in Custom Ref File!')
 
                 Allocate(rtmp(1:nr_ref))
 
@@ -1528,8 +1526,7 @@ Contains
               Endif
             end do
         Else
-            Write(6,*)'Error.  This file appears to be corrupt (check Endian convention).'
-            Write(6,*)'Pi integer: ', pi_integer
+            Call stdout%print('Error.  This file appears to be corrupt (check Endian convention).')
         Endif
 
         ! only used if user wants to change reference_type=1,2,3
@@ -1541,11 +1538,12 @@ Contains
                         use_custom_constant(j) = .true.
                     Else
                         If (my_rank .eq. 0) Then
-                            Write(6,*)' '
-                            Write(6,*)'You set with_custom_constant: ', j
-                            Write(6,*)'But this constant was not set in either main_input or '
-                            Write(6,*)'the custom reference file.  Selection will be ignored.'
-                            Write(6,*)' '
+                            Write(intstr,'(i3)')j
+                            Call stdout%print(' ')
+                            Call stdout%print('You set with_custom_constant: '//TRIM(ADJUSTL(intstr)))
+                            Call stdout%print('But this constant was not set in either main_input or ')
+                            Call stdout%print('the custom reference file.  Selection will be ignored.')
+                            Call stdout%print(' ')
                         Endif
                     Endif
                 Endif
@@ -1559,11 +1557,12 @@ Contains
                         use_custom_function(j) = .true.
                     Else
                         If (my_rank .eq. 0) Then
-                            Write(6,*)' '
-                            Write(6,*)'You set with_custom_function: ', j
-                            Write(6,*)'But this function was not set in either main_input or '
-                            Write(6,*)'the custom reference file.  Selection will be ignored.'
-                            Write(6,*)' '
+                            Write(intstr,'(i3)')j
+                            Call stdout%print(' ')
+                            Call stdout%print('You set with_custom_function: '//TRIM(ADJUSTL(intstr)))
+                            Call stdout%print('But this function was not set in either main_input or ')
+                            Call stdout%print('the custom reference file.  Selection will be ignored.')
+                            Call stdout%print(' ')
                         Endif
                     Endif
                 Endif

--- a/src/Physics/Sphere_Linear_Terms.F90
+++ b/src/Physics/Sphere_Linear_Terms.F90
@@ -503,9 +503,9 @@ Contains
             Endif
             Call Set_Boundary_Conditions(lp)
             If (sparsesolve) Then
-                !Write(6,*)'matrix: ', weq,lp, my_rank, l
+
                 Call Sparse_Load(weq,lp)
-                !Write(6,*)'matrix: ', zeq,lp,my_rank, l
+
                 Call Sparse_Load(zeq,lp)
 
                 do i = 1, n_passive_scalars

--- a/src/Physics/Sphere_Physical_Space.F90
+++ b/src/Physics/Sphere_Physical_Space.F90
@@ -50,8 +50,8 @@ Contains
         If (newtonian_cooling .and. (newtonian_cooling_profile_file .ne. '__nothing__')) Then
             cooling_profile(:) = newtonian_cooling_profile(:)
             If (my_rank .eq. 0) Then
-                Write(6,*) 'Newtonian cooling is active.'
-                Write(6,*) 'Cooling profile set from: ',newtonian_cooling_profile_file
+                call stdout%print('Newtonian cooling is active.')
+                call stdout%print('Cooling profile set from: '//TRIM(ADJUSTL(newtonian_cooling_profile_file)))
             Endif
         Else
             cooling_profile(:) = 1.0d0
@@ -65,7 +65,7 @@ Contains
 
             If (newtonian_cooling_type .eq. 1) Then
                 ! No angular variation
-                If (my_rank .eq. 0) Write(6,*) 'Newtonian cooling type = 1'
+                If (my_rank .eq. 0) call stdout%print('Newtonian cooling type = 1')
                 Do t = my_theta%min, my_theta%max
                     Do r = my_r%min, my_r%max
                         Do k =1, n_phi
@@ -79,7 +79,7 @@ Contains
             If (newtonian_cooling_type .eq. 2) Then
                 ! Angular variation (ell=1,m=1, motivated by hot Jupiters)
 
-                If (my_rank .eq. 0) Write(6,*) 'Newtonian cooling type = 2'
+                If (my_rank .eq. 0) call stdout%print('Newtonian cooling type = 2')
                 Do t = my_theta%min, my_theta%max
                     Do r = my_r%min, my_r%max
                         Do k =1, n_phi

--- a/src/Physics/Sphere_Spectral_Space.F90
+++ b/src/Physics/Sphere_Spectral_Space.F90
@@ -214,7 +214,6 @@ Contains
 
         !Copy each variable out of the RHS into the top part of the buffer
         ! These variables are in spectral space radially
-        !!!DDDD Write(6,*)'I am getting the new rhs: ', my_rank
         Call Get_All_RHS(wsp%p1a)
 
 


### PR DESCRIPTION
This PR removes all calls to write(6,\*) in the code that can be encountered during the course of a normal simulation.   Instead, stdout%print is used, which is redirected to a log file, if desired.    This change prevents a situation where some error message could be written out to standard out, whereas others would appear in the log file.   Note that several references to write(6,\*) have been retained.  These are not encountered during normal usage of the code and can still be helpful for debugging.  In addition, many references to write(6,\*) which were commented out or unnecessary have been removed.  This PR fixes issue #325 .