### PR TITLE
Timing Bug Fix

### DIFF
--- a/src/Physics/Sphere_Driver.F90
+++ b/src/Physics/Sphere_Driver.F90
@@ -72,7 +72,7 @@ Contains
     Subroutine Main_Loop_Sphere()
         Implicit None
         Integer ::  last_iteration, first_iteration, i, iret
-        Integer :: io=15, ierr
+        Integer :: io=15, ierr, iteration_count
         Real*8  :: captured_time, max_time_seconds
         Logical :: terminate_file_exists
         Character*14 :: tmstr
@@ -310,7 +310,8 @@ Contains
             Write(tmstr,fmtstr)captured_time
             Call stdout%print('captured time: '//tmstr)
 
-            Write(tmstr,fmtstr)(last_iteration-first_iteration)/StopWatch(loop_time)%elapsed
+            iteration_count = last_iteration-first_iteration
+            Write(tmstr,fmtstr)(iteration_count)/StopWatch(loop_time)%elapsed
             Call stdout%print('   ')
             Call stdout%print('     iter/sec: '//tmstr)
 
@@ -318,7 +319,7 @@ Contains
 
             
         Endif
-        Call Finalize_Timing(n_r,l_max,max_iterations)
+        Call Finalize_Timing(n_r,l_max,iteration_count)
     End Subroutine Main_Loop_Sphere
 
     ! Signal handler function


### PR DESCRIPTION
This fixes a bug where Rayleigh's timing files always record the number of timesteps as being the maximum number of iterations specified in main_input.   This becomes a problem when the user specifies the maximum walltime.  For instance, timing files for  3-minute test run might record 10 million timesteps, rather than a few hundred/thousand.

I've been using this branch for several weeks now to performance test Pleiades.  If the testers don't throw an error, I am going to merge without review.