### PR TITLE
[DRAFT] updated sphinxcontrib-bibtex version

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -15,7 +15,7 @@ dependencies:
   - jupyter=1.0
   - scipy=1.10
   - sphinx=4.0
-  - sphinxcontrib-bibtex=2.2
+  - sphinxcontrib-bibtex=2.6.5
   - nbsphinx=0.8
   - pandoc=3.2
   - recommonmark=0.7

--- a/environment_doc.yml
+++ b/environment_doc.yml
@@ -12,7 +12,7 @@ dependencies:
   - jupyter=1.0
   - scipy=1.10
   - sphinx=4.0
-  - sphinxcontrib-bibtex=2.2
+  - sphinxcontrib-bibtex=2.6.5
   - nbsphinx=0.8
   - pandoc=3.2
   - recommonmark=0.7


### PR DESCRIPTION
Some of the failures we are seeing in our tests look as though they are due to an incompatibility with the sphinxcontrib-bibtex package and one of its dependencies, pybtex.  We probably either need to roll the sphinxcontrib package forward, or specify the version of pybtex we want in the yml file.  This draft PR updates the sphinxcontrib version.