### PR TITLE
Updating Ubuntu version used by Readthedocs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -7,7 +7,7 @@ version: 2
 
 #Use Mamba instead of Conda to avoid running into memory limits (recommended by ReadtheDocs)
 build:
-  os: "ubuntu-20.04"
+  os: "ubuntu-24.04"
   tools:
     python: "mambaforge-4.10"
 


### PR DESCRIPTION
Ubuntu 20.04 is being deprecated by Readthedocs.  This PR updates to 24.04.   