### PR TITLE
Modified configure script to work on Athena.

### DIFF
--- a/configure
+++ b/configure
@@ -473,7 +473,7 @@ do
       ;;
 
     --for-athena)
-      FORATHENA="True";
+      FORATHENA="TRUE";
       ;;
     *)
       echo "unknown option: $option"

--- a/configure
+++ b/configure
@@ -47,7 +47,7 @@ function opt_flags {
 
   if [[ $1 == "GNU" ]]
   then
-    echo '-O3 -ffixed-line-length-132'
+    echo '-O3 -ffixed-line-length-132 -fallow-argument-mismatch'
   fi
 
   if [[ $1 == "AOCC" ]]
@@ -70,7 +70,7 @@ function dbg_flags {
   fi
   if [[ $1 == "GNU" ]]
   then
-    echo '-O0 -g -fbounds-check -ffpe-trap=invalid,zero,overflow -fbacktrace -ffixed-line-length-132'
+    echo '-O0 -g -fbounds-check -ffpe-trap=invalid,zero,overflow -fbacktrace -ffixed-line-length-132 -fallow-argument-mismatch'
   fi
   if [[ $1 == "AOCC" ]]
   then
@@ -305,6 +305,10 @@ function displayhelp {
     echo "      the standard Rayleigh source files."
     echo ""
 
+    echo "  --for-athena=<BOOL>"
+    echo "      Set this flag to use Cray's libsci for BLAS and LAPACK, use in"
+    echo "      combination with --with-blas and --with-lapack to point to the"
+    echo "      correct library."
 }
 
 
@@ -319,6 +323,7 @@ USE_MKL="FALSE"
 CONDAMKL="FALSE"
 DEBIANMKL="FALSE"
 CUSTOMROOT="none"
+FORATHENA="FALSE"
 
 
 ###############################################################################################
@@ -467,6 +472,9 @@ do
       BLANKMACHINE="TRUE";
       ;;
 
+    --for-athena)
+      FORATHENA="True";
+      ;;
     *)
       echo "unknown option: $option"
       exit 1
@@ -605,8 +613,10 @@ else
 
   if [ $FVERSION == "CRAY" ]
   then
-      OPT_FLAGS="$OPT_FLAGS -DCRAY_COMPILER"
-      DBG_FLAGS="$DBG_FLAGS -DCRAY_COMPILER"
+      #OPT_FLAGS="$OPT_FLAGS -DCRAY_COMPILER"
+      #DBG_FLAGS="$DBG_FLAGS -DCRAY_COMPILER"
+      OPT_FLAGS="$OPT_FLAGS"
+      DBG_FLAGS="$DBG_FLAGS"
   fi
 
   echo ' '
@@ -912,14 +922,40 @@ else
         then
           BLASLINK="-L$BLASROOT/lib/libblas.a"
         else
-          BLASLINK="-L$BLASROOT/lib -lblas"
+	    if [ $FORATHENA == "FALSE" ]
+	    then
+		BLASLINK="-L$BLASROOT/lib -lblas"
+	    else
+		if [ $FVERSION == "CRAY" ]
+		then
+		    BLASLINK="-L$BLASROOT/lib -lsci_cray"
+		fi
+
+		if [ $FVERSION == "GNU" ]
+		then
+		    BLASLINK="-L$BLASROOT/lib -lsci_gnu"
+		fi
+	    fi
         fi
         #LAPACK
         if [[ $STATICLAPACK == "TRUE" ]]
         then
             LAPACKLINK="-L$LPROOT/lib/liblapack.a"
         else
-            LAPACKLINK="-L$LPROOT/lib -llapack"
+	    if [ $FORATHENA == "FALSE" ]
+	    then
+		LAPACKLINK="-L$LPROOT/lib -llapack"
+	    else
+		if [ $FVERSION == "CRAY" ]
+		then
+		    BLASLINK="-L$BLASROOT/lib -lsci_cray"
+		fi
+
+		if [ $FVERSION == "GNU" ]
+		then
+		    BLASLINK="-L$BLASROOT/lib -lsci_gnu"
+		fi
+	    fi
         fi
     fi
     


### PR DESCRIPTION
There is a flag (--for-athena) that triggers one of two options for either GNU or CRAY compilers [can add intel/aocc if wanted].  This along with the --with-blas and --with-lapack flags allows the use of Cray's libsci on Athena so things build cleanly, you just need to specify the library path with $CRAY_LIBSCI_PREFIX;  same for fftw --with-fftw=$FFTW_ROOT.

Here's the currently loaded modules for the Cray environment:

module list
Currently Loaded Modulefiles:
  1) cray-libpals/1.8.0                5) xpmem/1.0.1-1.5_1_gfb6998056825   9) libfabric/12.0                   13) PrgEnv-cray/8.7.0
  2) cray-pals/1.8.0                   6) cray-fftw/3.3.10.11              10) craype-network-ofi
  3) craype-x86-turin                  7) cce/21.0.0                       11) cray-mpich/9.1.0
  4) perftools-base/26.03.0            8) craype/2.7.36                    12) cray-libsci/26.03.0

To use GNU module unload PrgEnv-cray and module load PrgEnv-gnu.  At runtime, be sure to add the libmpi path to your LD_LIBRARY_PATH for some reason that doesn't seem to be provided by the module properly.  For the cray config that is

/opt/cray/pe/mpich/9.1.0/ofi/CRAY/20.0/lib

for GNU it is

/opt/cray/pe/mpich/9.1.0/ofi/GNU/11.2/lib
