### PR TITLE
do not build TACC image anymore

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -73,30 +73,3 @@ jobs:
           tags: |
             ghcr.io/${{env.REPO_NAME_LC}}:${{github.ref_name}}
             ${{env.REPO_NAME_LC}}:${{github.ref_name}}
-
-
-      - name: Build and push TACC image for main
-        if: contains(github.event_name, 'push')
-        uses: docker/build-push-action@v7
-        with:
-          context: ./docker/rayleigh-tacc/
-          cache-from: type=registry,ref=geodynamics/rayleigh-buildenv-bionic
-          cache-to: type=inline
-          platforms: linux/amd64
-          push: true
-          tags: |
-            ghcr.io/${{env.REPO_NAME_LC}}:latest-tacc
-            ${{env.REPO_NAME_LC}}:latest-tacc
-
-      - name: Build and push TACC image for release
-        if: contains(github.event_name, 'release')
-        uses: docker/build-push-action@v7
-        with:
-          context: ./docker/rayleigh-tacc/
-          cache-from: type=registry,ref=geodynamics/rayleigh-buildenv-bionic
-          cache-to: type=inline
-          platforms: linux/amd64
-          push: true
-          tags: |
-            ghcr.io/${{env.REPO_NAME_LC}}:${{github.ref_name}}-tacc
-            ${{env.REPO_NAME_LC}}:${{github.ref_name}}-tacc

--- a/doc/source/User_Guide/getting_started.rst
+++ b/doc/source/User_Guide/getting_started.rst
@@ -389,29 +389,6 @@ and ``TACC_CC`` are not set, and so the compilers need to be specified manually:
 
 An example jobscript for Stampede3 may be found in *Rayleigh/job_scripts/TACC_Stampede3*.
 
-Using the Apptainer container system
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-We provide a precompiled container that provides an alternative way to use Rayleigh on the TACC computing systems Stampede3 and Frontera.
-
-To activate the container system and download the container:
-
-.. code-block:: bash
-
-   module load tacc-apptainer
-   apptainer pull docker://gassmoeller/rayleigh:tacc-latest
-
-This will create a file `rayleigh_tacc-latest.sif` that you can think of as a Rayleigh executable.
-To run Rayleigh models using the downloaded container run (on a compute node):
-
-.. code-block:: bash
-
-   ibrun -n N_CORES apptainer run rayleigh_tacc-latest.sif rayleigh.opt
-
-Make sure to replace N_CORES with the number of requested cores (or remove -n option to run with the
-total number of cores requested). Also make sure to provide the correct path to `rayleigh_tacc-latest.sif`
-if it is not in the current directory.
-
 .. _pleiades:
 
 NASA Pleiades

--- a/docker/rayleigh-tacc/Readme.md
+++ b/docker/rayleigh-tacc/Readme.md
@@ -1,6 +1,3 @@
 This is a docker container that can be used to run Rayleigh on the set of TACC
 supercomputers, in particular Frontera and Stampede3, without having to manually
 compile the code.
-
-Steps to use this container on Stampede3/Frontera are described on
-https://rayleigh-documentation.readthedocs.io/en/latest/doc/source/User_Guide/getting_started.html.


### PR DESCRIPTION
We would need some changes to make it build with the TACC base image. Remove this for now as we do not seem to have users for these containers at the moment.

Also removes the respective documentation to avoid confusion. If we want to resurrect that feature, we can just take it out of the git history.

Fixes #602.