### PR TITLE
Bugfix in rayleigh_diagnostics (Shell_Slices)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixed
 
+- Fixed a bug in rayleigh_diagnostics.py (Shell_Slices). The time and iteration number were read incorrectly if the user specified that only a single shell slice be read (a single iteration, a single quantity code, and a single radius). The code did not skip to the end of the record to read the time and iteration number.  \[Brad Hindman; 6-13-202; [#612](https://github.com/geodynamics/Rayleigh/pull/612)\]
+
 ## [1.3.0] - 5-8-2026
 
 ### Added

--- a/post_processing/rayleigh_diagnostics.py
+++ b/post_processing/rayleigh_diagnostics.py
@@ -2230,6 +2230,8 @@ class Shell_Slices:
             self.qv[0] = qspec
             tmp = np.reshape(swapread(fd,dtype='float64',count=ntheta*nphi,swap=bs),(nphi,ntheta), order = 'F')
             self.vals[:,:,0,0,0] = tmp
+            seek_offset = rec_size*(tspec+1) - seek_bytes - slice_size - 12  # distance to the end of the record - 12-bytes (for time and time index)
+            fd.seek(seek_offset,1) # skip to the end of the quantity data in the record
             self.time[0]  = swapread(fd, dtype='float64',count=1,swap=bs)
             self.iters[0] = swapread(fd, dtype='int32'  ,count=1,swap=bs)
         else:


### PR DESCRIPTION
When reading a single iteration, single quantity code, and single radius (using the keyword slice_spec), the code did not skip to the  end of the record before reading the time and the iteration number.  Hence, those two quantities were reading random stuff.  Added two lines to reposition the read position in the file.