### PR TITLE
Point_Probes Can Now Sample all Points in Theta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - Fixed a bug in rayleigh_diagnostics.py (Shell_Slices). The time and iteration number were read incorrectly if the user specified that only a single shell slice be read (a single iteration, a single quantity code, and a single radius). The code did not skip to the end of the record to read the time and iteration number.  \[Brad Hindman; 6-13-202; [#612](https://github.com/geodynamics/Rayleigh/pull/612)\]
 
+- Rayleigh no longer produces a segmentation fault if all theta values local to a particular process are requested for the Point_Probe output. \[Nick Featherstone; 7-16-2026; [#622](https://github.com/geodynamics/Rayleigh/pull/622)\]
+
 ## [1.3.0] - 5-8-2026
 
 ### Added

--- a/src/IO/Parallel_IO.F90
+++ b/src/IO/Parallel_IO.F90
@@ -440,7 +440,7 @@ Contains
             my_min = pfi%all_2p(self%row_rank)%min
             my_max = pfi%all_2p(self%row_rank)%max
 
-            Allocate(tmp(1:(my_max-my_min)))
+            Allocate(tmp(1:(my_max-my_min+1)))
 
             Do p = 0, pfi%nprow-1
                 tmin = pfi%all_2p(p)%min


### PR DESCRIPTION
A temporary array used when initializing the io_buffer object was allocated with 1 less element than intended.  This prevented Point_Probes from sampling all theta values local to a particular process.  For example., if a process was responsible for 32 theta points, only 31 of those points could be sampled without producing a seg fault.   This PR increases the size that of array by 1.  