### PR TITLE
Bug Fix for SPH_Modes Class in rayleigh_diagnostics.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - Rayleigh no longer produces a segmentation fault if all theta values local to a particular process are requested for the Point_Probe output. \[Nick Featherstone; 7-16-2026; [#622](https://github.com/geodynamics/Rayleigh/pull/622)\]
 
-- Fixed a bug in the initialization method of the SPH_Modes class in rayleigh_diagnostics.py that caused data corruption whenever multiple quantities were output. \[Nick Featherstone; 7-16-2026; [#622](https://github.com/geodynamics/Rayleigh/pull/622)\]
+- Fixed a bug in the initialization method of the SPH_Modes class in rayleigh_diagnostics.py that caused data corruption whenever multiple quantities were output. \[Nick Featherstone; 7-16-2026; [#624](https://github.com/geodynamics/Rayleigh/pull/624)\]
 
 ## [1.3.0] - 5-8-2026
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - Rayleigh no longer produces a segmentation fault if all theta values local to a particular process are requested for the Point_Probe output. \[Nick Featherstone; 7-16-2026; [#622](https://github.com/geodynamics/Rayleigh/pull/622)\]
 
+- Fixed a bug in the initialization method of the SPH_Modes class in rayleigh_diagnostics.py that caused data corruption whenever multiple quantities were output. \[Nick Featherstone; 7-16-2026; [#622](https://github.com/geodynamics/Rayleigh/pull/622)\]
+
 ## [1.3.0] - 5-8-2026
 
 ### Added

--- a/post_processing/rayleigh_diagnostics.py
+++ b/post_processing/rayleigh_diagnostics.py
@@ -2322,8 +2322,8 @@ class SPH_Modes:
         self.time  = np.zeros(nrec,dtype='float64')
         self.version = version
         for i in range(nrec):
-            for qv in range(nq):
-                for p in range(2):
+            for p in range(2):
+                for qv in range(nq):
                     for rr in range(nr):
                         for lv in range(nell):
                             lval = self.lvals[lv]


### PR DESCRIPTION
The SPH_Modes initialization routine in rayleigh_diagnostics.py was treating the data as though it were striped in a different form that what is actually output by Rayleigh.

In Rayleigh, within a record, the real portion of the entire record (all modes, radii, quantity codes) is written out, followed by the imaginary part.  The SPH_Modes class was treating the data as though each quantity code, rather than each record, was written real part then imaginary part.

This PR fixes the bug by reording the quantity-code and real/imaginary loops used to read in the data.