### PR TITLE
Bug Fix: IO Buffer Used Before Initialization

### DIFF
--- a/src/Physics/Benchmarking.F90
+++ b/src/Physics/Benchmarking.F90
@@ -378,9 +378,6 @@ Contains
             reference_type = 4
             custom_reference_file = file_remember
             heating_type = type_remember
-            If (global_rank .eq. 0) Then
-                Call stdout%print('Reference Type 4 set for Benchmark Mode.')
-            Endif
         Endif
         
         If (with_custom_reference) Then
@@ -587,6 +584,9 @@ Contains
                 Call stdout%print(" -- Benchmarking Mode is Activated.")
                 Call stdout%print(" -- Selected Benchmark :  "//trim(benchmark_name))
                 Call stdout%print(" ")
+                If (reference_type .eq. 4) Then
+                    Call stdout%print(' -- Reference Type 4 set for Benchmark Mode.')
+                Endif
             Endif
         Endif
         If (benchmark_integration_interval .gt. 0) Then

--- a/src/Physics/Benchmarking.F90
+++ b/src/Physics/Benchmarking.F90
@@ -583,10 +583,10 @@ Contains
                 Call stdout%print(" ")
                 Call stdout%print(" -- Benchmarking Mode is Activated.")
                 Call stdout%print(" -- Selected Benchmark :  "//trim(benchmark_name))
-                Call stdout%print(" ")
                 If (reference_type .eq. 4) Then
                     Call stdout%print(' -- Reference Type 4 set for Benchmark Mode.')
                 Endif
+                Call stdout%print(" ")                
             Endif
         Endif
         If (benchmark_integration_interval .gt. 0) Then

--- a/src/Physics/Benchmarking.F90
+++ b/src/Physics/Benchmarking.F90
@@ -586,7 +586,7 @@ Contains
                 If (reference_type .eq. 4) Then
                     Call stdout%print(' -- Reference Type 4 set for Benchmark Mode.')
                 Endif
-                Call stdout%print(" ")                
+                Call stdout%print(" ")
             Endif
         Endif
         If (benchmark_integration_interval .gt. 0) Then


### PR DESCRIPTION
This PR addresses a bug that was causing the IO Buffer's print method to be called before the buffer was initialized.  This bug seemed to only arise when reference_type=4 was used along with benchmarking mode.   What's odd is that it was causing a crash in the custom-reference-state test, but that crash wasn't causing the tester to throw an error.

It would be good to review/approve quickly if you have a minute @tukss @illorenzo7 @cianwilson 