### PR TITLE
Ordering of compute_BandCurlB and Hybrid_Output_Final had switched

### DIFF
--- a/src/Physics/Sphere_Hybrid_Space.F90
+++ b/src/Physics/Sphere_Hybrid_Space.F90
@@ -123,9 +123,9 @@ Contains
            end do
         Endif 
         
-        If (output_iteration) Call Hybrid_Output_Final()
-
         If (magnetism) Call compute_BandCurlB()
+
+        If (output_iteration) Call Hybrid_Output_Final()
 
         Call DeAllocate_rlm_Field(ftemp1)
         Call DeAllocate_rlm_Field(ftemp2)


### PR DESCRIPTION
This PR returns the order of compute_BandCurlB and Hybrid_Output_Final to what it was until recently.  Was there a reason it was changed?

After merging main into a branch I started seeing something that wasn't B in my output (presumably it was C).  This reversion fixes that and gets me B back again.  Once that other branch is finished there will be a test for this but I wanted to get a fix in for this ASAP in case anyone interprets the output as B in the meantime.